### PR TITLE
Add PA integration capabilities API contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ pytest --cov=engine --cov=app --cov-report term-missing
   - **Description:** Decomposes the portfolio's active return against a benchmark into allocation, selection, and interaction effects.
   - **Example Payload:** See `docs/examples/attribution_request.json`.
 
+### 5\. Integration Capabilities
+
+  - **Endpoint:** `GET /integration/capabilities`
+  - **Description:** Returns backend-governed PA capability and workflow metadata for BFF/PAS/DPM integration.
+
 -----
 
 ## Advanced Usage

--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -1,0 +1,119 @@
+import os
+from datetime import UTC, date, datetime
+from typing import Literal
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+
+ConsumerSystem = Literal["BFF", "PA", "DPM", "UI", "UNKNOWN"]
+
+
+class FeatureCapability(BaseModel):
+    key: str = Field(description="Canonical feature key.")
+    enabled: bool = Field(description="Whether this feature is enabled.")
+    owner_service: str = Field(description="Owning service for this feature.")
+    description: str = Field(description="Human-readable capability summary.")
+
+
+class WorkflowCapability(BaseModel):
+    workflow_key: str = Field(description="Workflow key for feature orchestration.")
+    enabled: bool = Field(description="Whether workflow is enabled.")
+    required_features: list[str] = Field(
+        default_factory=list,
+        description="Feature keys required for this workflow.",
+    )
+
+
+class IntegrationCapabilitiesResponse(BaseModel):
+    contract_version: str = Field(alias="contractVersion")
+    source_service: str = Field(alias="sourceService")
+    consumer_system: ConsumerSystem = Field(alias="consumerSystem")
+    tenant_id: str = Field(alias="tenantId")
+    generated_at: datetime = Field(alias="generatedAt")
+    as_of_date: date = Field(alias="asOfDate")
+    policy_version: str = Field(alias="policyVersion")
+    supported_input_modes: list[str] = Field(alias="supportedInputModes")
+    features: list[FeatureCapability]
+    workflows: list[WorkflowCapability]
+
+    model_config = {"populate_by_name": True}
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@router.get(
+    "/capabilities",
+    response_model=IntegrationCapabilitiesResponse,
+    summary="Get PA Integration Capabilities",
+    description=(
+        "Returns backend-governed PA capability/workflow controls for BFF, PAS, and DPM integration."
+    ),
+)
+async def get_integration_capabilities(
+    consumer_system: ConsumerSystem = Query("BFF", alias="consumerSystem"),
+    tenant_id: str = Query("default", alias="tenantId"),
+) -> IntegrationCapabilitiesResponse:
+    twr_enabled = _env_bool("PA_CAP_TWR_ENABLED", True)
+    mwr_enabled = _env_bool("PA_CAP_MWR_ENABLED", True)
+    contribution_enabled = _env_bool("PA_CAP_CONTRIBUTION_ENABLED", True)
+    attribution_enabled = _env_bool("PA_CAP_ATTRIBUTION_ENABLED", True)
+
+    features = [
+        FeatureCapability(
+            key="pa.analytics.twr",
+            enabled=twr_enabled,
+            owner_service="PA",
+            description="Time-weighted return analytics APIs.",
+        ),
+        FeatureCapability(
+            key="pa.analytics.mwr",
+            enabled=mwr_enabled,
+            owner_service="PA",
+            description="Money-weighted return analytics APIs.",
+        ),
+        FeatureCapability(
+            key="pa.analytics.contribution",
+            enabled=contribution_enabled,
+            owner_service="PA",
+            description="Contribution analytics APIs.",
+        ),
+        FeatureCapability(
+            key="pa.analytics.attribution",
+            enabled=attribution_enabled,
+            owner_service="PA",
+            description="Attribution analytics APIs.",
+        ),
+    ]
+
+    workflows = [
+        WorkflowCapability(
+            workflow_key="performance_snapshot",
+            enabled=twr_enabled and mwr_enabled,
+            required_features=["pa.analytics.twr", "pa.analytics.mwr"],
+        ),
+        WorkflowCapability(
+            workflow_key="performance_explainability",
+            enabled=contribution_enabled and attribution_enabled,
+            required_features=["pa.analytics.contribution", "pa.analytics.attribution"],
+        ),
+    ]
+
+    return IntegrationCapabilitiesResponse(
+        contractVersion="v1",
+        sourceService="performance-analytics",
+        consumerSystem=consumer_system,
+        tenantId=tenant_id,
+        generatedAt=datetime.now(UTC),
+        asOfDate=date.today(),
+        policyVersion=os.getenv("PA_POLICY_VERSION", "tenant-default-v1"),
+        supportedInputModes=["pas_ref", "inline_bundle"],
+        features=features,
+        workflows=workflows,
+    )

--- a/docs/RFCs/RFC 030 - Integration Capabilities Contract API.md
+++ b/docs/RFCs/RFC 030 - Integration Capabilities Contract API.md
@@ -1,0 +1,30 @@
+# RFC 030 - Integration Capabilities Contract API
+
+- Status: Accepted
+- Date: 2026-02-23
+
+## Summary
+
+Add `GET /integration/capabilities` so PA publishes backend-governed feature/workflow capability metadata for BFF and cross-service integration.
+
+## Contract
+
+Inputs:
+- `consumerSystem`
+- `tenantId`
+
+Outputs:
+- `contractVersion`
+- `sourceService`
+- `consumerSystem`
+- `tenantId`
+- `policyVersion`
+- `supportedInputModes`
+- `features[]`
+- `workflows[]`
+
+## Rationale
+
+1. Keeps feature control in backend service boundaries.
+2. Aligns PA contract shape with PAS and DPM capability contracts.
+3. Enables BFF to aggregate platform capabilities without UI hardcoding.

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.responses import JSONResponse
 import orjson
 
-from app.api.endpoints import contribution, performance, lineage
+from app.api.endpoints import contribution, integration_capabilities, lineage, performance
 from app.core.config import get_settings
 from app.core.exceptions import PerformanceCalculatorError
 from app.core.handlers import performance_calculator_exception_handler
@@ -84,6 +84,7 @@ app.add_exception_handler(PerformanceCalculatorError, performance_calculator_exc
 app.include_router(performance.router, prefix="/performance")
 app.include_router(contribution.router, prefix="/performance")
 app.include_router(lineage.router, prefix="/performance")
+app.include_router(integration_capabilities.router, prefix="/integration")
 
 
 @app.get("/")

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+def test_integration_capabilities_default_contract():
+    with TestClient(app) as client:
+        response = client.get("/integration/capabilities?consumerSystem=BFF&tenantId=default")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contractVersion"] == "v1"
+    assert body["sourceService"] == "performance-analytics"
+    assert body["consumerSystem"] == "BFF"
+    assert body["tenantId"] == "default"
+    assert body["supportedInputModes"] == ["pas_ref", "inline_bundle"]
+    assert len(body["features"]) >= 4
+    assert len(body["workflows"]) >= 2
+
+
+def test_integration_capabilities_env_override(monkeypatch):
+    monkeypatch.setenv("PA_CAP_ATTRIBUTION_ENABLED", "false")
+    monkeypatch.setenv("PA_POLICY_VERSION", "tenant-a-v4")
+    with TestClient(app) as client:
+        response = client.get("/integration/capabilities?consumerSystem=DPM&tenantId=tenant-a")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["consumerSystem"] == "DPM"
+    assert body["tenantId"] == "tenant-a"
+    assert body["policyVersion"] == "tenant-a-v4"
+    features = {item["key"]: item["enabled"] for item in body["features"]}
+    assert features["pa.analytics.attribution"] is False


### PR DESCRIPTION
## Summary\n- add /integration/capabilities in performanceAnalytics\n- add integration tests and RFC\n- align contract shape with PAS and DPM\n\n## Validation\n- python -m pytest tests/integration/test_integration_capabilities_api.py -q