### PR TITLE
docs(pa): align governance boundary with central platform docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An API for calculating portfolio performance metrics, aligned with the `portfoli
 - Docs-with-code standard: `docs/documentation/implementation-documentation-standard.md`
 - Branch-protection workflow: `docs/documentation/git-branch-protection-workflow.md`
 - PR checklist template: `.github/pull_request_template.md`
+- Platform-wide architecture governance source: `https://github.com/sgajbi/pbwm-platform-docs`
 
 ## Key Features
 

--- a/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
+++ b/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
@@ -1,5 +1,11 @@
 # RFC Implementation Status
 
+## Governance Boundary
+
+- Service-specific PA implementation RFCs are maintained in this repository.
+- Cross-cutting platform and multi-service architecture decisions are maintained in:
+  `https://github.com/sgajbi/pbwm-platform-docs`
+
 This document provides a summary of the implementation status for all RFCs related to the `performanceAnalytics` service. It also outlines a strategic, sequential roadmap for implementing the remaining features to build a cohesive and powerful analytics suite.
 
 ---


### PR DESCRIPTION
## Summary
Aligns PA documentation boundaries with central platform governance and documentation synchronization approach.

## What Changed
- Updated README.md with central governance pointer:
  - https://github.com/sgajbi/pbwm-platform-docs
- Updated docs/RFCs/RFC_IMPLEMENTATION_STATUS.md with governance boundary section:
  - service-specific RFCs remain local
  - cross-cutting/multi-service architecture decisions are central

## Why
Improves documentation ownership clarity and keeps platform-level direction centralized.

## Impact
- Documentation-only change
- No runtime/API behavior changes