### PR TITLE
chore(pa): default docker host port to 8002 for full-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ An API for calculating portfolio performance metrics, aligned with the `portfoli
 2.  **Access API Documentation:**
     -   **Swagger UI**: `http://127.0.0.1:8000/docs`
 
+Docker runtime note:
+- `docker compose up` exposes container port `8000` on host `${PA_HOST_PORT:-8002}` by default.
+- Example Swagger URL with default compose port: `http://127.0.0.1:8002/docs`
+
 ---
 
 ## Testing & Validation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
     build: .
     container_name: performance-analytics
     ports:
-      - "8000:8000"
+      - "${PA_HOST_PORT:-8002}:8000"


### PR DESCRIPTION
## Summary\n- set docker compose host port mapping to ${PA_HOST_PORT:-8002}:8000\n- document default docker port behavior in README\n- remove default host-port conflict with DPM (8000) during full platform bring-up\n\n## Validation\n- docker compose config