### PR TITLE
fix(periods): normalize effective period dtype to datetime64[ns]

### DIFF
--- a/engine/periods.py
+++ b/engine/periods.py
@@ -8,7 +8,7 @@ from engine.config import EngineConfig
 def get_effective_period_start_dates(perf_dates_dt: pd.Series, config: EngineConfig) -> pd.Series:
     """
     Vectorized calculation of the effective period start date for each row.
-    Returns a Series with dtype=datetime64[us].
+    Returns a Series with dtype=datetime64[ns].
     """
     if config.period_type == PeriodType.YTD:
         effective_starts = perf_dates_dt.dt.to_period("Y").dt.start_time
@@ -22,22 +22,22 @@ def get_effective_period_start_dates(perf_dates_dt: pd.Series, config: EngineCon
             config.report_start_date or config.performance_start_date,
         )
         return pd.Series(pd.to_datetime(explicit_start), index=perf_dates_dt.index, name=perf_dates_dt.name).astype(
-            "datetime64[us]"
+            "datetime64[ns]"
         )
     elif config.period_type in [PeriodType.ONE_YEAR, PeriodType.THREE_YEARS, PeriodType.FIVE_YEARS]:
         years = int(config.period_type.value[:-1])
         start_date = pd.to_datetime(config.report_end_date) - pd.DateOffset(years=years) + pd.Timedelta(days=1)
-        return pd.Series(start_date, index=perf_dates_dt.index, name=perf_dates_dt.name).astype("datetime64[us]")
+        return pd.Series(start_date, index=perf_dates_dt.index, name=perf_dates_dt.name).astype("datetime64[ns]")
     elif config.period_type == PeriodType.ITD:
         return pd.Series(
             pd.to_datetime(config.performance_start_date), index=perf_dates_dt.index, name=perf_dates_dt.name
-        ).astype("datetime64[us]")
+        ).astype("datetime64[ns]")
     else:
         # Fallback case, though validation should prevent this.
         return pd.Series(
             pd.to_datetime(config.performance_start_date), index=perf_dates_dt.index, name=perf_dates_dt.name
-        ).astype("datetime64[us]")
+        ).astype("datetime64[ns]")
 
     perf_start_dt = pd.to_datetime(config.performance_start_date)
 
-    return effective_starts.where(effective_starts >= perf_start_dt, perf_start_dt).astype("datetime64[us]")
+    return effective_starts.where(effective_starts >= perf_start_dt, perf_start_dt).astype("datetime64[ns]")


### PR DESCRIPTION
## Summary
- normalize get_effective_period_start_dates output to datetime64[ns]
- align runtime dtype with unit-test expectations across pandas versions

## Validation
- python -m pytest tests/unit/engine/test_periods.py -q
- python -m pytest tests/unit/engine/test_compute.py::test_run_calculations_unexpected_exception_handling tests/unit/engine/test_periods.py -q