### PR TITLE
feat(analytics): PA-owned workbench concentration and allocation analytics

### DIFF
--- a/app/api/endpoints/analytics.py
+++ b/app/api/endpoints/analytics.py
@@ -3,10 +3,21 @@ from fastapi import APIRouter, HTTPException, status
 from app.core.config import get_settings
 from app.models.positions_analytics_requests import PositionAnalyticsRequest
 from app.models.positions_analytics_responses import PositionAnalyticsResponse
+from app.models.workbench_analytics_requests import (
+    WorkbenchAnalyticsRequest,
+    WorkbenchProjectedPositionInput,
+)
+from app.models.workbench_analytics_responses import (
+    WorkbenchAnalyticsBucket,
+    WorkbenchAnalyticsResponse,
+    WorkbenchRiskProxy,
+    WorkbenchTopChange,
+)
 from app.services.pas_snapshot_service import PasSnapshotService
 
 router = APIRouter(tags=["Analytics"])
 settings = get_settings()
+_BENCHMARK_FALLBACK_RETURNS = {"MODEL_60_40": 3.1, "MSCI_ACWI": 4.2, "CUSTOM": 2.8}
 
 
 @router.post(
@@ -48,3 +59,149 @@ async def get_positions_analytics(request: PositionAnalyticsRequest):
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Invalid PAS positions analytics payload: missing {exc}",
         ) from exc
+
+
+def _workbench_buckets(
+    current_positions: list,
+    projected_positions: list[WorkbenchProjectedPositionInput],
+    group_by: str,
+) -> list[WorkbenchAnalyticsBucket]:
+    current_map = {row.security_id: row for row in current_positions}
+    projected_map = {row.security_id: row for row in projected_positions}
+    keys = set(current_map) | set(projected_map)
+
+    grouped: dict[str, dict[str, float | str]] = {}
+    current_total = sum(row.quantity for row in current_positions)
+    proposed_total = (
+        sum(row.proposed_quantity for row in projected_positions)
+        if projected_positions
+        else current_total
+    )
+
+    for security_id in keys:
+        current_row = current_map.get(security_id)
+        projected_row = projected_map.get(security_id)
+
+        if group_by == "SECURITY":
+            bucket_key = security_id
+            bucket_label = (
+                projected_row.instrument_name
+                if projected_row
+                else (current_row.instrument_name if current_row else security_id)
+            )
+        else:
+            asset_class = (
+                projected_row.asset_class
+                if projected_row
+                else (current_row.asset_class if current_row else None)
+            )
+            bucket_key = str(asset_class or "UNCLASSIFIED").upper()
+            bucket_label = bucket_key
+
+        if bucket_key not in grouped:
+            grouped[bucket_key] = {
+                "bucket_label": bucket_label,
+                "current_quantity": 0.0,
+                "proposed_quantity": 0.0,
+            }
+
+        grouped[bucket_key]["current_quantity"] = float(grouped[bucket_key]["current_quantity"]) + (
+            current_row.quantity if current_row else 0.0
+        )
+        grouped[bucket_key]["proposed_quantity"] = float(grouped[bucket_key]["proposed_quantity"]) + (
+            projected_row.proposed_quantity
+            if projected_row
+            else (current_row.quantity if current_row else 0.0)
+        )
+
+    buckets: list[WorkbenchAnalyticsBucket] = []
+    for key, row in grouped.items():
+        current_quantity = float(row["current_quantity"])
+        proposed_quantity = float(row["proposed_quantity"])
+        buckets.append(
+            WorkbenchAnalyticsBucket(
+                bucketKey=key,
+                bucketLabel=str(row["bucket_label"]),
+                currentQuantity=current_quantity,
+                proposedQuantity=proposed_quantity,
+                deltaQuantity=proposed_quantity - current_quantity,
+                currentWeightPct=((current_quantity / current_total) * 100 if current_total > 0 else 0.0),
+                proposedWeightPct=((proposed_quantity / proposed_total) * 100 if proposed_total > 0 else 0.0),
+            )
+        )
+
+    return sorted(buckets, key=lambda item: abs(item.delta_quantity), reverse=True)
+
+
+def _top_changes(projected_positions: list[WorkbenchProjectedPositionInput]) -> list[WorkbenchTopChange]:
+    rows = sorted(projected_positions, key=lambda row: abs(row.delta_quantity), reverse=True)
+    return [
+        WorkbenchTopChange(
+            securityId=row.security_id,
+            instrumentName=row.instrument_name,
+            deltaQuantity=row.delta_quantity,
+            direction="INCREASE" if row.delta_quantity >= 0 else "DECREASE",
+        )
+        for row in rows[:10]
+    ]
+
+
+def _risk_proxy(buckets: list[WorkbenchAnalyticsBucket]) -> WorkbenchRiskProxy:
+    current_hhi = 0.0
+    proposed_hhi = 0.0
+    for bucket in buckets:
+        current_weight = (bucket.current_weight_pct or 0.0) / 100.0
+        proposed_weight = (bucket.proposed_weight_pct or 0.0) / 100.0
+        current_hhi += current_weight * current_weight
+        proposed_hhi += proposed_weight * proposed_weight
+
+    scaled_current = current_hhi * 10000
+    scaled_proposed = proposed_hhi * 10000
+    return WorkbenchRiskProxy(
+        hhiCurrent=scaled_current,
+        hhiProposed=scaled_proposed,
+        hhiDelta=scaled_proposed - scaled_current,
+    )
+
+
+@router.post(
+    "/workbench",
+    response_model=WorkbenchAnalyticsResponse,
+    summary="Calculate PA-owned workbench analytics",
+    description=(
+        "Returns PA-owned allocation, concentration (HHI proxy), and top-change analytics "
+        "for workbench flows. BFF passes normalized holdings and projected positions."
+    ),
+)
+async def get_workbench_analytics(request: WorkbenchAnalyticsRequest):
+    buckets = _workbench_buckets(
+        current_positions=request.current_positions,
+        projected_positions=request.projected_positions,
+        group_by=request.group_by,
+    )
+    top_changes = _top_changes(request.projected_positions)
+    risk_proxy = _risk_proxy(buckets)
+
+    benchmark_return = (
+        request.benchmark_return_pct
+        if request.benchmark_return_pct is not None
+        else _BENCHMARK_FALLBACK_RETURNS.get(request.benchmark_code, 0.0)
+    )
+    active_return = (
+        request.portfolio_return_pct - benchmark_return
+        if request.portfolio_return_pct is not None and benchmark_return is not None
+        else None
+    )
+
+    return WorkbenchAnalyticsResponse(
+        portfolioId=request.portfolio_id,
+        period=request.period,
+        groupBy=request.group_by,
+        benchmarkCode=request.benchmark_code,
+        portfolioReturnPct=request.portfolio_return_pct,
+        benchmarkReturnPct=benchmark_return,
+        activeReturnPct=active_return,
+        allocationBuckets=buckets,
+        topChanges=top_changes,
+        riskProxy=risk_proxy,
+    )

--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -62,6 +62,8 @@ async def get_integration_capabilities(
     mwr_enabled = _env_bool("PA_CAP_MWR_ENABLED", True)
     contribution_enabled = _env_bool("PA_CAP_CONTRIBUTION_ENABLED", True)
     attribution_enabled = _env_bool("PA_CAP_ATTRIBUTION_ENABLED", True)
+    risk_enabled = _env_bool("PA_CAP_RISK_ENABLED", True)
+    concentration_enabled = _env_bool("PA_CAP_CONCENTRATION_ENABLED", True)
 
     features = [
         FeatureCapability(
@@ -88,6 +90,18 @@ async def get_integration_capabilities(
             owner_service="PA",
             description="Attribution analytics APIs.",
         ),
+        FeatureCapability(
+            key="pa.analytics.risk",
+            enabled=risk_enabled,
+            owner_service="PA",
+            description="Risk analytics APIs.",
+        ),
+        FeatureCapability(
+            key="pa.analytics.concentration",
+            enabled=concentration_enabled,
+            owner_service="PA",
+            description="Concentration analytics APIs.",
+        ),
     ]
 
     workflows = [
@@ -100,6 +114,15 @@ async def get_integration_capabilities(
             workflow_key="performance_explainability",
             enabled=contribution_enabled and attribution_enabled,
             required_features=["pa.analytics.contribution", "pa.analytics.attribution"],
+        ),
+        WorkflowCapability(
+            workflow_key="workbench_analytics",
+            enabled=risk_enabled and concentration_enabled and twr_enabled,
+            required_features=[
+                "pa.analytics.twr",
+                "pa.analytics.risk",
+                "pa.analytics.concentration",
+            ],
         ),
     ]
 

--- a/app/models/workbench_analytics_requests.py
+++ b/app/models/workbench_analytics_requests.py
@@ -1,0 +1,72 @@
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class WorkbenchPositionInput(BaseModel):
+    security_id: str = Field(..., alias="securityId")
+    instrument_name: str = Field(..., alias="instrumentName")
+    asset_class: str | None = Field(default=None, alias="assetClass")
+    quantity: float
+
+    model_config = {"populate_by_name": True}
+
+
+class WorkbenchProjectedPositionInput(BaseModel):
+    security_id: str = Field(..., alias="securityId")
+    instrument_name: str = Field(..., alias="instrumentName")
+    asset_class: str | None = Field(default=None, alias="assetClass")
+    baseline_quantity: float = Field(..., alias="baselineQuantity")
+    proposed_quantity: float = Field(..., alias="proposedQuantity")
+    delta_quantity: float = Field(..., alias="deltaQuantity")
+
+    model_config = {"populate_by_name": True}
+
+
+class WorkbenchAnalyticsRequest(BaseModel):
+    portfolio_id: str = Field(..., alias="portfolioId")
+    as_of_date: date = Field(..., alias="asOfDate")
+    period: str = "YTD"
+    group_by: Literal["ASSET_CLASS", "SECURITY"] = Field("ASSET_CLASS", alias="groupBy")
+    benchmark_code: str = Field("MODEL_60_40", alias="benchmarkCode")
+    portfolio_return_pct: float | None = Field(default=None, alias="portfolioReturnPct")
+    benchmark_return_pct: float | None = Field(default=None, alias="benchmarkReturnPct")
+    current_positions: list[WorkbenchPositionInput] = Field(default_factory=list, alias="currentPositions")
+    projected_positions: list[WorkbenchProjectedPositionInput] = Field(
+        default_factory=list, alias="projectedPositions"
+    )
+
+    model_config = {
+        "populate_by_name": True,
+        "json_schema_extra": {
+            "example": {
+                "portfolioId": "DEMO_DPM_EUR_001",
+                "asOfDate": "2026-02-24",
+                "period": "YTD",
+                "groupBy": "ASSET_CLASS",
+                "benchmarkCode": "MODEL_60_40",
+                "portfolioReturnPct": 4.2,
+                "benchmarkReturnPct": 3.8,
+                "currentPositions": [
+                    {
+                        "securityId": "AAPL.US",
+                        "instrumentName": "Apple Inc",
+                        "assetClass": "EQUITY",
+                        "quantity": 120.0,
+                    }
+                ],
+                "projectedPositions": [
+                    {
+                        "securityId": "AAPL.US",
+                        "instrumentName": "Apple Inc",
+                        "assetClass": "EQUITY",
+                        "baselineQuantity": 120.0,
+                        "proposedQuantity": 100.0,
+                        "deltaQuantity": -20.0,
+                    }
+                ],
+            }
+        },
+    }
+

--- a/app/models/workbench_analytics_responses.py
+++ b/app/models/workbench_analytics_responses.py
@@ -1,0 +1,48 @@
+from pydantic import BaseModel, Field
+
+
+class WorkbenchAnalyticsBucket(BaseModel):
+    bucket_key: str = Field(alias="bucketKey")
+    bucket_label: str = Field(alias="bucketLabel")
+    current_quantity: float = Field(alias="currentQuantity")
+    proposed_quantity: float = Field(alias="proposedQuantity")
+    delta_quantity: float = Field(alias="deltaQuantity")
+    current_weight_pct: float = Field(alias="currentWeightPct")
+    proposed_weight_pct: float = Field(alias="proposedWeightPct")
+
+    model_config = {"populate_by_name": True}
+
+
+class WorkbenchTopChange(BaseModel):
+    security_id: str = Field(alias="securityId")
+    instrument_name: str = Field(alias="instrumentName")
+    delta_quantity: float = Field(alias="deltaQuantity")
+    direction: str
+
+    model_config = {"populate_by_name": True}
+
+
+class WorkbenchRiskProxy(BaseModel):
+    hhi_current: float = Field(alias="hhiCurrent")
+    hhi_proposed: float = Field(alias="hhiProposed")
+    hhi_delta: float = Field(alias="hhiDelta")
+
+    model_config = {"populate_by_name": True}
+
+
+class WorkbenchAnalyticsResponse(BaseModel):
+    source_mode: str = "pa_calc"
+    source_service: str = Field("performance-analytics", alias="sourceService")
+    portfolio_id: str = Field(alias="portfolioId")
+    period: str
+    group_by: str = Field(alias="groupBy")
+    benchmark_code: str = Field(alias="benchmarkCode")
+    portfolio_return_pct: float | None = Field(default=None, alias="portfolioReturnPct")
+    benchmark_return_pct: float | None = Field(default=None, alias="benchmarkReturnPct")
+    active_return_pct: float | None = Field(default=None, alias="activeReturnPct")
+    allocation_buckets: list[WorkbenchAnalyticsBucket] = Field(default_factory=list, alias="allocationBuckets")
+    top_changes: list[WorkbenchTopChange] = Field(default_factory=list, alias="topChanges")
+    risk_proxy: WorkbenchRiskProxy = Field(alias="riskProxy")
+
+    model_config = {"populate_by_name": True}
+

--- a/tests/integration/test_analytics_api.py
+++ b/tests/integration/test_analytics_api.py
@@ -58,3 +58,49 @@ def test_positions_analytics_invalid_payload(monkeypatch):
         json={"portfolioId": "P1", "asOfDate": "2026-02-24"},
     )
     assert response.status_code == 502
+
+
+def test_workbench_analytics_success():
+    client = TestClient(app)
+    response = client.post(
+        "/analytics/workbench",
+        json={
+            "portfolioId": "P1",
+            "asOfDate": "2026-02-24",
+            "period": "YTD",
+            "groupBy": "ASSET_CLASS",
+            "benchmarkCode": "MODEL_60_40",
+            "portfolioReturnPct": 4.2,
+            "currentPositions": [
+                {
+                    "securityId": "AAPL.US",
+                    "instrumentName": "Apple Inc",
+                    "assetClass": "EQUITY",
+                    "quantity": 120.0,
+                },
+                {
+                    "securityId": "UST10Y",
+                    "instrumentName": "US Treasury 10Y",
+                    "assetClass": "FIXED_INCOME",
+                    "quantity": 80.0,
+                },
+            ],
+            "projectedPositions": [
+                {
+                    "securityId": "AAPL.US",
+                    "instrumentName": "Apple Inc",
+                    "assetClass": "EQUITY",
+                    "baselineQuantity": 120.0,
+                    "proposedQuantity": 100.0,
+                    "deltaQuantity": -20.0,
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["source_mode"] == "pa_calc"
+    assert body["portfolioId"] == "P1"
+    assert len(body["allocationBuckets"]) >= 1
+    assert "riskProxy" in body
+    assert body["activeReturnPct"] is not None

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -14,8 +14,11 @@ def test_integration_capabilities_default_contract():
     assert body["consumerSystem"] == "BFF"
     assert body["tenantId"] == "default"
     assert body["supportedInputModes"] == ["pas_ref", "inline_bundle"]
-    assert len(body["features"]) >= 4
-    assert len(body["workflows"]) >= 2
+    assert len(body["features"]) >= 6
+    assert len(body["workflows"]) >= 3
+    features = {item["key"] for item in body["features"]}
+    assert "pa.analytics.risk" in features
+    assert "pa.analytics.concentration" in features
 
 
 def test_integration_capabilities_env_override(monkeypatch):


### PR DESCRIPTION
## Summary
- add new PA endpoint POST /analytics/workbench for allocation buckets, top changes, and concentration proxy (HHI)
- keep advanced analytics calculations in PA (no BFF reimplementation)
- expand integration capabilities with PA risk/concentration feature flags

## Validation
- python -m pytest tests/integration/test_analytics_api.py -q
- python -m pytest tests/integration/test_integration_capabilities_api.py -q