### PR TITLE
chore: ignore local output artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ htmlcov/
 # Lineage data (RFC 025)
 lineage_data/
 htmlcov/
+output/


### PR DESCRIPTION
## Summary\n- add output/ to git ignore for local async artifacts\n\n## Why\n- keeps working tree clean during async runs and automation tasks