### PR TITLE
PA coverage hardening wave 1 (95% -> 97%)

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,3 @@
+# RFC Index
+
+- `RFC-0001-pa-coverage-hardening-wave-1.md`

--- a/rfcs/RFC-0001-pa-coverage-hardening-wave-1.md
+++ b/rfcs/RFC-0001-pa-coverage-hardening-wave-1.md
@@ -1,0 +1,42 @@
+# RFC-0001: PA Coverage Hardening Wave 1
+
+## Status
+
+Proposed
+
+## Date
+
+2026-02-24
+
+## Problem Statement
+
+`performanceAnalytics` was below target meaningful coverage and had concentrated gaps in PAS integration adapter paths, observability helpers, and endpoint negative-path validation.
+
+## Decision
+
+Deliver an incremental hardening wave focused on highest-risk uncovered backend behavior without changing functional contracts.
+
+## Scope
+
+- Add unit tests for `PasSnapshotService` request/response contract behavior and fallback payload parsing.
+- Add unit tests for observability helpers (correlation/request/trace resolution and propagation header generation).
+- Add integration tests for:
+  - analytics upstream failure passthrough
+  - workbench analytics security-group branch
+  - contribution edge paths (no resolved periods, empty period slice)
+  - PAS-input TWR negative paths (missing performance start, invalid valuation shape, missing period results)
+
+## Result
+
+- Full test suite: `209 passed`
+- Coverage improved from ~`95%` to `97%`
+- `app/services/pas_snapshot_service.py`: now `100%`
+- `app/observability.py`: now `100%`
+- `app/api/endpoints/analytics.py`: now `100%`
+- `app/api/endpoints/contribution.py`: now `100%`
+
+## Follow-up
+
+Wave 2 will target remaining concentrated misses in:
+- `app/api/endpoints/performance.py`
+- `app/services/lineage_service.py`

--- a/tests/unit/services/test_pas_snapshot_service.py
+++ b/tests/unit/services/test_pas_snapshot_service.py
@@ -1,0 +1,159 @@
+from datetime import date
+
+import httpx
+import pytest
+
+from app.services.pas_snapshot_service import PasSnapshotService
+
+
+class _FakeAsyncClient:
+    responses: list[httpx.Response] = []
+    calls: list[dict] = []
+
+    def __init__(self, timeout: float):
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "json": json or {}, "headers": headers or {}})
+        if not self.responses:
+            raise AssertionError("No queued response available.")
+        response = self.responses.pop(0)
+        if response.request is None:
+            response.request = httpx.Request("POST", url)  # type: ignore[misc]
+        return response
+
+    @classmethod
+    def queue_json(cls, status_code: int, payload):
+        cls.responses.append(
+            httpx.Response(
+                status_code=status_code,
+                json=payload,
+                request=httpx.Request("POST", "http://test"),
+            )
+        )
+
+    @classmethod
+    def queue_text(cls, status_code: int, text: str):
+        cls.responses.append(
+            httpx.Response(
+                status_code=status_code,
+                content=text.encode("utf-8"),
+                headers={"Content-Type": "text/plain"},
+                request=httpx.Request("POST", "http://test"),
+            )
+        )
+
+
+@pytest.fixture(autouse=True)
+def _patch_async_client(monkeypatch):
+    _FakeAsyncClient.responses = []
+    _FakeAsyncClient.calls = []
+    monkeypatch.setattr("app.services.pas_snapshot_service.httpx.AsyncClient", _FakeAsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_get_core_snapshot_posts_contract_payload():
+    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"snapshot": {"overview": {}}})
+
+    status_code, payload = await service.get_core_snapshot(
+        portfolio_id="PORT-1",
+        as_of_date=date(2026, 2, 24),
+        include_sections=["OVERVIEW", "HOLDINGS"],
+        consumer_system="PA",
+    )
+
+    assert status_code == 200
+    assert payload["snapshot"] == {"overview": {}}
+    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/portfolios/PORT-1/core-snapshot"
+    assert _FakeAsyncClient.calls[0]["json"]["includeSections"] == ["OVERVIEW", "HOLDINGS"]
+    assert _FakeAsyncClient.calls[0]["json"]["consumerSystem"] == "PA"
+
+
+@pytest.mark.asyncio
+async def test_get_performance_input_posts_contract_payload():
+    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"valuationPoints": []})
+
+    status_code, payload = await service.get_performance_input(
+        portfolio_id="PORT-2",
+        as_of_date=date(2026, 2, 24),
+        lookback_days=365,
+        consumer_system="PA",
+    )
+
+    assert status_code == 200
+    assert "valuationPoints" in payload
+    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/portfolios/PORT-2/performance-input"
+    assert _FakeAsyncClient.calls[0]["json"]["lookbackDays"] == 365
+
+
+@pytest.mark.asyncio
+async def test_get_positions_analytics_with_and_without_performance_periods():
+    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"portfolioId": "PORT-3"})
+    _FakeAsyncClient.queue_json(200, {"portfolioId": "PORT-3"})
+
+    status_one, _ = await service.get_positions_analytics(
+        portfolio_id="PORT-3",
+        as_of_date=date(2026, 2, 24),
+        sections=["BASE"],
+        performance_periods=["YTD", "MTD"],
+    )
+    status_two, _ = await service.get_positions_analytics(
+        portfolio_id="PORT-3",
+        as_of_date=date(2026, 2, 24),
+        sections=["BASE"],
+        performance_periods=None,
+    )
+
+    assert status_one == 200
+    assert status_two == 200
+    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/portfolios/PORT-3/positions-analytics"
+    assert _FakeAsyncClient.calls[0]["json"]["performanceOptions"]["periods"] == ["YTD", "MTD"]
+    assert "performanceOptions" not in _FakeAsyncClient.calls[1]["json"]
+
+
+@pytest.mark.parametrize(
+    ("payload", "text", "expected"),
+    [
+        ({"ok": True}, "", {"ok": True}),
+        (["non-dict"], "", {"detail": ["non-dict"]}),
+        (ValueError("bad json"), "plain-text", {"detail": "plain-text"}),
+    ],
+)
+def test_response_payload_parsing(payload, text, expected):
+    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+
+    class _Resp:
+        def __init__(self, value, raw_text: str):
+            self._value = value
+            self.text = raw_text
+
+        def json(self):
+            if isinstance(self._value, Exception):
+                raise self._value
+            return self._value
+
+    parsed = service._response_payload(_Resp(payload, text))
+    assert parsed == expected
+
+
+@pytest.mark.asyncio
+async def test_text_error_payload_is_mapped_to_detail():
+    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_text(503, "upstream unavailable")
+    status_code, payload = await service.get_core_snapshot(
+        portfolio_id="PORT-4",
+        as_of_date=date(2026, 2, 24),
+        include_sections=["OVERVIEW"],
+        consumer_system="PA",
+    )
+    assert status_code == 503
+    assert payload["detail"] == "upstream unavailable"

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,87 @@
+import json
+import logging
+
+from fastapi import Request
+
+from app.observability import (
+    JsonFormatter,
+    correlation_id_var,
+    propagation_headers,
+    request_id_var,
+    resolve_correlation_id,
+    resolve_request_id,
+    resolve_trace_id,
+    trace_id_var,
+)
+
+
+def _request_with_headers(headers: dict[str, str]) -> Request:
+    asgi_headers = [(k.lower().encode("utf-8"), v.encode("utf-8")) for k, v in headers.items()]
+    scope = {"type": "http", "headers": asgi_headers}
+    return Request(scope)
+
+
+def test_resolve_correlation_id_primary_and_alias():
+    assert resolve_correlation_id(_request_with_headers({"X-Correlation-Id": "corr-1"})) == "corr-1"
+    assert resolve_correlation_id(_request_with_headers({"X-Correlation-ID": "corr-2"})) == "corr-2"
+
+
+def test_resolve_request_id_generates_when_missing():
+    value = resolve_request_id(_request_with_headers({}))
+    assert value.startswith("req_")
+
+
+def test_resolve_trace_id_prefers_traceparent_then_header_then_generated():
+    traceparent_value = "00-0123456789abcdef0123456789abcdef-0000000000000001-01"
+    assert resolve_trace_id(_request_with_headers({"traceparent": traceparent_value})) == (
+        "0123456789abcdef0123456789abcdef"
+    )
+    assert resolve_trace_id(_request_with_headers({"traceparent": "invalid", "X-Trace-Id": "trace-1"})) == ("trace-1")
+    generated = resolve_trace_id(_request_with_headers({"traceparent": "invalid"}))
+    assert len(generated) == 32
+
+
+def test_propagation_headers_use_context_values():
+    correlation_id_var.set("corr-ctx")
+    request_id_var.set("req-ctx")
+    trace_id_var.set("0123456789abcdef0123456789abcdef")
+    headers = propagation_headers()
+    assert headers["X-Correlation-Id"] == "corr-ctx"
+    assert headers["X-Request-Id"] == "req-ctx"
+    assert headers["traceparent"] == "00-0123456789abcdef0123456789abcdef-0000000000000001-01"
+
+
+def test_propagation_headers_generates_when_context_absent():
+    correlation_id_var.set("")
+    request_id_var.set("")
+    trace_id_var.set("")
+    headers = propagation_headers()
+    assert headers["X-Correlation-Id"].startswith("corr_")
+    assert headers["X-Request-Id"].startswith("req_")
+    assert len(headers["X-Trace-Id"]) == 32
+
+
+def test_json_formatter_includes_standard_and_extra_fields(monkeypatch):
+    monkeypatch.setenv("SERVICE_NAME", "pa-test")
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    correlation_id_var.set("corr-log")
+    request_id_var.set("req-log")
+    trace_id_var.set("trace-log")
+
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="unit.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="log-message",
+        args=(),
+        exc_info=None,
+    )
+    record.extra_fields = {"endpoint": "/health", "latency_ms": 12.3}
+    payload = json.loads(formatter.format(record))
+    assert payload["service"] == "pa-test"
+    assert payload["environment"] == "test"
+    assert payload["message"] == "log-message"
+    assert payload["endpoint"] == "/health"
+    assert payload["latency_ms"] == 12.3


### PR DESCRIPTION
## Summary
- add RFC-0001 for PA coverage hardening wave 1
- add unit tests for PAS snapshot adapter request/response contracts and payload fallback paths
- add unit tests for observability helper behavior (correlation/request/trace resolution and propagation)
- add integration tests for analytics and contribution edge/error branches
- extend PAS-input TWR integration tests for missing/invalid upstream payload paths

## Validation
- `python -m pytest tests --cov=app --cov=engine --cov=core --cov=adapters --cov-report=term-missing --cov-fail-under=0`

## Result
- tests: 209 passed
- coverage: 97% (from ~95%)
- `app/services/pas_snapshot_service.py`: 100%
- `app/observability.py`: 100%
- `app/api/endpoints/analytics.py`: 100%
- `app/api/endpoints/contribution.py`: 100%
