### PR TITLE
PA: E2E pyramid wave 3 resilience and lineage workflows

### DIFF
--- a/docs/RFCs/RFC 037 - E2E Pyramid Wave 3 - Resilience and Lineage Workflow Coverage.md
+++ b/docs/RFCs/RFC 037 - E2E Pyramid Wave 3 - Resilience and Lineage Workflow Coverage.md
@@ -1,0 +1,26 @@
+# RFC 037 - E2E Pyramid Wave 3 - Resilience and Lineage Workflow Coverage
+
+## Problem Statement
+PA meets the 99% coverage gate but remains below the platform E2E test-pyramid target (5-10% of total tests), leaving cross-endpoint workflow and resilience paths under-validated.
+
+## Root Cause
+Most recent PA test expansion focused on unit and integration layers. End-to-end coverage did not scale at the same pace, especially for failure passthrough and lineage-backed workflow verification.
+
+## Proposed Solution
+Add a focused wave of PA E2E tests that validate:
+1. PAS-ref workflow success and upstream failure passthrough.
+2. Position analytics upstream payload validation behavior.
+3. Contribution, attribution, and MWR lineage retrieval workflows.
+4. Capability toggle behavior and workbench analytics response quality.
+
+## Architectural Impact
+No API contract or runtime behavior changes. This change increases confidence in PA's public contracts and integration-facing behavior under realistic workflows.
+
+## Risks and Trade-offs
+- Slightly longer E2E runtime in CI.
+- Additional test maintenance as contracts evolve.
+
+## High-Level Implementation Approach
+1. Add 8 E2E tests in `tests/e2e/test_workflow_journeys.py` targeting high-value user-facing and upstream-facing flows.
+2. Keep assertions behavior-focused (status, contract shape, lineage availability, passthrough semantics).
+3. Run PA E2E suite and full coverage gate to verify threshold and pyramid movement.


### PR DESCRIPTION
## Summary
- add RFC 037 for PA E2E pyramid wave 3
- add 8 new E2E workflow tests focused on resilience, passthrough semantics, and lineage roundtrips
- increase PA e2e count from 5 to 13 to move toward platform pyramid target band

## Scope
- `tests/e2e/test_workflow_journeys.py`
- `docs/RFCs/RFC 037 - E2E Pyramid Wave 3 - Resilience and Lineage Workflow Coverage.md`

## Validation
- `python -m pytest tests/e2e/test_workflow_journeys.py -q` -> 13 passed
- `python -m pytest --cov=app --cov=engine --cov=core --cov=adapters --cov-report=term --cov-fail-under=99` -> pass (99.03%)