### PR TITLE
PA: fix lint import order in E2E tests

### DIFF
--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -1,5 +1,5 @@
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 from main import app
 


### PR DESCRIPTION
## Summary
- fix import order in `tests/e2e/test_workflow_journeys.py` to satisfy ruff I001
- no behavior changes

## Validation
- `python -m ruff check .` passes locally