### PR TITLE
docs: RFC 038 PA domain vocabulary alignment plan

### DIFF
--- a/docs/RFCs/RFC 038 - PA Domain Vocabulary Alignment with Platform Glossary.md
+++ b/docs/RFCs/RFC 038 - PA Domain Vocabulary Alignment with Platform Glossary.md
@@ -1,0 +1,73 @@
+# RFC 038 - PA Domain Vocabulary Alignment with Platform Glossary
+
+## Status
+Proposed
+
+## Date
+2026-02-25
+
+## Problem Statement
+
+`performanceAnalytics` still uses legacy shared terms (`portfolio_number`, `pas-snapshot`) in API contracts, models, tests, and documentation.
+This conflicts with the platform glossary in `pbwm-platform-docs/Domain Vocabulary Glossary.md`, which mandates canonical cross-service terms such as `portfolio_id`, `as_of_date`, and `pas-input` terminology.
+
+Current measurable drift (baseline from `Validate-Domain-Vocabulary.ps1`):
+- `portfolio_number`: 121 findings
+- `pas-snapshot`: 5 findings
+
+## Decision
+
+Perform a phased vocabulary migration in PA to align with platform glossary while preserving service stability during rollout.
+
+1. Canonical request/response field names use `snake_case` internally and canonical cross-service aliases (`portfolioId`, `asOfDate`) at BFF-facing integration boundaries where required.
+2. Remove `portfolio_number` from PA public contracts and replace with `portfolio_id`.
+3. Deprecate `pas-snapshot` naming and replace with `pas-input` terminology in endpoints/docs/contracts.
+4. Keep compatibility shims only for an explicitly time-boxed transition window (if needed), with clear removal milestones.
+
+## Scope
+
+- PA API contracts and model fields.
+- PA endpoint naming and docs references.
+- PA tests and fixtures.
+- PA docs/examples/RFC references in this repository.
+
+## Out of Scope
+
+- Cross-service consumer migrations in the same PR.
+- PAS/DPM/BFF contract changes beyond PA-owned surface.
+
+## Implementation Plan
+
+### Phase A - Contract Surface Alignment
+- Introduce canonical PA models using `portfolio_id`.
+- Replace `/performance/twr/pas-snapshot` naming with `pas-input` terminology.
+- Keep temporary alias compatibility only where required by existing tests.
+
+### Phase B - Test and Fixture Migration
+- Rename all fixtures/assertions from `portfolio_number` to `portfolio_id`.
+- Update integration/e2e tests to canonical terminology.
+- Ensure no behavior regression.
+
+### Phase C - Documentation and RFC Alignment
+- Update README, guides, examples, and PA RFC references.
+- Replace deprecated terms in public examples and OpenAPI descriptions.
+
+### Phase D - Compatibility Removal
+- Remove temporary alias support.
+- Enforce zero prohibited terms in PA conformance baseline.
+
+## Risks and Trade-offs
+
+- Broad rename impacts many files and tests; high change surface.
+- Temporary dual-term support may increase short-term complexity.
+
+Mitigation:
+- Execute in small PR waves (A-D).
+- Keep strict contract tests and OpenAPI gate active in each wave.
+
+## Acceptance Criteria
+
+1. PA has zero `portfolio_number` and zero `pas-snapshot` occurrences in active code/contracts/docs.
+2. OpenAPI reflects canonical vocabulary.
+3. All PA CI gates remain green (`lint`, `typecheck`, `openapi-gate`, tests, coverage, security).
+4. Platform vocabulary conformance report marks PA as `ok`.

--- a/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
+++ b/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
@@ -39,6 +39,11 @@ The following RFCs have been **fully implemented** and their features are part o
 
 The following RFCs are not yet implemented. This roadmap presents a logical order for their development, prioritizing foundational capabilities that enable more advanced analytics.
 
+### Phase 0: Vocabulary and Contract Hygiene
+
+1.  **RFC 038 — PA Domain Vocabulary Alignment with Platform Glossary**
+    * **Reasoning:** **Eliminate cross-platform semantic drift first.** Aligns PA to canonical platform language (`portfolio_id`, `pas-input`) before further contract expansion.
+
 ### Phase 1: Foundational Enhancements
 
 1.  **RFC 032 — Real-Time Analytics Surfaces for Iterative Advisory and DPM Simulation**


### PR DESCRIPTION
Summary: add RFC 038 to migrate PA from legacy shared terms (`portfolio_number`, `pas-snapshot`) to platform glossary terms and update RFC status roadmap with Phase 0 priority.