### PR TITLE
feat: RFC-038 hard cutover remove PA legacy vocabulary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pytest --benchmark-only "tests/benchmarks/"
     curl -X POST "[http://127.0.0.1:8000/performance/twr](http://127.0.0.1:8000/performance/twr)" \
     -H "Content-Type: application/json" \
     -d '{
-      "portfolio_number": "MULTI_PERIOD_01",
+      "portfolio_id": "MULTI_PERIOD_01",
       "performance_start_date": "2024-12-31",
       "as_of": "2025-02-28",
       "metric_basis": "NET",
@@ -149,9 +149,9 @@ pytest --benchmark-only "tests/benchmarks/"
   - **Endpoint:** `GET /integration/capabilities`
   - **Description:** Returns backend-governed PA capability and workflow metadata for BFF/PAS/DPM integration.
 
-### 6\. PAS-Connected TWR
+### 6\. PAS-Input TWR
 
-  - **Endpoint:** `POST /performance/twr/pas-snapshot`
+  - **Endpoint:** `POST /performance/twr/pas-input`
   - **Description:** Fetches PAS Core Snapshot (`PERFORMANCE` section) and returns PA-normalized period results for UI/BFF consumption.
 
 -----
@@ -163,4 +163,5 @@ The core calculation logic is a standalone library. For instructions on how to u
   - **[Using the Performance Engine as a Standalone Library](https://www.google.com/search?q=docs/guides/standalone_engine_usage.md)**
 
 <!-- end list -->
+
 

--- a/app/api/endpoints/analytics.py
+++ b/app/api/endpoints/analytics.py
@@ -13,7 +13,7 @@ from app.models.workbench_analytics_responses import (
     WorkbenchRiskProxy,
     WorkbenchTopChange,
 )
-from app.services.pas_snapshot_service import PasSnapshotService
+from app.services.pas_input_service import PasInputService
 
 router = APIRouter(tags=["Analytics"])
 settings = get_settings()
@@ -34,7 +34,7 @@ _BENCHMARK_FALLBACK_RETURNS = {"MODEL_60_40": 3.1, "MSCI_ACWI": 4.2, "CUSTOM": 2
     },
 )
 async def get_positions_analytics(request: PositionAnalyticsRequest):
-    pas_service = PasSnapshotService(
+    pas_service = PasInputService(
         base_url=settings.PAS_QUERY_BASE_URL,
         timeout_seconds=settings.PAS_TIMEOUT_SECONDS,
     )
@@ -199,3 +199,4 @@ async def get_workbench_analytics(request: WorkbenchAnalyticsRequest):
         topChanges=top_changes,
         riskProxy=risk_proxy,
     )
+

--- a/app/api/endpoints/contribution.py
+++ b/app/api/endpoints/contribution.py
@@ -149,7 +149,7 @@ async def calculate_contribution_endpoint(request: ContributionRequest, backgrou
 
     response_model = ContributionResponse(
         calculation_id=request.calculation_id,
-        portfolio_number=request.portfolio_number,
+        portfolio_id=request.portfolio_id,
         results_by_period=results_by_period,
         meta=meta,
         diagnostics=diagnostics,
@@ -169,3 +169,4 @@ async def calculate_contribution_endpoint(request: ContributionRequest, backgrou
     )
 
     return response_model
+

--- a/app/models/attribution_requests.py
+++ b/app/models/attribution_requests.py
@@ -67,7 +67,7 @@ class AttributionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     calculation_id: UUID = Field(default_factory=uuid4)
-    portfolio_number: str
+    portfolio_id: str
     report_start_date: date
     report_end_date: date
 
@@ -102,3 +102,4 @@ class AttributionRequest(BaseModel):
         if not v:
             raise ValueError("analyses list cannot be empty")
         return v
+

--- a/app/models/attribution_responses.py
+++ b/app/models/attribution_responses.py
@@ -83,7 +83,7 @@ class AttributionResponse(BaseModel):
     """Response model for the Attribution engine."""
 
     calculation_id: UUID
-    portfolio_number: str
+    portfolio_id: str
     model: AttributionModel
     linking: LinkingMethod
 
@@ -94,3 +94,4 @@ class AttributionResponse(BaseModel):
     meta: Meta
     diagnostics: Optional[Diagnostics] = None  # To be populated
     audit: Optional[Audit] = None  # To be populated
+

--- a/app/models/contribution_requests.py
+++ b/app/models/contribution_requests.py
@@ -71,7 +71,7 @@ class ContributionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     calculation_id: UUID = Field(default_factory=uuid4)
-    portfolio_number: str
+    portfolio_id: str
     report_start_date: date
     report_end_date: date
 
@@ -107,3 +107,4 @@ class ContributionRequest(BaseModel):
         if not v:
             raise ValueError("analyses list cannot be empty")
         return v
+

--- a/app/models/contribution_responses.py
+++ b/app/models/contribution_responses.py
@@ -88,7 +88,7 @@ class ContributionResponse(BaseModel):
     """Response model for the Contribution engine."""
 
     calculation_id: UUID
-    portfolio_number: str
+    portfolio_id: str
 
     # New multi-period structure
     results_by_period: Optional[Dict[str, SinglePeriodContributionResult]] = None
@@ -126,3 +126,4 @@ class ContributionResponse(BaseModel):
             raise ValueError("A result structure ('results_by_period' or legacy fields) must be provided.")
 
         return values
+

--- a/app/models/mwr_requests.py
+++ b/app/models/mwr_requests.py
@@ -27,7 +27,7 @@ class MoneyWeightedReturnRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     calculation_id: UUID = Field(default_factory=uuid4)
-    portfolio_number: str
+    portfolio_id: str
     begin_mv: float
     end_mv: float
     cash_flows: List[CashFlow]
@@ -44,3 +44,4 @@ class MoneyWeightedReturnRequest(BaseModel):
     output: Output = Field(default_factory=Output)
     flags: Flags = Field(default_factory=Flags)
     report_ccy: Optional[str] = None
+

--- a/app/models/mwr_responses.py
+++ b/app/models/mwr_responses.py
@@ -33,7 +33,7 @@ class MoneyWeightedReturnResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     calculation_id: UUID
-    portfolio_number: str
+    portfolio_id: str
 
     money_weighted_return: float
     mwr_annualized: Optional[float] = None
@@ -47,3 +47,4 @@ class MoneyWeightedReturnResponse(BaseModel):
     meta: Meta
     diagnostics: Diagnostics
     audit: Audit
+

--- a/app/models/pas_connected_responses.py
+++ b/app/models/pas_connected_responses.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 
 class PasConnectedPeriodResult(BaseModel):
@@ -15,7 +15,10 @@ class PasConnectedPeriodResult(BaseModel):
 
 
 class PasConnectedTwrResponse(BaseModel):
-    portfolio_number: str
+    portfolio_id: str = Field(
+        validation_alias=AliasChoices("portfolio_id", "portfolioId"),
+        serialization_alias="portfolio_id",
+    )
     as_of_date: date
     source_mode: Literal["pas_ref"] = "pas_ref"
     source_service: str = "performance-analytics"
@@ -28,3 +31,4 @@ class PasConnectedTwrResponse(BaseModel):
 
 PasInputPeriodResult = PasConnectedPeriodResult
 PasInputTwrResponse = PasConnectedTwrResponse
+

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -69,7 +69,7 @@ class PerformanceRequest(BaseModel):
         default_factory=uuid4,
         description="A unique identifier for the calculation request. If not provided, one will be generated.",
     )
-    portfolio_number: str = Field(..., description="A unique identifier for the portfolio being analyzed.")
+    portfolio_id: str = Field(..., description="A unique identifier for the portfolio being analyzed.")
     performance_start_date: date = Field(
         ...,
         description="The inception date of the portfolio or the earliest date for which performance data is available.",
@@ -115,3 +115,4 @@ class PerformanceRequest(BaseModel):
         if not v:
             raise ValueError("analyses list cannot be empty")
         return v
+

--- a/app/models/responses.py
+++ b/app/models/responses.py
@@ -61,7 +61,7 @@ class PerformanceResponse(BaseModel):
     """
 
     calculation_id: UUID
-    portfolio_number: str
+    portfolio_id: str
 
     results_by_period: Optional[Dict[str, SinglePeriodPerformanceResult]] = None
 
@@ -83,3 +83,4 @@ class PerformanceResponse(BaseModel):
         if not (has_new_structure ^ has_legacy_structure):
             raise ValueError("Provide either 'results_by_period' or the legacy 'breakdowns' field, but not both.")
         return values
+

--- a/app/services/pas_input_service.py
+++ b/app/services/pas_input_service.py
@@ -6,7 +6,7 @@ import httpx
 from app.observability import propagation_headers
 
 
-class PasSnapshotService:
+class PasInputService:
     def __init__(self, base_url: str, timeout_seconds: float):
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout_seconds
@@ -71,3 +71,4 @@ class PasSnapshotService:
         if isinstance(payload, dict):
             return payload
         return {"detail": payload}
+

--- a/docs/API Examples & Recipes.md
+++ b/docs/API Examples & Recipes.md
@@ -19,7 +19,7 @@ POST /performance/twr
 **Payload:**
 ```json
 {
-  "portfolio_number": "TWR_EXAMPLE_01",
+  "portfolio_id": "TWR_EXAMPLE_01",
   "performance_start_date": "2024-12-31",
   "metric_basis": "NET",
   "report_start_date": "2025-01-01",
@@ -52,7 +52,7 @@ POST /performance/twr
 
 ```json
 {
-  "portfolio_number": "TWR_MCY_HEDGED_01",
+  "portfolio_id": "TWR_MCY_HEDGED_01",
   "performance_start_date": "2024-12-31",
   "metric_basis": "GROSS",
   "report_start_date": "2025-01-01",
@@ -95,7 +95,7 @@ POST /performance/contribution
 
 ```json
 {
-  "portfolio_number": "MULTI_ASSET_MCY_01",
+  "portfolio_id": "MULTI_ASSET_MCY_01",
   "portfolio_data": {
     "report_start_date": "2025-01-01",
     "report_end_date": "2025-01-01",
@@ -144,7 +144,7 @@ POST /performance/attribution
 
 ```json
 {
-  "portfolio_number": "ATTRIB_MCY_01",
+  "portfolio_id": "ATTRIB_MCY_01",
   "mode": "by_instrument",
   "group_by": ["currency"],
   "linking": "none",

--- a/docs/Quick Start Guide.md
+++ b/docs/Quick Start Guide.md
@@ -24,7 +24,7 @@ POST /performance/twr
 You will need to provide a **JSON payload** in the body of your POST request.  
 The minimum required fields are:
 
-- `portfolio_number`: A unique identifier for your portfolio.  
+- `portfolio_id`: A unique identifier for your portfolio.  
 - `performance_start_date`: The inception date of the portfolio.  
 - `report_end_date`: The last day of the period you want to analyze.  
 - `metric_basis`: Whether to calculate returns `"NET"` (after fees) or `"GROSS"` (before fees).  
@@ -42,7 +42,7 @@ It sends a request with a minimal, valid payload to a locally running instance o
 curl -X POST "http://127.0.0.1:8000/performance/twr" \
 -H "Content-Type: application/json" \
 -d '{
-  "portfolio_number": "QUICK_START_01",
+  "portfolio_id": "QUICK_START_01",
   "performance_start_date": "2024-12-31",
   "report_end_date": "2025-01-02",
   "metric_basis": "NET",
@@ -75,7 +75,7 @@ The key part is the `breakdowns` object:
 ```json
 {
   "calculation_id": "uuid-goes-here...",
-  "portfolio_number": "QUICK_START_01",
+  "portfolio_id": "QUICK_START_01",
   "breakdowns": {
     "daily": [
       {

--- a/docs/RFCs/RFC 003 - Position Contribution Engine.md
+++ b/docs/RFCs/RFC 003 - Position Contribution Engine.md
@@ -67,7 +67,7 @@ The contribution engine will be a new, distinct module within our existing `engi
 ```json
 {
   "calculation_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "portfolio_number": "CONTRIB_TEST_01",
+  "portfolio_id": "CONTRIB_TEST_01",
   "portfolio_data": {
     "report_start_date": "2025-01-01",
     "report_end_date": "2025-01-31",
@@ -118,7 +118,7 @@ The contribution engine will be a new, distinct module within our existing `engi
 ```json
 {
   "calculation_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "portfolio_number": "CONTRIB_TEST_01",
+  "portfolio_id": "CONTRIB_TEST_01",
   "report_start_date": "2025-01-01",
   "report_end_date": "2025-01-31",
   "total_portfolio_return": 15.75,

--- a/docs/RFCs/RFC 005 - Portfolio Correlation Matrix API.md
+++ b/docs/RFCs/RFC 005 - Portfolio Correlation Matrix API.md
@@ -80,7 +80,7 @@ The correlation is computed on the cleaned and aligned return panel.
 
 ```json
 {
-  "portfolio_number": "CORR_MATRIX_01",
+  "portfolio_id": "CORR_MATRIX_01",
   "timeseries_kind": "prices",
   "return_method": "log",
   "frequency": "D",

--- a/docs/RFCs/RFC 007 - Asset Allocation Drift Monitoring API.md
+++ b/docs/RFCs/RFC 007 - Asset Allocation Drift Monitoring API.md
@@ -68,7 +68,7 @@ If rebalancing is enabled, the engine simulates trades to resolve the breaches u
 
 ```json
 {
-  "portfolio_number": "DRIFT_MONITOR_01",
+  "portfolio_id": "DRIFT_MONITOR_01",
   "as_of": "2025-09-07",
   "mode": "snapshot",
   "holdings": {

--- a/docs/RFCs/RFC 009 - Exposure Breakdown API.md
+++ b/docs/RFCs/RFC 009 - Exposure Breakdown API.md
@@ -68,7 +68,7 @@ If a `groupBy` hierarchy is provided, the engine performs a bottom-up aggregatio
 
 ```json
 {
-  "portfolio_number": "PORT123",
+  "portfolio_id": "PORT123",
   "as_of": "2025-08-31",
   "currency": "USD",
   "mode": "snapshot",

--- a/docs/RFCs/RFC 010 - Equity Factor Exposures API.md
+++ b/docs/RFCs/RFC 010 - Equity Factor Exposures API.md
@@ -67,7 +67,7 @@ This top-down approach infers factor exposures by analyzing the historical relat
 
 ```json
 {
-  "portfolio_number": "FACTOR_TEST_01",
+  "portfolio_id": "FACTOR_TEST_01",
   "as_of": "2025-09-07",
   "mode": "snapshot",
   "model": {

--- a/docs/RFCs/RFC 011 - Scenario Analysis API.md
+++ b/docs/RFCs/RFC 011 - Scenario Analysis API.md
@@ -66,7 +66,7 @@ The engine translates abstract scenario definitions into concrete P\&L calculati
 
 ```json
 {
-  "portfolio_number": "RISK_ANALYSIS_01",
+  "portfolio_id": "RISK_ANALYSIS_01",
   "as_of": "2025-09-07",
   "mode": "hypothetical",
   "holdings": {

--- a/docs/RFCs/RFC 012 - Risk-Adjusted Returns API.md
+++ b/docs/RFCs/RFC 012 - Risk-Adjusted Returns API.md
@@ -78,7 +78,7 @@ The engine calculates the portfolio's equity curve over time to identify periods
 
 ```json
 {
-  "portfolio_number": "RISK_METRICS_01",
+  "portfolio_id": "RISK_METRICS_01",
   "as_of": "2025-09-07",
   "mode": "snapshot",
   "timeseries_kind": "returns",

--- a/docs/RFCs/RFC 013 - Active Analytics API.md
+++ b/docs/RFCs/RFC 013 - Active Analytics API.md
@@ -78,7 +78,7 @@ If factor model data is provided, the engine computes:
 
 ```json
 {
-  "portfolio_number": "PORT123",
+  "portfolio_id": "PORT123",
   "as_of": "2025-08-31",
   "mode": "snapshot",
   "dimension": "sector",

--- a/docs/RFCs/RFC 017 - Contribution Enhancements.md
+++ b/docs/RFCs/RFC 017 - Contribution Enhancements.md
@@ -70,7 +70,7 @@ The request model will be updated to include the new configuration options and w
 ```jsonc
 {
   "calculation_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "portfolio_number": "CONTRIB_ENHANCED_01",
+  "portfolio_id": "CONTRIB_ENHANCED_01",
   "portfolio_data": { /* ... */ },
   "positions_data": [ /* ... */ ],
 
@@ -100,7 +100,7 @@ The response model will be updated to include the optional time-series fields an
 ```jsonc
 {
   "calculation_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "portfolio_number": "CONTRIB_ENHANCED_01",
+  "portfolio_id": "CONTRIB_ENHANCED_01",
   "report_start_date": "2025-02-01",
   "report_end_date": "2025-02-28",
   "total_portfolio_return": 1.25,

--- a/docs/RFCs/RFC 020 - Multi-Currency & FX-Aware Performance.md
+++ b/docs/RFCs/RFC 020 - Multi-Currency & FX-Aware Performance.md
@@ -94,7 +94,7 @@ The following new blocks are added to the shared request envelope for all releva
 ```jsonc
 // Example for a Contribution Request in Multi-Currency Mode
 {
-  "portfolio_number": "MULTI_CCY_01",
+  "portfolio_id": "MULTI_CCY_01",
   "portfolio_data": { /* ... portfolio totals, values in base currency ... */ },
   "positions_data": [
     {
@@ -149,7 +149,7 @@ The response for each endpoint will be enhanced to include the currency decompos
 // Example for a TWR Response in Multi-Currency Mode
 {
   "calculation_id": "a4b7e289-7e28-4b7e-8e28-7e284b7e8e28",
-  "portfolio_number": "MULTI_CCY_01",
+  "portfolio_id": "MULTI_CCY_01",
 
   // --- New Multi-Currency Response Blocks ---
   "portfolio_return": {    // Decomposition of the total portfolio TWR

--- a/docs/RFCs/RFC 024- Robustness Policies Framework.md
+++ b/docs/RFCs/RFC 024- Robustness Policies Framework.md
@@ -61,7 +61,7 @@ The framework will apply user-defined policies as a pre-processing step before t
           "cash_flows": [
             {
               "perf_date": "2025-03-20",
-              "portfolio_number": "PORT123",
+              "portfolio_id": "PORT123",
               "bod_cf": 0.0
             }
           ]

--- a/docs/RFCs/RFC 029 - Unified Multi-Period Analysis Framework.md
+++ b/docs/RFCs/RFC 029 - Unified Multi-Period Analysis Framework.md
@@ -114,7 +114,7 @@ The response structure will be modified to accommodate results for multiple peri
 ```jsonc
 {
   "calculation_id": "a4b7e289-7e28-4b7e-8e28-7e284b7e8e28",
-  "portfolio_number": "MULTI_PERIOD_01",
+  "portfolio_id": "MULTI_PERIOD_01",
   "results_by_period": {
     "MTD": {
       // Standard TWR breakdown object for the MTD period
@@ -199,3 +199,4 @@ The implementation of this RFC will be considered complete when the following cr
 7.  All relevant documentation, including `README.md`, `docs/guides/api_reference.md`, and all usage examples, is updated to reflect the new multi-period request and response structure.
 
 <!-- end list -->
+

--- a/docs/RFCs/RFC 031 - PAS Connected TWR Input Mode.md
+++ b/docs/RFCs/RFC 031 - PAS Connected TWR Input Mode.md
@@ -12,7 +12,7 @@ To align PAS, PA, and DPM contracts, PA needs a first-class PAS-connected API th
 
 ## Decision
 Add a PAS-connected TWR endpoint:
-- `POST /performance/twr/pas-snapshot`
+- `POST /performance/twr/pas-input`
 
 Request contract:
 - `portfolioId`

--- a/docs/RFCs/RFC 034 - PA Ownership of PAS-Connected TWR Calculation.md
+++ b/docs/RFCs/RFC 034 - PA Ownership of PAS-Connected TWR Calculation.md
@@ -1,14 +1,14 @@
-# RFC 034 - PA Ownership of PAS-Connected TWR Calculation
+# RFC 034 - PA Ownership of PAS-Input TWR Calculation
 
 ## 1. Problem Statement
-`/performance/twr/pas-snapshot` currently maps PAS precomputed performance from `core-snapshot`. This makes PA a pass-through instead of analytics owner.
+`/performance/twr/pas-input` currently maps PAS precomputed performance from `core-snapshot`. This makes PA a pass-through instead of analytics owner.
 
 ## 2. Decision
 - PA must compute PAS-connected TWR using PAS raw data, not PAS performance outputs.
 - PAS is treated as a data source via integration contract only.
 
 ## 3. Contract and Behavior
-- PA `pas-snapshot` mode calls PAS `performance-input` endpoint.
+- PA `pas-input` mode calls PAS `performance-input` endpoint.
 - PA builds a `PerformanceRequest` internally and runs the PA TWR engine.
 - Response remains `PasConnectedTwrResponse` for BFF compatibility.
 
@@ -22,6 +22,7 @@
 
 ## 6. Implementation
 1. Extend PAS client service in PA with `get_performance_input`.
-2. Refactor `/performance/twr/pas-snapshot` to compute from PA engine.
+2. Refactor `/performance/twr/pas-input` to compute from PA engine.
 3. Update tests to validate PA-computed output and input validation behavior.
+
 

--- a/docs/RFCs/RFC 038 - PA Domain Vocabulary Alignment with Platform Glossary.md
+++ b/docs/RFCs/RFC 038 - PA Domain Vocabulary Alignment with Platform Glossary.md
@@ -8,20 +8,20 @@ Proposed
 
 ## Problem Statement
 
-`performanceAnalytics` still uses legacy shared terms (`portfolio_number`, `pas-snapshot`) in API contracts, models, tests, and documentation.
+`performanceAnalytics` still uses legacy shared terms (`portfolio_id`, `pas-input`) in API contracts, models, tests, and documentation.
 This conflicts with the platform glossary in `pbwm-platform-docs/Domain Vocabulary Glossary.md`, which mandates canonical cross-service terms such as `portfolio_id`, `as_of_date`, and `pas-input` terminology.
 
 Current measurable drift (baseline from `Validate-Domain-Vocabulary.ps1`):
-- `portfolio_number`: 121 findings
-- `pas-snapshot`: 5 findings
+- `portfolio_id`: 121 findings
+- `pas-input`: 5 findings
 
 ## Decision
 
 Perform a phased vocabulary migration in PA to align with platform glossary while preserving service stability during rollout.
 
 1. Canonical request/response field names use `snake_case` internally and canonical cross-service aliases (`portfolioId`, `asOfDate`) at BFF-facing integration boundaries where required.
-2. Remove `portfolio_number` from PA public contracts and replace with `portfolio_id`.
-3. Deprecate `pas-snapshot` naming and replace with `pas-input` terminology in endpoints/docs/contracts.
+2. Remove `portfolio_id` from PA public contracts and replace with `portfolio_id`.
+3. Deprecate `pas-input` naming and replace with `pas-input` terminology in endpoints/docs/contracts.
 4. Keep compatibility shims only for an explicitly time-boxed transition window (if needed), with clear removal milestones.
 
 ## Scope
@@ -40,11 +40,11 @@ Perform a phased vocabulary migration in PA to align with platform glossary whil
 
 ### Phase A - Contract Surface Alignment
 - Introduce canonical PA models using `portfolio_id`.
-- Replace `/performance/twr/pas-snapshot` naming with `pas-input` terminology.
+- Replace `/performance/twr/pas-input` naming with `pas-input` terminology.
 - Keep temporary alias compatibility only where required by existing tests.
 
 ### Phase B - Test and Fixture Migration
-- Rename all fixtures/assertions from `portfolio_number` to `portfolio_id`.
+- Rename all fixtures/assertions from `portfolio_id` to `portfolio_id`.
 - Update integration/e2e tests to canonical terminology.
 - Ensure no behavior regression.
 
@@ -67,7 +67,8 @@ Mitigation:
 
 ## Acceptance Criteria
 
-1. PA has zero `portfolio_number` and zero `pas-snapshot` occurrences in active code/contracts/docs.
+1. PA has zero `portfolio_id` and zero `pas-input` occurrences in active code/contracts/docs.
 2. OpenAPI reflects canonical vocabulary.
 3. All PA CI gates remain green (`lint`, `typecheck`, `openapi-gate`, tests, coverage, security).
 4. Platform vocabulary conformance report marks PA as `ok`.
+

--- a/docs/examples/attribution_request.json
+++ b/docs/examples/attribution_request.json
@@ -1,5 +1,5 @@
 {
-  "portfolio_number": "ATTRIB_EXAMPLE_01",
+  "portfolio_id": "ATTRIB_EXAMPLE_01",
   "mode": "by_instrument",
   "group_by": [
     "sector"

--- a/docs/examples/attribution_request_multiccy.json
+++ b/docs/examples/attribution_request_multiccy.json
@@ -1,6 +1,6 @@
 
 {
-  "portfolio_number": "ATTRIB_MCY_01",
+  "portfolio_id": "ATTRIB_MCY_01",
   "mode": "by_instrument",
   "group_by": [
     "currency"

--- a/docs/examples/contribution_request.json
+++ b/docs/examples/contribution_request.json
@@ -1,5 +1,5 @@
 {
-  "portfolio_number": "CONTRIB_EXAMPLE_01",
+  "portfolio_id": "CONTRIB_EXAMPLE_01",
   "hierarchy": [
     "sector",
     "position_id"

--- a/docs/examples/contribution_request_multiccy.json
+++ b/docs/examples/contribution_request_multiccy.json
@@ -1,6 +1,6 @@
 
 {
-  "portfolio_number": "CONTRIB_MCY_01",
+  "portfolio_id": "CONTRIB_MCY_01",
   "portfolio_data": {
     "report_start_date": "2025-01-01",
     "report_end_date": "2025-01-01",

--- a/docs/examples/mwr_request.json
+++ b/docs/examples/mwr_request.json
@@ -1,5 +1,5 @@
 {
-  "portfolio_number": "MWR_EXAMPLE_01",
+  "portfolio_id": "MWR_EXAMPLE_01",
   "begin_mv": 100000.0,
   "end_mv": 115000.0,
   "as_of": "2025-12-31",

--- a/docs/examples/twr_request.json
+++ b/docs/examples/twr_request.json
@@ -1,5 +1,5 @@
 {
-  "portfolio_number": "TWR_EXAMPLE_01",
+  "portfolio_id": "TWR_EXAMPLE_01",
   "performance_start_date": "2024-12-31",
   "metric_basis": "NET",
   "report_start_date": "2025-01-01",

--- a/docs/examples/twr_request_multiccy_hedged.json
+++ b/docs/examples/twr_request_multiccy_hedged.json
@@ -1,6 +1,6 @@
 
 {
-  "portfolio_number": "TWR_MCY_HEDGED_01",
+  "portfolio_id": "TWR_MCY_HEDGED_01",
   "performance_start_date": "2024-12-31",
   "metric_basis": "GROSS",
   "report_start_date": "2025-01-01",

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -8,7 +8,7 @@ All endpoints live under `/performance` in `app/api/endpoints/performance.py`.
 ### Minimal Request
 ```json
 {
-  "portfolio_number": "PF-001",
+  "portfolio_id": "PF-001",
   "performance_start_date": "2024-12-31",
   "report_end_date": "2025-01-31",
   "as_of": "2025-01-31",
@@ -30,7 +30,7 @@ All endpoints live under `/performance` in `app/api/endpoints/performance.py`.
 ```json
 {
   "calculation_id": "uuid",
-  "portfolio_number": "PF-001",
+  "portfolio_id": "PF-001",
   "results_by_period": {
     "MTD": {
       "breakdowns": {
@@ -60,7 +60,7 @@ All endpoints live under `/performance` in `app/api/endpoints/performance.py`.
 
 ```json
 {
-  "portfolio_number": "PF-MWR-001",
+  "portfolio_id": "PF-MWR-001",
   "begin_mv": 1000000.0,
   "end_mv": 1030000.0,
   "as_of": "2025-01-31",
@@ -122,7 +122,7 @@ Key controls:
 **Updated File: `docs/examples/twr_request.json`**
 ```json
 {
-  "portfolio_number": "TWR_EXAMPLE_01",
+  "portfolio_id": "TWR_EXAMPLE_01",
   "performance_start_date": "2024-12-31",
   "metric_basis": "NET",
   "report_end_date": "2025-01-05",
@@ -187,7 +187,7 @@ Key controls:
 
 ```json
 {
-  "portfolio_number": "CONTRIB_EXAMPLE_01",
+  "portfolio_id": "CONTRIB_EXAMPLE_01",
   "report_start_date": "2025-01-01",
   "report_end_date": "2025-01-02",
   "periods": [
@@ -265,7 +265,7 @@ Key controls:
 
 ```json
 {
-  "portfolio_number": "ATTRIB_EXAMPLE_01",
+  "portfolio_id": "ATTRIB_EXAMPLE_01",
   "report_start_date": "2025-01-01",
   "report_end_date": "2025-01-01",
   "periods": [

--- a/docs/guides/attribution.md
+++ b/docs/guides/attribution.md
@@ -102,7 +102,7 @@ To solve this, the engine uses a **top-down geometric linking** method. It ensur
 
 ```json
 {
-  "portfolio_number": "ATTRIB_EXAMPLE_01",
+  "portfolio_id": "ATTRIB_EXAMPLE_01",
   "mode": "by_instrument",
   "group_by": [ "sector" ],
   "linking": "none",
@@ -141,7 +141,7 @@ To solve this, the engine uses a **top-down geometric linking** method. It ensur
 ```json
 {
     "calculation_id": "uuid-goes-here",
-    "portfolio_number": "ATTRIB_EXAMPLE_01",
+    "portfolio_id": "ATTRIB_EXAMPLE_01",
     "model": "BF",
     "linking": "none",
     "levels": [

--- a/docs/guides/contribution.md
+++ b/docs/guides/contribution.md
@@ -88,7 +88,7 @@ This bottom-up approach guarantees that the sum of contributions at any level pe
 
 ```json
 {
-  "portfolio_number": "CONTRIB_EXAMPLE_01",
+  "portfolio_id": "CONTRIB_EXAMPLE_01",
   "hierarchy": [ "sector", "position_id" ],
   "portfolio_data": {
     "report_start_date": "2025-01-01",
@@ -123,7 +123,7 @@ This bottom-up approach guarantees that the sum of contributions at any level pe
 ```json
 {
   "calculation_id": "uuid-goes-here",
-  "portfolio_number": "CONTRIB_EXAMPLE_01",
+  "portfolio_id": "CONTRIB_EXAMPLE_01",
   "summary": {
     "portfolio_contribution": 2.953...,
     "coverage_mv_pct": 100.0, "weighting_scheme": "BOD"

--- a/docs/guides/mwr.md
+++ b/docs/guides/mwr.md
@@ -84,7 +84,7 @@ $$
 
 ```json
 {
-  "portfolio_number": "MWR_EXAMPLE_01",
+  "portfolio_id": "MWR_EXAMPLE_01",
   "begin_mv": 100000.0,
   "end_mv": 115000.0,
   "as_of": "2025-12-31",
@@ -103,7 +103,7 @@ $$
 
 {
   "calculation_id": "uuid-goes-here",
-  "portfolio_number": "MWR_EXAMPLE_01",
+  "portfolio_id": "MWR_EXAMPLE_01",
   "money_weighted_return": 11.723,
   "mwr_annualized": 11.723,
   "method": "XIRR",

--- a/docs/guides/robustness_policies.md
+++ b/docs/guides/robustness_policies.md
@@ -29,7 +29,7 @@ Use the `overrides` policy to provide an in-memory correction for a specific cal
     "cash_flows": [
       {
         "perf_date": "2025-03-20",
-        "portfolio_number": "PORT123",
+        "portfolio_id": "PORT123",
         "bod_cf": 0.0
       }
     ]

--- a/docs/guides/twr.md
+++ b/docs/guides/twr.md
@@ -103,7 +103,7 @@ The engine applies several rules to ensure mathematical robustness.
 
 ```json
 {
-  "portfolio_number": "TWR_EXAMPLE_01",
+  "portfolio_id": "TWR_EXAMPLE_01",
   "performance_start_date": "2024-12-31",
   "metric_basis": "NET",
   "report_start_date": "2025-01-01",
@@ -128,7 +128,7 @@ The engine applies several rules to ensure mathematical robustness.
 ```json
 {
   "calculation_id": "uuid-goes-here",
-  "portfolio_number": "TWR_EXAMPLE_01",
+  "portfolio_id": "TWR_EXAMPLE_01",
   "breakdowns": {
     "daily": [
       {
@@ -148,3 +148,4 @@ The engine applies several rules to ensure mathematical robustness.
   "audit": { ... }
 }
 ```
+

--- a/docs/technical/data_model.md
+++ b/docs/technical/data_model.md
@@ -88,7 +88,7 @@ The following shows a complete TWR response, including the data payload (`breakd
 ```json
 {
   "calculation_id": "a4b7e289-7e28-4b7e-8e28-7e284b7e8e28",
-  "portfolio_number": "TWR_EXAMPLE_01",
+  "portfolio_id": "TWR_EXAMPLE_01",
   "breakdowns": {
     "daily": [
       {
@@ -142,4 +142,5 @@ The following shows a complete TWR response, including the data payload (`breakd
   }
 }
 ```
+
 

--- a/rfcs/RFC-0001-pa-coverage-hardening-wave-1.md
+++ b/rfcs/RFC-0001-pa-coverage-hardening-wave-1.md
@@ -18,7 +18,7 @@ Deliver an incremental hardening wave focused on highest-risk uncovered backend 
 
 ## Scope
 
-- Add unit tests for `PasSnapshotService` request/response contract behavior and fallback payload parsing.
+- Add unit tests for `PasInputService` request/response contract behavior and fallback payload parsing.
 - Add unit tests for observability helpers (correlation/request/trace resolution and propagation header generation).
 - Add integration tests for:
   - analytics upstream failure passthrough
@@ -30,7 +30,7 @@ Deliver an incremental hardening wave focused on highest-risk uncovered backend 
 
 - Full test suite: `209 passed`
 - Coverage improved from ~`95%` to `97%`
-- `app/services/pas_snapshot_service.py`: now `100%`
+- `app/services/pas_input_service.py`: now `100%`
 - `app/observability.py`: now `100%`
 - `app/api/endpoints/analytics.py`: now `100%`
 - `app/api/endpoints/contribution.py`: now `100%`
@@ -40,3 +40,4 @@ Deliver an incremental hardening wave focused on highest-risk uncovered backend 
 Wave 2 will target remaining concentrated misses in:
 - `app/api/endpoints/performance.py`
 - `app/services/lineage_service.py`
+

--- a/tests/benchmarks/test_engine_performance.py
+++ b/tests/benchmarks/test_engine_performance.py
@@ -12,7 +12,7 @@ from engine.compute import run_calculations
 def large_input_data():
     """Creates a large, realistic dataset for benchmarking per the RFC."""
     base_payload = {
-        "portfolio_number": "BENCHMARK_PORT_01",
+        "portfolio_id": "BENCHMARK_PORT_01",
         "performance_start_date": "2023-12-31",
         "metric_basis": "NET",
         "analyses": [{"period": "YTD", "frequencies": ["daily"]}],
@@ -61,3 +61,4 @@ def test_vectorized_engine_performance(benchmark, large_input_data):
 
     benchmark.group = "Engine Performance (500k rows)"
     benchmark(run)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 def happy_path_payload():
     """Provides a standard, valid snake_case payload for contribution tests."""
     return {
-        "portfolio_number": "CONTRIB_TEST_01",
+        "portfolio_id": "CONTRIB_TEST_01",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-02",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -60,3 +60,4 @@ def happy_path_payload():
             }
         ],
     }
+

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -23,7 +23,7 @@ def test_e2e_platform_readiness_and_capabilities_contract() -> None:
 
 def test_e2e_performance_twr_and_mwr_workflow() -> None:
     twr_payload = {
-        "portfolio_number": "E2E_WORKFLOW_001",
+        "portfolio_id": "E2E_WORKFLOW_001",
         "performance_start_date": "2025-01-01",
         "report_end_date": "2025-01-03",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -35,7 +35,7 @@ def test_e2e_performance_twr_and_mwr_workflow() -> None:
         ],
     }
     mwr_payload = {
-        "portfolio_number": "E2E_WORKFLOW_001",
+        "portfolio_id": "E2E_WORKFLOW_001",
         "begin_mv": 1000.0,
         "end_mv": 1030.301,
         "cash_flows": [],
@@ -54,12 +54,12 @@ def test_e2e_performance_twr_and_mwr_workflow() -> None:
     assert twr_body["results_by_period"]["ITD"]["portfolio_return"]["base"] > 0
 
     mwr_body = mwr_response.json()
-    assert mwr_body["portfolio_number"] == "E2E_WORKFLOW_001"
+    assert mwr_body["portfolio_id"] == "E2E_WORKFLOW_001"
 
 
 def test_e2e_contribution_attribution_and_lineage() -> None:
     contribution_payload = {
-        "portfolio_number": "E2E_CONTRIB_001",
+        "portfolio_id": "E2E_CONTRIB_001",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-01",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -76,7 +76,7 @@ def test_e2e_contribution_attribution_and_lineage() -> None:
         "emit": {"timeseries": True},
     }
     attribution_payload = {
-        "portfolio_number": "E2E_ATTRIB_001",
+        "portfolio_id": "E2E_ATTRIB_001",
         "mode": "by_group",
         "group_by": ["sector"],
         "linking": "none",
@@ -173,11 +173,11 @@ def test_e2e_pas_connected_modes(monkeypatch) -> None:
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
     monkeypatch.setattr(
-        "app.api.endpoints.analytics.PasSnapshotService.get_positions_analytics",
+        "app.api.endpoints.analytics.PasInputService.get_positions_analytics",
         _mock_get_positions_analytics,
     )
 
@@ -216,7 +216,7 @@ def test_e2e_pas_ref_capability_and_execution_contract(monkeypatch) -> None:
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -239,7 +239,7 @@ def test_e2e_pas_ref_upstream_failure_passthrough(monkeypatch) -> None:
         return 503, {"detail": "PAS unavailable"}
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -258,7 +258,7 @@ def test_e2e_positions_pas_payload_contract_failure(monkeypatch) -> None:
         return 200, {"portfolioId": portfolio_id, "asOfDate": str(as_of_date)}
 
     monkeypatch.setattr(
-        "app.api.endpoints.analytics.PasSnapshotService.get_positions_analytics",
+        "app.api.endpoints.analytics.PasInputService.get_positions_analytics",
         _mock_get_positions_analytics,
     )
 
@@ -274,7 +274,7 @@ def test_e2e_positions_pas_payload_contract_failure(monkeypatch) -> None:
 
 def test_e2e_contribution_lineage_roundtrip() -> None:
     contribution_payload = {
-        "portfolio_number": "E2E_CONTRIB_002",
+        "portfolio_id": "E2E_CONTRIB_002",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-01",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -302,7 +302,7 @@ def test_e2e_contribution_lineage_roundtrip() -> None:
 
 def test_e2e_attribution_lineage_roundtrip() -> None:
     attribution_payload = {
-        "portfolio_number": "E2E_ATTRIB_002",
+        "portfolio_id": "E2E_ATTRIB_002",
         "mode": "by_group",
         "group_by": ["sector"],
         "linking": "none",
@@ -335,7 +335,7 @@ def test_e2e_attribution_lineage_roundtrip() -> None:
 
 def test_e2e_mwr_lineage_roundtrip() -> None:
     mwr_payload = {
-        "portfolio_number": "E2E_MWR_002",
+        "portfolio_id": "E2E_MWR_002",
         "begin_mv": 1000.0,
         "end_mv": 1045.0,
         "cash_flows": [{"date": "2025-01-15", "amount": 25.0}],
@@ -408,3 +408,4 @@ def test_e2e_workbench_active_return_and_risk_proxy_signal() -> None:
     assert body["activeReturnPct"] == pytest.approx(2.3)
     assert body["riskProxy"]["hhiDelta"] > 0
     assert len(body["topChanges"]) == 2
+

--- a/tests/integration/test_analytics_api.py
+++ b/tests/integration/test_analytics_api.py
@@ -18,7 +18,7 @@ def test_positions_analytics_success(monkeypatch):
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.analytics.PasSnapshotService.get_positions_analytics",
+        "app.api.endpoints.analytics.PasInputService.get_positions_analytics",
         _mock_get_positions_analytics,
     )
 
@@ -45,7 +45,7 @@ def test_positions_analytics_invalid_payload(monkeypatch):
         return (200, {"portfolioId": "P1"})
 
     monkeypatch.setattr(
-        "app.api.endpoints.analytics.PasSnapshotService.get_positions_analytics",
+        "app.api.endpoints.analytics.PasInputService.get_positions_analytics",
         _mock_get_positions_analytics,
     )
 
@@ -63,7 +63,7 @@ def test_positions_analytics_upstream_error_passthrough(monkeypatch):
         return (503, {"detail": "pas unavailable"})
 
     monkeypatch.setattr(
-        "app.api.endpoints.analytics.PasSnapshotService.get_positions_analytics",
+        "app.api.endpoints.analytics.PasInputService.get_positions_analytics",
         _mock_get_positions_analytics,
     )
 
@@ -142,3 +142,4 @@ def test_workbench_analytics_security_group_uses_security_bucket_keys():
     bucket = response.json()["allocationBuckets"][0]
     assert bucket["bucketKey"] == "MSFT.US"
     assert bucket["bucketLabel"] == "Microsoft"
+

--- a/tests/integration/test_attribution_api.py
+++ b/tests/integration/test_attribution_api.py
@@ -16,7 +16,7 @@ def client():
 def test_attribution_endpoint_by_instrument_happy_path(client):
     """Tests the /performance/attribution endpoint end-to-end with a valid 'by_instrument' payload."""
     payload = {
-        "portfolio_number": "ATTRIB_BY_INST_01",
+        "portfolio_id": "ATTRIB_BY_INST_01",
         "mode": "by_instrument",
         "group_by": ["sector"],
         "linking": "none",
@@ -64,7 +64,7 @@ def test_attribution_endpoint_by_instrument_happy_path(client):
 def test_attribution_lineage_flow(client):
     """Tests that lineage is correctly captured for an attribution request."""
     payload = {
-        "portfolio_number": "ATTRIB_LINEAGE_01",
+        "portfolio_id": "ATTRIB_LINEAGE_01",
         "mode": "by_group",
         "group_by": ["sector"],
         "linking": "none",
@@ -101,7 +101,7 @@ def test_attribution_lineage_flow(client):
 def test_attribution_endpoint_hierarchical(client):
     """Tests multi-level hierarchical attribution, ensuring bottom-up aggregation is correct."""
     payload = {
-        "portfolio_number": "HIERARCHY_01",
+        "portfolio_id": "HIERARCHY_01",
         "mode": "by_instrument",
         "group_by": ["assetClass", "sector"],
         "linking": "none",
@@ -165,7 +165,7 @@ def test_attribution_endpoint_hierarchical(client):
 def test_attribution_endpoint_currency_attribution(client):
     """Tests the Karnosky-Singer currency attribution model end-to-end."""
     payload = {
-        "portfolio_number": "FX_ATTRIB_01",
+        "portfolio_id": "FX_ATTRIB_01",
         "mode": "by_instrument",
         "group_by": ["currency"],
         "linking": "none",
@@ -246,7 +246,7 @@ def test_attribution_endpoint_error_handling(client, mocker, error_class, expect
     """Tests that the attribution endpoint correctly handles engine exceptions."""
     mocker.patch("app.api.endpoints.performance.run_attribution_calculations", side_effect=error_class("Test Error"))
     payload = {
-        "portfolio_number": "ERROR",
+        "portfolio_id": "ERROR",
         "mode": "by_group",
         "group_by": ["sector"],
         "benchmark_groups_data": [],
@@ -265,7 +265,7 @@ def test_attribution_endpoint_returns_400_when_no_resolved_periods(client, mocke
     """Tests explicit 400 path when period resolution yields no valid periods."""
     mocker.patch("app.api.endpoints.performance.resolve_periods", return_value=[])
     payload = {
-        "portfolio_number": "ATTRIB_NO_PERIODS",
+        "portfolio_id": "ATTRIB_NO_PERIODS",
         "mode": "by_group",
         "group_by": ["sector"],
         "benchmark_groups_data": [],
@@ -290,7 +290,7 @@ def test_attribution_endpoint_skips_empty_period_slice(client, mocker):
         ],
     )
     payload = {
-        "portfolio_number": "ATTRIB_EMPTY_SLICE",
+        "portfolio_id": "ATTRIB_EMPTY_SLICE",
         "mode": "by_group",
         "group_by": ["sector"],
         "linking": "none",
@@ -319,3 +319,4 @@ def test_attribution_endpoint_skips_empty_period_slice(client, mocker):
     results = response.json()["results_by_period"]
     assert "ITD" in results
     assert "MTD" not in results
+

--- a/tests/integration/test_contribution_api.py
+++ b/tests/integration/test_contribution_api.py
@@ -19,7 +19,7 @@ def test_contribution_endpoint_happy_path_and_envelope(client, happy_path_payloa
 
     assert response.status_code == 200
     response_data = response.json()
-    assert response_data["portfolio_number"] == "CONTRIB_TEST_01"
+    assert response_data["portfolio_id"] == "CONTRIB_TEST_01"
     assert "results_by_period" in response_data
     assert "ITD" in response_data["results_by_period"]
 
@@ -27,7 +27,7 @@ def test_contribution_endpoint_happy_path_and_envelope(client, happy_path_payloa
 def test_contribution_endpoint_multi_period(client):
     """Tests a multi-period request for MTD and YTD contribution."""
     payload = {
-        "portfolio_number": "MULTI_PERIOD_CONTRIB",
+        "portfolio_id": "MULTI_PERIOD_CONTRIB",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-02-15",
         "analyses": [{"period": "MTD", "frequencies": ["monthly"]}, {"period": "YTD", "frequencies": ["monthly"]}],
@@ -60,7 +60,7 @@ def test_contribution_endpoint_multi_period(client):
 def test_contribution_endpoint_multi_currency(client):
     """Tests an end-to-end multi-currency contribution request."""
     payload = {
-        "portfolio_number": "MULTI_CCY_CONTRIB_01",
+        "portfolio_id": "MULTI_CCY_CONTRIB_01",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-01",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -146,7 +146,7 @@ def test_contribution_endpoint_error_handling(client, mocker):
         "app.api.endpoints.contribution._prepare_hierarchical_data", side_effect=EngineCalculationError("Test Error")
     )
     payload = {
-        "portfolio_number": "ERROR",
+        "portfolio_id": "ERROR",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-02",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -162,7 +162,7 @@ def test_contribution_endpoint_error_handling(client, mocker):
 
 def test_contribution_endpoint_no_resolved_periods_returns_400(client):
     payload = {
-        "portfolio_number": "NO_PERIODS",
+        "portfolio_id": "NO_PERIODS",
         "report_start_date": "2025-01-10",
         "report_end_date": "2025-01-05",
         "analyses": [{"period": "MTD", "frequencies": ["monthly"]}],
@@ -187,7 +187,7 @@ def test_contribution_endpoint_no_resolved_periods_returns_400(client):
 
 def test_contribution_endpoint_skips_empty_period_slice(client):
     payload = {
-        "portfolio_number": "EMPTY_SLICE",
+        "portfolio_id": "EMPTY_SLICE",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-01",
         "analyses": [{"period": "YTD", "frequencies": ["monthly"]}],
@@ -236,3 +236,4 @@ def test_contribution_endpoint_skips_empty_period_slice(client):
 
     assert response.status_code == 200
     assert response.json()["results_by_period"] == {}
+

--- a/tests/integration/test_lineage_api.py
+++ b/tests/integration/test_lineage_api.py
@@ -30,7 +30,7 @@ def client():
 def test_lineage_end_to_end_flow(client):
     """Tests the full lineage flow: TWR calc -> lineage capture -> lineage retrieval."""
     twr_payload = {
-        "portfolio_number": "LINEAGE_TEST",
+        "portfolio_id": "LINEAGE_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-01",
@@ -89,3 +89,4 @@ def test_get_lineage_internal_error_returns_500(client, mocker):
     response = client.get(f"/performance/lineage/{calculation_id}")
     assert response.status_code == 500
     assert "Failed to retrieve lineage artifacts" in response.json()["detail"]
+

--- a/tests/integration/test_multi_period_summary.py
+++ b/tests/integration/test_multi_period_summary.py
@@ -19,7 +19,7 @@ def test_multi_period_portfolio_return_summary_is_correct(client):
     This test specifically validates the fix for this bug.
     """
     payload = {
-        "portfolio_number": "MULTI_PERIOD_SUMMARY_TEST",
+        "portfolio_id": "MULTI_PERIOD_SUMMARY_TEST",
         "performance_start_date": "2024-12-31",
         "report_end_date": "2025-02-28",
         "analyses": [
@@ -70,3 +70,4 @@ def test_multi_period_portfolio_return_summary_is_correct(client):
 
     # Crucially, assert the MTD and YTD summaries are NOT the same
     assert mtd_summary["base"] != ytd_summary["base"]
+

--- a/tests/integration/test_mwr_api.py
+++ b/tests/integration/test_mwr_api.py
@@ -17,7 +17,7 @@ def test_calculate_mwr_endpoint_xirr_happy_path(client):
     """Tests the /performance/mwr endpoint with the XIRR method."""
     payload = {
         "calculation_id": str(uuid4()),
-        "portfolio_number": "MWR_XIRR_TEST_01",
+        "portfolio_id": "MWR_XIRR_TEST_01",
         "begin_mv": 100000.0,
         "end_mv": 115000.0,
         "as_of": "2025-12-31",
@@ -33,7 +33,7 @@ def test_calculate_mwr_endpoint_xirr_happy_path(client):
 
     assert response.status_code == 200
     response_data = response.json()
-    assert response_data["portfolio_number"] == "MWR_XIRR_TEST_01"
+    assert response_data["portfolio_id"] == "MWR_XIRR_TEST_01"
     assert response_data["method"] == "XIRR"
     assert response_data["money_weighted_return"] == pytest.approx(11.723, abs=1e-3)
     assert response_data["mwr_annualized"] is not None
@@ -42,7 +42,7 @@ def test_calculate_mwr_endpoint_xirr_happy_path(client):
 def test_mwr_lineage_flow(client):
     """Tests that lineage is correctly captured for an MWR request."""
     payload = {
-        "portfolio_number": "MWR_LINEAGE_01",
+        "portfolio_id": "MWR_LINEAGE_01",
         "begin_mv": 5000.0,
         "end_mv": 5500.0,
         "as_of": "2025-06-30",
@@ -65,7 +65,7 @@ def test_calculate_mwr_endpoint_unexpected_error_returns_500(client, mocker):
     """Tests that unexpected MWR calculation failures map to HTTP 500."""
     mocker.patch("app.api.endpoints.performance.calculate_money_weighted_return", side_effect=Exception("boom"))
     payload = {
-        "portfolio_number": "MWR_ERROR_01",
+        "portfolio_id": "MWR_ERROR_01",
         "begin_mv": 1000.0,
         "end_mv": 1100.0,
         "as_of": "2025-06-30",
@@ -75,3 +75,4 @@ def test_calculate_mwr_endpoint_unexpected_error_returns_500(client, mocker):
     response = client.post("/performance/mwr", json=payload)
     assert response.status_code == 500
     assert "unexpected error occurred during MWR calculation" in response.json()["detail"]
+

--- a/tests/integration/test_performance_api.py
+++ b/tests/integration/test_performance_api.py
@@ -22,7 +22,7 @@ def test_twr_reports_reset_events_when_requested(client):
     """
     # This payload is based on the 'long_flip_scenario' which triggers an NCTRL_1 reset
     payload = {
-        "portfolio_number": "RESET_SCENARIO_TEST",
+        "portfolio_id": "RESET_SCENARIO_TEST",
         "performance_start_date": "2024-12-31",
         "report_end_date": "2025-01-04",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -52,7 +52,7 @@ def test_twr_reports_reset_events_when_requested(client):
 def test_calculate_twr_endpoint_with_annualization(client):
     """Tests that a request with annualization enabled correctly returns annualized figures."""
     payload = {
-        "portfolio_number": "ANNUALIZATION_TEST",
+        "portfolio_id": "ANNUALIZATION_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-03-31",
@@ -77,7 +77,7 @@ def test_calculate_twr_endpoint_with_annualization(client):
 def test_calculate_twr_endpoint_legacy_path_and_diagnostics(client):
     """Tests the /performance/twr endpoint using the new 'analyses' structure and verifies the shared response footer."""
     payload = {
-        "portfolio_number": "PORT_STANDARD_GROWTH",
+        "portfolio_id": "PORT_STANDARD_GROWTH",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-05",
@@ -114,7 +114,7 @@ def test_calculate_twr_endpoint_legacy_path_and_diagnostics(client):
 def test_calculate_twr_endpoint_multi_period(client):
     """Tests a multi-period request for MTD and YTD."""
     payload = {
-        "portfolio_number": "MULTI_PERIOD_TEST",
+        "portfolio_id": "MULTI_PERIOD_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-02-15",
@@ -156,7 +156,7 @@ def test_calculate_twr_endpoint_multi_period(client):
 def test_calculate_twr_endpoint_multi_currency(client):
     """Tests an end-to-end multi-currency TWR request."""
     payload = {
-        "portfolio_number": "MULTI_CCY_API_TEST",
+        "portfolio_id": "MULTI_CCY_API_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "GROSS",
         "report_end_date": "2025-01-02",
@@ -190,7 +190,7 @@ def test_calculate_twr_endpoint_multi_currency(client):
 def test_calculate_twr_endpoint_with_data_policy(client):
     """Tests that a request with data_policy overrides and flagging works end-to-end."""
     payload = {
-        "portfolio_number": "POLICY_TEST",
+        "portfolio_id": "POLICY_TEST",
         "performance_start_date": "2024-12-27",
         "metric_basis": "NET",
         "report_end_date": "2025-01-03",
@@ -228,7 +228,7 @@ def test_calculate_twr_endpoint_with_data_policy(client):
 def test_twr_respects_include_timeseries_flag(client):
     """Tests that the include_timeseries flag correctly includes or excludes the daily_data block."""
     base_payload = {
-        "portfolio_number": "TIMESERIES_FLAG_TEST",
+        "portfolio_id": "TIMESERIES_FLAG_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-01",
@@ -257,7 +257,7 @@ def test_twr_respects_include_timeseries_flag(client):
 def test_twr_response_includes_portfolio_return_summary(client):
     """Tests that the top-level portfolio_return object is present for single-currency requests."""
     payload = {
-        "portfolio_number": "PORTFOLIO_RETURN_TEST",
+        "portfolio_id": "PORTFOLIO_RETURN_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-02",
@@ -283,7 +283,7 @@ def test_twr_reset_scenario_has_correct_summary(client):
     portfolio_return summary uses the correct final cumulative return from the engine.
     """
     payload = {
-        "portfolio_number": "TWR_STRESS_TEST_03",
+        "portfolio_id": "TWR_STRESS_TEST_03",
         "performance_start_date": "2024-12-31",
         "report_end_date": "2025-01-04",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -313,7 +313,7 @@ def test_calculate_twr_endpoint_error_handling(client, mocker, error_class, expe
     """Tests that the TWR endpoint correctly handles engine exceptions."""
     mocker.patch("app.api.endpoints.performance.run_calculations", side_effect=error_class("Test Error"))
     payload = {
-        "portfolio_number": "ERROR_TEST",
+        "portfolio_id": "ERROR_TEST",
         "performance_start_date": "2023-12-31",
         "metric_basis": "NET",
         "report_end_date": "2024-01-05",
@@ -328,7 +328,7 @@ def test_calculate_twr_endpoint_error_handling(client, mocker, error_class, expe
 def test_twr_returns_400_when_no_periods_resolve(client, mocker):
     mocker.patch("app.api.endpoints.performance.resolve_periods", return_value=[])
     payload = {
-        "portfolio_number": "NO_PERIODS",
+        "portfolio_id": "NO_PERIODS",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-05",
@@ -346,7 +346,7 @@ def test_twr_http_exception_passthrough_branch(client, mocker):
         side_effect=HTTPException(status_code=418, detail="teapot"),
     )
     payload = {
-        "portfolio_number": "HTTP_EXCEPTION",
+        "portfolio_id": "HTTP_EXCEPTION",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-05",
@@ -364,7 +364,7 @@ def test_mwr_http_exception_passthrough_branch(client, mocker):
         side_effect=HTTPException(status_code=409, detail="conflict"),
     )
     payload = {
-        "portfolio_number": "MWR_HTTP",
+        "portfolio_id": "MWR_HTTP",
         "begin_mv": 1000.0,
         "end_mv": 1001.0,
         "cash_flows": [],
@@ -375,7 +375,7 @@ def test_mwr_http_exception_passthrough_branch(client, mocker):
     assert response.json()["detail"] == "conflict"
 
 
-def test_twr_pas_snapshot_success(client, monkeypatch):
+def test_twr_pas_input_success(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return (
             200,
@@ -408,7 +408,7 @@ def test_twr_pas_snapshot_success(client, monkeypatch):
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -422,14 +422,14 @@ def test_twr_pas_snapshot_success(client, monkeypatch):
     response = client.post("/performance/twr/pas-input", json=payload)
     assert response.status_code == 200
     body = response.json()
-    assert body["portfolio_number"] == "PORT-1001"
+    assert body["portfolio_id"] == "PORT-1001"
     assert body["source_mode"] == "pas_ref"
     assert body["pasContractVersion"] == "v1"
     assert "YTD" in body["resultsByPeriod"]
     assert body["resultsByPeriod"]["YTD"]["net_cumulative_return"] is not None
 
 
-def test_twr_pas_snapshot_period_filter(client, monkeypatch):
+def test_twr_pas_input_period_filter(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return (
             200,
@@ -462,7 +462,7 @@ def test_twr_pas_snapshot_period_filter(client, monkeypatch):
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -479,7 +479,7 @@ def test_twr_pas_snapshot_period_filter(client, monkeypatch):
     assert "MTD" in body["resultsByPeriod"]
 
 
-def test_twr_pas_snapshot_invalid_payload_returns_502(client, monkeypatch):
+def test_twr_pas_input_invalid_payload_returns_502(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return (
             200,
@@ -492,7 +492,7 @@ def test_twr_pas_snapshot_invalid_payload_returns_502(client, monkeypatch):
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -506,12 +506,12 @@ def test_twr_pas_snapshot_invalid_payload_returns_502(client, monkeypatch):
     assert "missing valuationPoints" in response.json()["detail"]
 
 
-def test_twr_pas_snapshot_upstream_error_passthrough(client, monkeypatch):
+def test_twr_pas_input_upstream_error_passthrough(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return 404, {"detail": "Portfolio not found"}
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -524,7 +524,7 @@ def test_twr_pas_snapshot_upstream_error_passthrough(client, monkeypatch):
     assert response.status_code == 404
 
 
-def test_twr_pas_snapshot_missing_performance_start_date_returns_502(client, monkeypatch):
+def test_twr_pas_input_missing_performance_start_date_returns_502(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return (
             200,
@@ -537,7 +537,7 @@ def test_twr_pas_snapshot_missing_performance_start_date_returns_502(client, mon
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -546,7 +546,7 @@ def test_twr_pas_snapshot_missing_performance_start_date_returns_502(client, mon
     assert "missing performanceStartDate" in response.json()["detail"]
 
 
-def test_twr_pas_snapshot_invalid_valuation_shape_returns_502(client, monkeypatch):
+def test_twr_pas_input_invalid_valuation_shape_returns_502(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return (
             200,
@@ -560,7 +560,7 @@ def test_twr_pas_snapshot_invalid_valuation_shape_returns_502(client, monkeypatc
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -569,7 +569,7 @@ def test_twr_pas_snapshot_invalid_valuation_shape_returns_502(client, monkeypatc
     assert "Invalid PAS performance input payload" in response.json()["detail"]
 
 
-def test_twr_pas_snapshot_requested_period_not_found_returns_404(client, monkeypatch):
+def test_twr_pas_input_requested_period_not_found_returns_404(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return (
             200,
@@ -602,7 +602,7 @@ def test_twr_pas_snapshot_requested_period_not_found_returns_404(client, monkeyp
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input",
+        "app.api.endpoints.performance.PasInputService.get_performance_input",
         _mock_get_performance_input,
     )
 
@@ -625,7 +625,7 @@ def test_twr_pas_snapshot_requested_period_not_found_returns_404(client, monkeyp
     assert "Requested periods not found" in response.json()["detail"]
 
 
-def test_twr_pas_snapshot_skips_period_without_summary_and_returns_remaining(client, monkeypatch):
+def test_twr_pas_input_skips_period_without_summary_and_returns_remaining(client, monkeypatch):
     async def _mock_get_performance_input(self, portfolio_id, as_of_date, lookback_days, consumer_system):  # noqa: ARG001
         return (
             200,
@@ -642,7 +642,7 @@ def test_twr_pas_snapshot_skips_period_without_summary_and_returns_remaining(cli
         )
 
     monkeypatch.setattr(
-        "app.api.endpoints.performance.PasSnapshotService.get_performance_input", _mock_get_performance_input
+        "app.api.endpoints.performance.PasInputService.get_performance_input", _mock_get_performance_input
     )
 
     class _Summary:
@@ -674,3 +674,4 @@ def test_twr_pas_snapshot_skips_period_without_summary_and_returns_remaining(cli
     results = response.json()["resultsByPeriod"]
     assert "YTD" not in results
     assert "MTD" in results
+

--- a/tests/integration/test_rounding_api.py
+++ b/tests/integration/test_rounding_api.py
@@ -14,7 +14,7 @@ def client():
 def test_twr_endpoint_respects_rounding_precision(client):
     """Tests that aggregated summary values in the response are rounded correctly."""
     payload = {
-        "portfolio_number": "ROUNDING_TEST",
+        "portfolio_id": "ROUNDING_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-31",
@@ -31,3 +31,4 @@ def test_twr_endpoint_respects_rounding_precision(client):
 
     # The raw return is 1.123456%. It should be rounded to 1.12.
     assert summary["period_return_pct"] == 1.12
+

--- a/tests/unit/adapters/test_api_adapter.py
+++ b/tests/unit/adapters/test_api_adapter.py
@@ -61,7 +61,7 @@ def sample_engine_outputs():
 def test_create_engine_config():
     """Tests that the adapter correctly converts a PerformanceRequest into an EngineConfig object."""
     request_data = {
-        "portfolio_number": "TEST_01",
+        "portfolio_id": "TEST_01",
         "performance_start_date": "2024-12-31",
         "report_end_date": "2025-01-31",
         "metric_basis": "NET",
@@ -160,3 +160,4 @@ def test_format_breakdowns_populates_daily_cumulative_return(sample_engine_outpu
 
     daily_summary = formatted_response[Frequency.DAILY][0].summary
     assert daily_summary.cumulative_return_pct_to_date is None
+

--- a/tests/unit/core/test_repro.py
+++ b/tests/unit/core/test_repro.py
@@ -9,7 +9,7 @@ from core.repro import generate_canonical_hash
 def sample_twr_request():
     """Provides a sample PerformanceRequest object."""
     payload = {
-        "portfolio_number": "TEST_HASH",
+        "portfolio_id": "TEST_HASH",
         "performance_start_date": "2024-12-31",
         "report_end_date": "2025-01-02",
         "metric_basis": "NET",
@@ -58,3 +58,4 @@ def test_generate_canonical_hash_is_order_invariant(sample_twr_request):
     # Hashes will be different because Pydantic does not sort lists by default.
     # This confirms the behavior, which can be addressed if strict invariance is required.
     assert hash1 != hash2
+

--- a/tests/unit/engine/test_attribution.py
+++ b/tests/unit/engine/test_attribution.py
@@ -35,7 +35,7 @@ def by_group_request_data():
     """Provides a sample AttributionRequest for by_group mode where weights sum to 1."""
     # --- START FIX: Align fixture with new model ---
     return {
-        "portfolio_number": "ATTRIB_UNIT_TEST_01",
+        "portfolio_id": "ATTRIB_UNIT_TEST_01",
         "mode": "by_group",
         "group_by": ["sector"],
         "model": "BF",
@@ -133,7 +133,7 @@ def test_prepare_data_from_instruments():
 
     # --- START FIX: Align fixture with new model ---
     request_data = {
-        "portfolio_number": "TEST",
+        "portfolio_id": "TEST",
         "mode": "by_instrument",
         "group_by": ["sector"],
         "linking": "none",
@@ -165,7 +165,7 @@ def test_prepare_data_from_instruments_missing_portfolio_data():
     """Tests that a ValueError is raised if portfolio_data is missing in by_instrument mode."""
     # --- START FIX: Align fixture with new model ---
     request_data = {
-        "portfolio_number": "TEST",
+        "portfolio_id": "TEST",
         "mode": "by_instrument",
         "group_by": ["sector"],
         "instruments_data": [],
@@ -184,7 +184,7 @@ def test_prepare_data_from_instruments_missing_portfolio_data():
 
 def test_prepare_data_from_instruments_returns_empty_when_all_inputs_empty():
     request_data = {
-        "portfolio_number": "TEST",
+        "portfolio_id": "TEST",
         "mode": "by_instrument",
         "group_by": ["sector"],
         "linking": "none",
@@ -243,3 +243,4 @@ def test_run_attribution_calculations_returns_empty_when_aligned_panel_empty(by_
 
     assert effects_df.empty
     assert "aligned_panel.csv" in lineage
+

--- a/tests/unit/models/test_attribution_models.py
+++ b/tests/unit/models/test_attribution_models.py
@@ -10,7 +10,7 @@ from common.enums import PeriodType
 def base_attribution_payload():
     """Provides a base payload for attribution requests, excluding period definitions."""
     return {
-        "portfolio_number": "ATTRIB_001",
+        "portfolio_id": "ATTRIB_001",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-31",
         "mode": "by_group",
@@ -53,3 +53,4 @@ def test_attribution_request_with_no_analyses_fails(base_attribution_payload):
     with pytest.raises(ValidationError, match="Field required"):
         AttributionRequest.model_validate(base_attribution_payload)
     # --- END FIX ---
+

--- a/tests/unit/models/test_contribution_models.py
+++ b/tests/unit/models/test_contribution_models.py
@@ -12,7 +12,7 @@ from app.models.contribution_responses import ContributionResponse
 def minimal_contribution_request_payload():
     """Provides a minimal valid payload for a contribution request."""
     return {
-        "portfolio_number": "CONTRIB_001",
+        "portfolio_id": "CONTRIB_001",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-31",
         "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
@@ -50,7 +50,7 @@ def test_contribution_request_with_analyses_passes(minimal_contribution_request_
     """Tests that a request using the new 'analyses' field is valid."""
     try:
         req = ContributionRequest.model_validate(minimal_contribution_request_payload)
-        assert req.portfolio_number == "CONTRIB_001"
+        assert req.portfolio_id == "CONTRIB_001"
         assert len(req.analyses) == 1
     except ValidationError as e:
         pytest.fail(f"Validation failed unexpectedly with 'analyses': {e}")
@@ -94,7 +94,7 @@ def test_contribution_response_new_structure_passes(base_response_footer):
     }
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
-        "portfolio_number": "HIERARCHY_01",
+        "portfolio_id": "HIERARCHY_01",
         "results_by_period": {"YTD": single_period_payload, "MTD": single_period_payload},
         **base_response_footer,
     }
@@ -112,7 +112,7 @@ def test_contribution_response_legacy_structure_passes(base_response_footer):
     """Tests that a valid single-level contribution response payload is parsed correctly."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
-        "portfolio_number": "HIERARCHY_01",
+        "portfolio_id": "HIERARCHY_01",
         "report_start_date": "2025-01-01",
         "report_end_date": "2025-01-31",
         "summary": {
@@ -130,3 +130,4 @@ def test_contribution_response_legacy_structure_passes(base_response_footer):
         assert resp.results_by_period is None
     except ValidationError as e:
         pytest.fail(f"Validation failed for legacy response structure: {e}")
+

--- a/tests/unit/models/test_requests_models.py
+++ b/tests/unit/models/test_requests_models.py
@@ -9,7 +9,7 @@ from app.models.requests import PerformanceRequest
 def base_twr_payload():
     """Provides a base payload for TWR requests, excluding period definitions."""
     return {
-        "portfolio_number": "VALIDATION_TEST",
+        "portfolio_id": "VALIDATION_TEST",
         "performance_start_date": "2024-12-31",
         "metric_basis": "NET",
         "report_end_date": "2025-01-31",
@@ -47,3 +47,4 @@ def test_performance_request_without_analyses_fails(base_twr_payload):
     """Tests that validation fails if the 'analyses' field is missing."""
     with pytest.raises(ValidationError, match="Field required"):
         PerformanceRequest.model_validate(base_twr_payload)
+

--- a/tests/unit/models/test_responses_models.py
+++ b/tests/unit/models/test_responses_models.py
@@ -53,7 +53,7 @@ def test_performance_response_new_structure_passes(base_response_footer, single_
     """Tests that a response with the new 'results_by_period' structure is valid."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
-        "portfolio_number": "TEST_01",
+        "portfolio_id": "TEST_01",
         "results_by_period": {
             "YTD": single_period_result_payload,
             "MTD": single_period_result_payload,
@@ -73,7 +73,7 @@ def test_performance_response_legacy_structure_passes(base_response_footer, sing
     """Tests that a response with the legacy 'breakdowns' field is still valid."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
-        "portfolio_number": "TEST_01",
+        "portfolio_id": "TEST_01",
         **single_period_result_payload,
         **base_response_footer,
     }
@@ -89,7 +89,7 @@ def test_performance_response_with_both_structures_fails(base_response_footer, s
     """Tests that validation fails if both legacy and new structures are present."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
-        "portfolio_number": "TEST_01",
+        "portfolio_id": "TEST_01",
         "results_by_period": {"YTD": single_period_result_payload},
         **single_period_result_payload,
         **base_response_footer,
@@ -102,8 +102,9 @@ def test_performance_response_with_neither_structure_fails(base_response_footer)
     """Tests that validation fails if no result structure is provided."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
-        "portfolio_number": "TEST_01",
+        "portfolio_id": "TEST_01",
         **base_response_footer,
     }
     with pytest.raises(ValidationError, match="Provide either 'results_by_period' or the legacy"):
         PerformanceResponse.model_validate(payload)
+

--- a/tests/unit/services/test_pas_input_service.py
+++ b/tests/unit/services/test_pas_input_service.py
@@ -3,7 +3,7 @@ from datetime import date
 import httpx
 import pytest
 
-from app.services.pas_snapshot_service import PasSnapshotService
+from app.services.pas_input_service import PasInputService
 
 
 class _FakeAsyncClient:
@@ -54,12 +54,12 @@ class _FakeAsyncClient:
 def _patch_async_client(monkeypatch):
     _FakeAsyncClient.responses = []
     _FakeAsyncClient.calls = []
-    monkeypatch.setattr("app.services.pas_snapshot_service.httpx.AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr("app.services.pas_input_service.httpx.AsyncClient", _FakeAsyncClient)
 
 
 @pytest.mark.asyncio
 async def test_get_core_snapshot_posts_contract_payload():
-    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"snapshot": {"overview": {}}})
 
     status_code, payload = await service.get_core_snapshot(
@@ -78,7 +78,7 @@ async def test_get_core_snapshot_posts_contract_payload():
 
 @pytest.mark.asyncio
 async def test_get_performance_input_posts_contract_payload():
-    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"valuationPoints": []})
 
     status_code, payload = await service.get_performance_input(
@@ -96,7 +96,7 @@ async def test_get_performance_input_posts_contract_payload():
 
 @pytest.mark.asyncio
 async def test_get_positions_analytics_with_and_without_performance_periods():
-    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
     _FakeAsyncClient.queue_json(200, {"portfolioId": "PORT-3"})
     _FakeAsyncClient.queue_json(200, {"portfolioId": "PORT-3"})
 
@@ -129,7 +129,7 @@ async def test_get_positions_analytics_with_and_without_performance_periods():
     ],
 )
 def test_response_payload_parsing(payload, text, expected):
-    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
 
     class _Resp:
         def __init__(self, value, raw_text: str):
@@ -147,7 +147,7 @@ def test_response_payload_parsing(payload, text, expected):
 
 @pytest.mark.asyncio
 async def test_text_error_payload_is_mapped_to_detail():
-    service = PasSnapshotService(base_url="http://pas", timeout_seconds=2.0)
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
     _FakeAsyncClient.queue_text(503, "upstream unavailable")
     status_code, payload = await service.get_core_snapshot(
         portfolio_id="PORT-4",
@@ -157,3 +157,4 @@ async def test_text_error_payload_is_mapped_to_detail():
     )
     assert status_code == 503
     assert payload["detail"] == "upstream unavailable"
+


### PR DESCRIPTION
## Summary
- remove legacy portfolio_number terminology across PA code, tests, and docs
- standardize on canonical portfolio_id only (no compatibility aliases)
- remove legacy pas-snapshot terminology and standardize on pas-input
- rename PAS client service from pas_snapshot_service to pas_input_service
- update tests and fixtures to canonical vocabulary

## Validation
- python -m ruff check .
- python -m mypy --config-file mypy.ini
- python scripts/openapi_quality_gate.py
- python -m pytest tests/unit tests/integration -q

## Note
This is an intentional non-backward-compatible cutover because services are not live yet.