### PR TITLE
refactor: remove PA legacy response compatibility paths

### DIFF
--- a/app/models/responses.py
+++ b/app/models/responses.py
@@ -3,7 +3,7 @@ from datetime import date
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict
 
 from common.enums import Frequency
 from core.envelope import Audit, Diagnostics, Meta
@@ -56,31 +56,16 @@ class SinglePeriodPerformanceResult(BaseModel):
 class PerformanceResponse(BaseModel):
     """
     The main response model for a TWR calculation.
-    Can return results for multiple periods in 'results_by_period' or a single
-    period's results in the legacy flat structure for backward compatibility.
+    Returns results in canonical multi-period structure under 'results_by_period'.
     """
 
     calculation_id: UUID
     portfolio_id: str
 
-    results_by_period: Optional[Dict[str, SinglePeriodPerformanceResult]] = None
-
-    breakdowns: Optional[PerformanceBreakdown] = None
-    reset_events: Optional[List[ResetEvent]] = None
-    portfolio_return: Optional[PortfolioReturnDecomposition] = None
+    results_by_period: Dict[str, SinglePeriodPerformanceResult]
 
     meta: Meta
     diagnostics: Diagnostics
     audit: Audit
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_result_structure(cls, values):
-        """Ensures that exactly one result structure is used."""
-        has_new_structure = "results_by_period" in values and values.get("results_by_period") is not None
-        has_legacy_structure = "breakdowns" in values and values.get("breakdowns") is not None
-
-        if not (has_new_structure ^ has_legacy_structure):
-            raise ValueError("Provide either 'results_by_period' or the legacy 'breakdowns' field, but not both.")
-        return values
-
+    model_config = ConfigDict(extra="forbid")

--- a/core/envelope.py
+++ b/core/envelope.py
@@ -114,7 +114,6 @@ class Output(BaseModel):
 
 class Flags(BaseModel):
     fail_fast: bool = False
-    compat_legacy_names: bool = False
 
 
 class BaseRequest(BaseModel):

--- a/docs/technical/engine_config.md
+++ b/docs/technical/engine_config.md
@@ -69,7 +69,6 @@ These parameters are part of the unified API envelope and influence engine behav
 ### Flags
 
 -   **`fail_fast`**: When `true`, instructs the engine to raise an error on soft warnings instead of continuing.
--   **`compat_legacy_names`**: When `true`, instructs the API adapter to return legacy field names for backward compatibility.
 
 ---
 

--- a/tests/unit/models/test_contribution_models.py
+++ b/tests/unit/models/test_contribution_models.py
@@ -103,13 +103,12 @@ def test_contribution_response_new_structure_passes(base_response_footer):
         resp = ContributionResponse.model_validate(payload)
         assert "YTD" in resp.results_by_period
         assert resp.results_by_period["YTD"].summary.portfolio_contribution == 1.82
-        assert resp.summary is None
     except ValidationError as e:
         pytest.fail(f"Validation failed for new response structure: {e}")
 
 
-def test_contribution_response_legacy_structure_passes(base_response_footer):
-    """Tests that a valid single-level contribution response payload is parsed correctly."""
+def test_contribution_response_legacy_structure_fails(base_response_footer):
+    """Tests that legacy top-level contribution fields are rejected."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
         "portfolio_id": "HIERARCHY_01",
@@ -124,10 +123,5 @@ def test_contribution_response_legacy_structure_passes(base_response_footer):
         **base_response_footer,
     }
 
-    try:
-        resp = ContributionResponse.model_validate(payload)
-        assert resp.summary.portfolio_contribution == 1.82
-        assert resp.results_by_period is None
-    except ValidationError as e:
-        pytest.fail(f"Validation failed for legacy response structure: {e}")
-
+    with pytest.raises(ValidationError):
+        ContributionResponse.model_validate(payload)

--- a/tests/unit/models/test_responses_models.py
+++ b/tests/unit/models/test_responses_models.py
@@ -64,29 +64,24 @@ def test_performance_response_new_structure_passes(base_response_footer, single_
         response = PerformanceResponse.model_validate(payload)
         assert "YTD" in response.results_by_period
         assert "MTD" in response.results_by_period
-        assert response.breakdowns is None  # Old field should be absent
     except ValidationError as e:
         pytest.fail(f"Validation failed unexpectedly for new structure: {e}")
 
 
-def test_performance_response_legacy_structure_passes(base_response_footer, single_period_result_payload):
-    """Tests that a response with the legacy 'breakdowns' field is still valid."""
+def test_performance_response_legacy_structure_fails(base_response_footer, single_period_result_payload):
+    """Tests that a response with top-level legacy 'breakdowns' is rejected."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
         "portfolio_id": "TEST_01",
         **single_period_result_payload,
         **base_response_footer,
     }
-    try:
-        response = PerformanceResponse.model_validate(payload)
-        assert response.breakdowns is not None
-        assert response.results_by_period is None  # New field should be absent
-    except ValidationError as e:
-        pytest.fail(f"Validation failed unexpectedly for legacy structure: {e}")
+    with pytest.raises(ValidationError):
+        PerformanceResponse.model_validate(payload)
 
 
 def test_performance_response_with_both_structures_fails(base_response_footer, single_period_result_payload):
-    """Tests that validation fails if both legacy and new structures are present."""
+    """Tests that validation fails if legacy and canonical structures are both present."""
     payload = {
         "calculation_id": base_response_footer["meta"]["calculation_id"],
         "portfolio_id": "TEST_01",
@@ -94,7 +89,7 @@ def test_performance_response_with_both_structures_fails(base_response_footer, s
         **single_period_result_payload,
         **base_response_footer,
     }
-    with pytest.raises(ValidationError, match="Provide either 'results_by_period' or the legacy"):
+    with pytest.raises(ValidationError):
         PerformanceResponse.model_validate(payload)
 
 
@@ -105,6 +100,5 @@ def test_performance_response_with_neither_structure_fails(base_response_footer)
         "portfolio_id": "TEST_01",
         **base_response_footer,
     }
-    with pytest.raises(ValidationError, match="Provide either 'results_by_period' or the legacy"):
+    with pytest.raises(ValidationError):
         PerformanceResponse.model_validate(payload)
-


### PR DESCRIPTION
## Summary
- remove legacy top-level response compatibility from performance and contribution response models
- enforce canonical response contract via esults_by_period only
- remove obsolete lags.compat_legacy_names from shared request envelope
- update unit tests and engine config docs to match hard cutover

## Validation
- python -m ruff check app/models/contribution_responses.py app/models/responses.py core/envelope.py tests/unit/models/test_contribution_models.py tests/unit/models/test_responses_models.py
- python -m pytest tests/unit/models/test_responses_models.py tests/unit/models/test_contribution_models.py -q
- python -m pytest tests/unit tests/integration -q
