### PR TITLE
PA: ruff format alignment for fast-feedback

### DIFF
--- a/app/api/endpoints/analytics.py
+++ b/app/api/endpoints/analytics.py
@@ -199,4 +199,3 @@ async def get_workbench_analytics(request: WorkbenchAnalyticsRequest):
         topChanges=top_changes,
         riskProxy=risk_proxy,
     )
-

--- a/app/api/endpoints/contribution.py
+++ b/app/api/endpoints/contribution.py
@@ -169,4 +169,3 @@ async def calculate_contribution_endpoint(request: ContributionRequest, backgrou
     )
 
     return response_model
-

--- a/app/api/endpoints/performance.py
+++ b/app/api/endpoints/performance.py
@@ -486,4 +486,3 @@ async def calculate_attribution_endpoint(request: AttributionRequest, background
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"An unexpected server error occurred: {str(e)}",
         )
-

--- a/app/models/attribution_requests.py
+++ b/app/models/attribution_requests.py
@@ -102,4 +102,3 @@ class AttributionRequest(BaseModel):
         if not v:
             raise ValueError("analyses list cannot be empty")
         return v
-

--- a/app/models/attribution_responses.py
+++ b/app/models/attribution_responses.py
@@ -94,4 +94,3 @@ class AttributionResponse(BaseModel):
     meta: Meta
     diagnostics: Optional[Diagnostics] = None  # To be populated
     audit: Optional[Audit] = None  # To be populated
-

--- a/app/models/contribution_requests.py
+++ b/app/models/contribution_requests.py
@@ -107,4 +107,3 @@ class ContributionRequest(BaseModel):
         if not v:
             raise ValueError("analyses list cannot be empty")
         return v
-

--- a/app/models/mwr_requests.py
+++ b/app/models/mwr_requests.py
@@ -44,4 +44,3 @@ class MoneyWeightedReturnRequest(BaseModel):
     output: Output = Field(default_factory=Output)
     flags: Flags = Field(default_factory=Flags)
     report_ccy: Optional[str] = None
-

--- a/app/models/mwr_responses.py
+++ b/app/models/mwr_responses.py
@@ -47,4 +47,3 @@ class MoneyWeightedReturnResponse(BaseModel):
     meta: Meta
     diagnostics: Diagnostics
     audit: Audit
-

--- a/app/models/pas_connected_responses.py
+++ b/app/models/pas_connected_responses.py
@@ -31,4 +31,3 @@ class PasConnectedTwrResponse(BaseModel):
 
 PasInputPeriodResult = PasConnectedPeriodResult
 PasInputTwrResponse = PasConnectedTwrResponse
-

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -115,4 +115,3 @@ class PerformanceRequest(BaseModel):
         if not v:
             raise ValueError("analyses list cannot be empty")
         return v
-

--- a/app/services/pas_input_service.py
+++ b/app/services/pas_input_service.py
@@ -71,4 +71,3 @@ class PasInputService:
         if isinstance(payload, dict):
             return payload
         return {"detail": payload}
-

--- a/tests/benchmarks/test_engine_performance.py
+++ b/tests/benchmarks/test_engine_performance.py
@@ -61,4 +61,3 @@ def test_vectorized_engine_performance(benchmark, large_input_data):
 
     benchmark.group = "Engine Performance (500k rows)"
     benchmark(run)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,4 +60,3 @@ def happy_path_payload():
             }
         ],
     }
-

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -408,4 +408,3 @@ def test_e2e_workbench_active_return_and_risk_proxy_signal() -> None:
     assert body["activeReturnPct"] == pytest.approx(2.3)
     assert body["riskProxy"]["hhiDelta"] > 0
     assert len(body["topChanges"]) == 2
-

--- a/tests/integration/test_analytics_api.py
+++ b/tests/integration/test_analytics_api.py
@@ -142,4 +142,3 @@ def test_workbench_analytics_security_group_uses_security_bucket_keys():
     bucket = response.json()["allocationBuckets"][0]
     assert bucket["bucketKey"] == "MSFT.US"
     assert bucket["bucketLabel"] == "Microsoft"
-

--- a/tests/integration/test_attribution_api.py
+++ b/tests/integration/test_attribution_api.py
@@ -319,4 +319,3 @@ def test_attribution_endpoint_skips_empty_period_slice(client, mocker):
     results = response.json()["results_by_period"]
     assert "ITD" in results
     assert "MTD" not in results
-

--- a/tests/integration/test_contribution_api.py
+++ b/tests/integration/test_contribution_api.py
@@ -236,4 +236,3 @@ def test_contribution_endpoint_skips_empty_period_slice(client):
 
     assert response.status_code == 200
     assert response.json()["results_by_period"] == {}
-

--- a/tests/integration/test_lineage_api.py
+++ b/tests/integration/test_lineage_api.py
@@ -89,4 +89,3 @@ def test_get_lineage_internal_error_returns_500(client, mocker):
     response = client.get(f"/performance/lineage/{calculation_id}")
     assert response.status_code == 500
     assert "Failed to retrieve lineage artifacts" in response.json()["detail"]
-

--- a/tests/integration/test_multi_period_summary.py
+++ b/tests/integration/test_multi_period_summary.py
@@ -70,4 +70,3 @@ def test_multi_period_portfolio_return_summary_is_correct(client):
 
     # Crucially, assert the MTD and YTD summaries are NOT the same
     assert mtd_summary["base"] != ytd_summary["base"]
-

--- a/tests/integration/test_mwr_api.py
+++ b/tests/integration/test_mwr_api.py
@@ -75,4 +75,3 @@ def test_calculate_mwr_endpoint_unexpected_error_returns_500(client, mocker):
     response = client.post("/performance/mwr", json=payload)
     assert response.status_code == 500
     assert "unexpected error occurred during MWR calculation" in response.json()["detail"]
-

--- a/tests/integration/test_performance_api.py
+++ b/tests/integration/test_performance_api.py
@@ -674,4 +674,3 @@ def test_twr_pas_input_skips_period_without_summary_and_returns_remaining(client
     results = response.json()["resultsByPeriod"]
     assert "YTD" not in results
     assert "MTD" in results
-

--- a/tests/integration/test_rounding_api.py
+++ b/tests/integration/test_rounding_api.py
@@ -31,4 +31,3 @@ def test_twr_endpoint_respects_rounding_precision(client):
 
     # The raw return is 1.123456%. It should be rounded to 1.12.
     assert summary["period_return_pct"] == 1.12
-

--- a/tests/unit/adapters/test_api_adapter.py
+++ b/tests/unit/adapters/test_api_adapter.py
@@ -160,4 +160,3 @@ def test_format_breakdowns_populates_daily_cumulative_return(sample_engine_outpu
 
     daily_summary = formatted_response[Frequency.DAILY][0].summary
     assert daily_summary.cumulative_return_pct_to_date is None
-

--- a/tests/unit/core/test_repro.py
+++ b/tests/unit/core/test_repro.py
@@ -58,4 +58,3 @@ def test_generate_canonical_hash_is_order_invariant(sample_twr_request):
     # Hashes will be different because Pydantic does not sort lists by default.
     # This confirms the behavior, which can be addressed if strict invariance is required.
     assert hash1 != hash2
-

--- a/tests/unit/engine/test_attribution.py
+++ b/tests/unit/engine/test_attribution.py
@@ -243,4 +243,3 @@ def test_run_attribution_calculations_returns_empty_when_aligned_panel_empty(by_
 
     assert effects_df.empty
     assert "aligned_panel.csv" in lineage
-

--- a/tests/unit/models/test_attribution_models.py
+++ b/tests/unit/models/test_attribution_models.py
@@ -53,4 +53,3 @@ def test_attribution_request_with_no_analyses_fails(base_attribution_payload):
     with pytest.raises(ValidationError, match="Field required"):
         AttributionRequest.model_validate(base_attribution_payload)
     # --- END FIX ---
-

--- a/tests/unit/models/test_requests_models.py
+++ b/tests/unit/models/test_requests_models.py
@@ -47,4 +47,3 @@ def test_performance_request_without_analyses_fails(base_twr_payload):
     """Tests that validation fails if the 'analyses' field is missing."""
     with pytest.raises(ValidationError, match="Field required"):
         PerformanceRequest.model_validate(base_twr_payload)
-

--- a/tests/unit/services/test_pas_input_service.py
+++ b/tests/unit/services/test_pas_input_service.py
@@ -157,4 +157,3 @@ async def test_text_error_payload_is_mapped_to_detail():
     )
     assert status_code == 503
     assert payload["detail"] == "upstream unavailable"
-


### PR DESCRIPTION
## Summary
- apply uff format across PA codebase
- no functional logic change
- restores fast-feedback/ci parity checks

## Validation
- python -m ruff check .
- python -m ruff format --check .
- python -m mypy --config-file mypy.ini
- python -m pytest tests/unit
