### PR TITLE
PA: remove deprecated 422 constant usage

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -1,6 +1,11 @@
 # core/errors.py
 from fastapi import HTTPException, status
 
+if hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_CONTENT
+else:
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 class APIError(HTTPException):
     """Base class for custom API exceptions for consistent error handling."""
@@ -20,7 +25,7 @@ class APIUnprocessableEntityError(APIError):
     """To be used for 422 Unprocessable Entity errors (valid request, but data is insufficient)."""
 
     def __init__(self, detail: str = "Unprocessable Entity"):
-        super().__init__(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail)
+        super().__init__(status_code=HTTP_422_UNPROCESSABLE, detail=detail)
 
 
 class APIConflictError(APIError):

--- a/tests/unit/core/test_errors.py
+++ b/tests/unit/core/test_errors.py
@@ -3,6 +3,11 @@ from fastapi import status
 
 from core.errors import APIBadRequestError, APIConflictError, APIUnprocessableEntityError
 
+if hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT"):
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_CONTENT
+else:
+    HTTP_422_UNPROCESSABLE = status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 def test_api_bad_request_error():
     """Tests the APIBadRequestError custom exception."""
@@ -18,7 +23,7 @@ def test_api_unprocessable_entity_error():
     try:
         raise APIUnprocessableEntityError("Calculation failed to converge")
     except APIUnprocessableEntityError as e:
-        assert e.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert e.status_code == HTTP_422_UNPROCESSABLE
         assert e.detail == "Calculation failed to converge"
 
 


### PR DESCRIPTION
## Summary
- replace direct use of deprecated HTTP_422_UNPROCESSABLE_ENTITY
- use HTTP_422_UNPROCESSABLE_CONTENT when available with compatibility fallback
- update unit test expectation accordingly

## Validation
- python -m ruff check .
- python -m ruff format --check .
- python -m mypy --config-file mypy.ini
- python -m pytest tests/unit/core/test_errors.py
