### PR TITLE
Close scalability gaps: health and pagination guardrails

### DIFF
--- a/app/api/endpoints/health.py
+++ b/app/api/endpoints/health.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+
+router = APIRouter(tags=["Health"])
+
+
+@router.get("/health", summary="Service health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/health/live", summary="Service liveness")
+async def health_live() -> dict[str, str]:
+    return {"status": "live"}
+
+
+@router.get("/health/ready", summary="Service readiness")
+async def health_ready() -> dict[str, str]:
+    return {"status": "ready"}

--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -57,6 +57,8 @@ def _env_bool(name: str, default: bool) -> bool:
 async def get_integration_capabilities(
     consumer_system: ConsumerSystem = Query("BFF", alias="consumerSystem"),
     tenant_id: str = Query("default", alias="tenantId"),
+    feature_limit: int = Query(default=100, ge=1, le=500, alias="featureLimit"),
+    workflow_limit: int = Query(default=50, ge=1, le=200, alias="workflowLimit"),
 ) -> IntegrationCapabilitiesResponse:
     twr_enabled = _env_bool("PA_CAP_TWR_ENABLED", True)
     mwr_enabled = _env_bool("PA_CAP_MWR_ENABLED", True)
@@ -165,6 +167,6 @@ async def get_integration_capabilities(
         asOfDate=date.today(),
         policyVersion=os.getenv("PA_POLICY_VERSION", "tenant-default-v1"),
         supportedInputModes=supported_input_modes,
-        features=features,
-        workflows=workflows,
+        features=features[:feature_limit],
+        workflows=workflows[:workflow_limit],
     )

--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -10,6 +10,7 @@ This repository adopts the platform-wide standard defined in pbwm-platform-docs/
 - Explicit timeout and bounded retry/backoff for inter-service communication where applicable.
 - Health/liveness/readiness endpoints for runtime orchestration.
 - Observability instrumentation for latency/error/throughput diagnostics.
+- API pagination/filter guardrails through bounded query parameters (`featureLimit`, `workflowLimit`).
 
 ## Required Evidence
 

--- a/main.py
+++ b/main.py
@@ -8,7 +8,14 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import JSONResponse
 
-from app.api.endpoints import analytics, contribution, integration_capabilities, lineage, performance
+from app.api.endpoints import (
+    analytics,
+    contribution,
+    health,
+    integration_capabilities,
+    lineage,
+    performance,
+)
 from app.core.config import get_settings
 from app.core.exceptions import PerformanceCalculatorError
 from app.core.handlers import performance_calculator_exception_handler
@@ -104,21 +111,7 @@ app.include_router(contribution.router, prefix="/performance")
 app.include_router(lineage.router, prefix="/performance")
 app.include_router(analytics.router, prefix="/analytics")
 app.include_router(integration_capabilities.router, prefix="/integration")
-
-
-@app.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
-
-
-@app.get("/health/live")
-async def health_live() -> dict[str, str]:
-    return {"status": "live"}
-
-
-@app.get("/health/ready")
-async def health_ready() -> dict[str, str]:
-    return {"status": "ready"}
+app.include_router(health.router)
 
 
 @app.get("/")

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -43,6 +43,18 @@ def test_integration_capabilities_env_override(monkeypatch):
     assert body["supportedInputModes"] == ["pas_ref"]
 
 
+def test_integration_capabilities_limit_guardrails():
+    with TestClient(app) as client:
+        response = client.get(
+            "/integration/capabilities?consumerSystem=BFF&tenantId=default&featureLimit=2&workflowLimit=1"
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["features"]) == 2
+    assert len(body["workflows"]) == 1
+
+
 def test_health_and_metrics_endpoints_available():
     with TestClient(app) as client:
         health = client.get("/health")


### PR DESCRIPTION
Adds explicit health router under app endpoints and bounded integration capability limits with tests and standards update.