### PR TITLE
Scalability/Availability gap closure: drain readiness and docs

### DIFF
--- a/app/api/endpoints/health.py
+++ b/app/api/endpoints/health.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request, Response, status
 
 router = APIRouter(tags=["Health"])
 
@@ -14,5 +14,8 @@ async def health_live() -> dict[str, str]:
 
 
 @router.get("/health/ready", summary="Service readiness")
-async def health_ready() -> dict[str, str]:
+async def health_ready(request: Request, response: Response) -> dict[str, str]:
+    if bool(getattr(request.app.state, "is_draining", False)):
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {"status": "draining"}
     return {"status": "ready"}

--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -30,6 +30,20 @@ This repository adopts the platform-wide standard defined in pbwm-platform-docs/
 - Recovery targets: RTO 30 minutes and RPO 15 minutes for persisted analytics state.
 - Backup and restore validation: restoration drill evidence is required in environment runbooks before go-live.
 
+## Caching Policy Baseline
+
+- Cache usage is explicit for read-optimized analytics surfaces only.
+- TTL, invalidation owner, and stale-read behavior must be documented before enabling cache-backed responses.
+- Correctness-critical valuation/performance calculations cannot depend on stale cache values.
+
+## Scale Signal Metrics Coverage
+
+- PA exposes `/metrics` for latency/error/throughput and downstream dependency instrumentation.
+- Platform-shared metrics for CPU/memory, DB performance, and queue/consumer lag are sourced from:
+  - `pbwm-platform-docs/platform-stack/prometheus/prometheus.yml`
+  - `pbwm-platform-docs/platform-stack/docker-compose.yml`
+  - `pbwm-platform-docs/Platform Observability Standards.md`
+
 ## Deviation Rule
 
 Any deviation from this standard requires ADR/RFC with remediation timeline.

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -70,3 +70,13 @@ def test_health_and_metrics_endpoints_available():
     assert ready.json() == {"status": "ready"}
     assert metrics.status_code == 200
     assert "http_requests_total" in metrics.text or "http_request_duration" in metrics.text
+
+
+def test_health_ready_returns_503_when_draining():
+    with TestClient(app) as client:
+        app.state.is_draining = True
+        response = client.get("/health/ready")
+    app.state.is_draining = False
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "draining"}


### PR DESCRIPTION
## Summary\n- add graceful-drain readiness behavior\n- add readiness-drain integration coverage\n- expand scalability/availability documentation for cache + scale metrics\n\n## Validation\n- targeted integration tests passed\n