### PR TITLE
chore: align performance naming to lotus platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Portfolio Performance Analytics API (V3 Engine)
 
-An API for calculating portfolio performance metrics, aligned with the `portfolio-analytics-system`. It provides three primary services:
+An API for calculating portfolio performance metrics, aligned with the `lotus-core`. It provides three primary services:
 1.  **Performance Calculation**: Endpoints for calculating **Time-Weighted Return (TWR)** with frequency-based breakdowns and **Money-Weighted Return (MWR)**.
 2.  **Contribution Analysis**: An endpoint for calculating **Position Contribution** to explain the drivers of portfolio performance. Supports both single-level and multi-level hierarchical breakdowns.
 3.  **Attribution Analysis**: An endpoint for calculating single-level, multi-period **Performance Attribution** (Brinson-style) to explain a portfolio's active return against a benchmark.
@@ -13,7 +13,7 @@ An API for calculating portfolio performance metrics, aligned with the `portfoli
 - Docs-with-code standard: `docs/documentation/implementation-documentation-standard.md`
 - Branch-protection workflow: `docs/documentation/git-branch-protection-workflow.md`
 - PR checklist template: `.github/pull_request_template.md`
-- Platform-wide architecture governance source: `https://github.com/sgajbi/pbwm-platform-docs`
+- Platform-wide architecture governance source: `https://github.com/sgajbi/lotus-platform`
 
 ## Key Features
 
@@ -33,8 +33,8 @@ An API for calculating portfolio performance metrics, aligned with the `portfoli
 
 1.  **Clone the repository:**
     ```bash
-    git clone [https://github.com/sgajbi/performanceAnalytics](https://github.com/sgajbi/performanceAnalytics)
-    cd performanceAnalytics
+    git clone [https://github.com/sgajbi/lotus-performance](https://github.com/sgajbi/lotus-performance)
+    cd lotus-performance
     ```
 
 2.  **Create and activate a virtual environment:**
@@ -176,3 +176,5 @@ Standards documentation:
 
 - `docs/standards/migration-contract.md`
 - `docs/standards/data-model-ownership.md`
+
+

--- a/docs/RFCs/RFC 002 - Engine Upgrade - Performance Breakdown API.md
+++ b/docs/RFCs/RFC 002 - Engine Upgrade - Performance Breakdown API.md
@@ -7,7 +7,7 @@
 
 ## 1. Executive Summary
 
-This document proposes a new plan to upgrade the `performanceAnalytics` engine to be API-compatible with the `portfolio-analytics-system`. This RFC supersedes all previous V3 proposals.
+This document proposes a new plan to upgrade the `lotus-performance` engine to be API-compatible with the `lotus-core`. This RFC supersedes all previous V3 proposals.
 
 The primary goal is to refactor our API to return a **performance breakdown object**. Instead of a flat list of daily results, the engine will aggregate performance data into different time frequencies (**daily, monthly, quarterly, yearly**) as requested by the user.
 
@@ -15,7 +15,7 @@ This version also expands the list of supported **period types** to include `ITD
 
 ## 2. Gap Analysis
 
-A deep review of the `portfolio-analytics-system` reveals the following gaps:
+A deep review of the `lotus-core` reveals the following gaps:
 
 #### 2.1 API Contract & Output Structure
 -   **Input:** The `PerformanceRequest` in the target system accepts a `frequencies: list[Frequency]` parameter to specify the desired time aggregations.

--- a/docs/RFCs/RFC 005 - Portfolio Correlation Matrix API.md
+++ b/docs/RFCs/RFC 005 - Portfolio Correlation Matrix API.md
@@ -15,7 +15,7 @@ This document specifies the final design for a new **Portfolio Correlation Matri
 
 The engine will provide a robust, on-demand utility to compute a correlation matrix from a set of time series. It is designed for maximum flexibility, supporting both **Pearson (standard)** and **Spearman (rank-based)** correlation. The API can ingest either raw **prices** or pre-calculated **returns** and includes powerful, configurable policies for **data alignment** and **missing value handling**.
 
-In line with our architectural principles, the API is highly configurable, stateless, and follows the established patterns of the performanceAnalytics suite. It will support advanced features like **pre-aggregation by group** (e.g., sector-level correlations) and **rolling window analysis**. This feature will serve as a key building block for more advanced risk and optimization tools.
+In line with our architectural principles, the API is highly configurable, stateless, and follows the established patterns of the lotus-performance suite. It will support advanced features like **pre-aggregation by group** (e.g., sector-level correlations) and **rolling window analysis**. This feature will serve as a key building block for more advanced risk and optimization tools.
 
 ## 2\. Goals & Non-Goals
 
@@ -170,3 +170,4 @@ The implementation of this RFC is complete when:
 4.  The testing and validation strategy is fully implemented, all tests are passing, and the required coverage targets (**100% for engine**, **≥95% for project**) are met.
 5.  The characterization test passes, confirming numerical results match the external reference library.
 6.  New documentation is added to `docs/guides/` and `docs/technical/` for the Correlation Matrix API, ensuring documentation remains current.
+

--- a/docs/RFCs/RFC 038 - PA Domain Vocabulary Alignment with Platform Glossary.md
+++ b/docs/RFCs/RFC 038 - PA Domain Vocabulary Alignment with Platform Glossary.md
@@ -8,8 +8,8 @@ Proposed
 
 ## Problem Statement
 
-`performanceAnalytics` still uses legacy shared terms (`portfolio_id`, `pas-input`) in API contracts, models, tests, and documentation.
-This conflicts with the platform glossary in `pbwm-platform-docs/Domain Vocabulary Glossary.md`, which mandates canonical cross-service terms such as `portfolio_id`, `as_of_date`, and `pas-input` terminology.
+`lotus-performance` still uses legacy shared terms (`portfolio_id`, `pas-input`) in API contracts, models, tests, and documentation.
+This conflicts with the platform glossary in `lotus-platform/Domain Vocabulary Glossary.md`, which mandates canonical cross-service terms such as `portfolio_id`, `as_of_date`, and `pas-input` terminology.
 
 Current measurable drift (baseline from `Validate-Domain-Vocabulary.ps1`):
 - `portfolio_id`: 121 findings
@@ -71,4 +71,5 @@ Mitigation:
 2. OpenAPI reflects canonical vocabulary.
 3. All PA CI gates remain green (`lint`, `typecheck`, `openapi-gate`, tests, coverage, security).
 4. Platform vocabulary conformance report marks PA as `ok`.
+
 

--- a/docs/RFCs/RFC-028 - Unified snake_case API Naming & Legacy Alias Removal.md
+++ b/docs/RFCs/RFC-028 - Unified snake_case API Naming & Legacy Alias Removal.md
@@ -11,7 +11,7 @@ Here is the final, implementable RFC. It has been updated to remove all citation
 
 ## 1. Executive Summary
 
-This document specifies the final plan to standardize the entire public API contract of the `performanceAnalytics` service to a strict `snake_case` naming convention. The current API supports a mix of legacy, Title-Cased names (e.g., `"Perf. Date"`, `"Begin Market Value"`) and modern `snake_case` names through a series of adapters and compatibility flags. This approach has introduced significant technical debt, increased the complexity of models and tests, and created an inconsistent developer experience.
+This document specifies the final plan to standardize the entire public API contract of the `lotus-performance` service to a strict `snake_case` naming convention. The current API supports a mix of legacy, Title-Cased names (e.g., `"Perf. Date"`, `"Begin Market Value"`) and modern `snake_case` names through a series of adapters and compatibility flags. This approach has introduced significant technical debt, increased the complexity of models and tests, and created an inconsistent developer experience.
 
 This initiative will **remove all legacy aliases and compatibility flags**, enforcing `snake_case` for all request and response fields across the TWR, MWR, Contribution, and Attribution endpoints. This change simplifies the codebase, clarifies the API contract, eliminates a class of potential bugs, and aligns our service with modern API design standards, enabling better automated documentation and client generation. The core calculation engine's logic and numerical output will remain **unchanged**, a guarantee enforced by our existing characterization test suite.
 

--- a/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
+++ b/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
@@ -4,9 +4,9 @@
 
 - Service-specific PA implementation RFCs are maintained in this repository.
 - Cross-cutting platform and multi-service architecture decisions are maintained in:
-  `https://github.com/sgajbi/pbwm-platform-docs`
+  `https://github.com/sgajbi/lotus-platform`
 
-This document provides a summary of the implementation status for all RFCs related to the `performanceAnalytics` service. It also outlines a strategic, sequential roadmap for implementing the remaining features to build a cohesive and powerful analytics suite.
+This document provides a summary of the implementation status for all RFCs related to the `lotus-performance` service. It also outlines a strategic, sequential roadmap for implementing the remaining features to build a cohesive and powerful analytics suite.
 
 ---
 
@@ -93,3 +93,4 @@ The following RFCs are not yet implemented. This roadmap presents a logical orde
 
 14. **RFC 022 — Composite & Sleeve Aggregation API**
     * **Reasoning:** **Enable firm-level and GIPS-compliant reporting.** A major enterprise feature that aggregates results from multiple portfolios into composites, representing the pinnacle of the platform's capabilities.
+

--- a/docs/standards/data-model-ownership.md
+++ b/docs/standards/data-model-ownership.md
@@ -1,6 +1,6 @@
 # Data Model Ownership
 
-- Service: `performanceAnalytics`
+- Service: `lotus-performance`
 - Ownership status: no persisted core portfolio ledger entities.
 - Responsibility: advanced analytics computation contracts.
 
@@ -12,5 +12,6 @@
 
 ## Vocabulary
 
-- Canonical terms must align with `pbwm-platform-docs/Domain Vocabulary Glossary.md`.
+- Canonical terms must align with `lotus-platform/Domain Vocabulary Glossary.md`.
 - No service-local synonyms for portfolio, position, transaction, valuation, performance, risk.
+

--- a/docs/standards/durability-consistency.md
+++ b/docs/standards/durability-consistency.md
@@ -1,6 +1,6 @@
 # Durability and Consistency Standard (PA)
 
-- Standard reference: `pbwm-platform-docs/Durability and Consistency Standard.md`
+- Standard reference: `lotus-platform/Durability and Consistency Standard.md`
 - Scope: advanced analytics with PAS-sourced canonical inputs and stateless request mode.
 - Change control: RFC required for rule changes; ADR required for temporary deviations.
 
@@ -62,3 +62,4 @@
 ## Deviations
 
 - Any write-side mutation introduced in PA without idempotency/atomic controls requires ADR with expiry review date.
+

--- a/docs/standards/enterprise-readiness.md
+++ b/docs/standards/enterprise-readiness.md
@@ -1,6 +1,6 @@
 # Enterprise Readiness Baseline (PA)
 
-- Standard reference: `pbwm-platform-docs/Enterprise Readiness Standard.md`
+- Standard reference: `lotus-platform/Enterprise Readiness Standard.md`
 - Scope: advanced analytics API surfaces and PAS-integrated analytics delivery.
 - Change control: RFC for shared standard changes; ADR for temporary deviations.
 
@@ -62,3 +62,4 @@ Evidence:
 ## Deviations
 
 - Any deviation requires ADR with rationale and expiry review date.
+

--- a/docs/standards/migration-contract.md
+++ b/docs/standards/migration-contract.md
@@ -1,6 +1,6 @@
 # Migration Contract Standard
 
-- Service: `performanceAnalytics`
+- Service: `lotus-performance`
 - Persistence mode: **no persistent schema** in current architecture.
 - Migration policy: **versioned migration contract** remains mandatory as a governance control.
 
@@ -21,3 +21,4 @@ If storage is introduced:
 1. Adopt versioned migrations.
 2. Add deterministic migration apply checks in CI.
 3. Keep forward-only migration policy with explicit rollback runbook.
+

--- a/docs/standards/rounding-precision.md
+++ b/docs/standards/rounding-precision.md
@@ -1,6 +1,6 @@
 # Rounding and Precision Standard
 
-This repository adopts the platform-wide mandatory standard defined in `pbwm-platform-docs/Financial Rounding and Precision Standard.md` and RFC-0063.
+This repository adopts the platform-wide mandatory standard defined in `lotus-platform/Financial Rounding and Precision Standard.md` and RFC-0063.
 
 ## Local Enforcement
 
@@ -34,6 +34,7 @@ This repository adopts the platform-wide mandatory standard defined in `pbwm-pla
 ## Cross-Service Regression Link
 
 - Shared golden fixture: `tests/fixtures/rounding-golden-vectors.json`.
-- Platform check: `pbwm-platform-docs/automation/Validate-Rounding-Consistency.ps1`.
+- Platform check: `lotus-platform/automation/Validate-Rounding-Consistency.ps1`.
 - Evidence artifact: `Rounding Consistency Report`.
+
 

--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -2,7 +2,7 @@
 
 Service: PA
 
-This repository adopts the platform-wide standard defined in pbwm-platform-docs/Scalability and Availability Standard.md.
+This repository adopts the platform-wide standard defined in lotus-platform/Scalability and Availability Standard.md.
 
 ## Implemented Baseline
 
@@ -14,7 +14,7 @@ This repository adopts the platform-wide standard defined in pbwm-platform-docs/
 
 ## Required Evidence
 
-- Compliance matrix entry in pbwm-platform-docs/output/scalability-availability-compliance.md.
+- Compliance matrix entry in lotus-platform/output/scalability-availability-compliance.md.
 - Service-specific tests covering resilience and concurrency-critical paths.
 
 ## Database Scalability Fundamentals
@@ -40,10 +40,11 @@ This repository adopts the platform-wide standard defined in pbwm-platform-docs/
 
 - PA exposes `/metrics` for latency/error/throughput and downstream dependency instrumentation.
 - Platform-shared metrics for CPU/memory, DB performance, and queue/consumer lag are sourced from:
-  - `pbwm-platform-docs/platform-stack/prometheus/prometheus.yml`
-  - `pbwm-platform-docs/platform-stack/docker-compose.yml`
-  - `pbwm-platform-docs/Platform Observability Standards.md`
+  - `lotus-platform/platform-stack/prometheus/prometheus.yml`
+  - `lotus-platform/platform-stack/docker-compose.yml`
+  - `lotus-platform/Platform Observability Standards.md`
 
 ## Deviation Rule
 
 Any deviation from this standard requires ADR/RFC with remediation timeline.
+

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -1,7 +1,7 @@
  
 # Engine Architecture & API Structure
 
-The performanceAnalytics system is designed with a clean separation of concerns, split into distinct layers to ensure testability, reusability, and maintainability.
+The lotus-performance system is designed with a clean separation of concerns, split into distinct layers to ensure testability, reusability, and maintainability.
 
 1.  **API Layer (`app/`)**
     * Implemented in FastAPI and located in `app/api/endpoints/`.

--- a/docs/technical/methodology_index.md
+++ b/docs/technical/methodology_index.md
@@ -1,6 +1,6 @@
 # Methodology Index
 
-This index provides a central navigation point for all detailed methodology and technical documentation for the **performanceAnalytics** engine and API. It is designed to help new developers, business analysts, and product teams quickly find the information they need.
+This index provides a central navigation point for all detailed methodology and technical documentation for the **lotus-performance** engine and API. It is designed to help new developers, business analysts, and product teams quickly find the information they need.
 
 ---
 ## Core Technical Documents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "performanceAnalytics"
+name = "lotus-performance"
 version = "0.1.0"
 description = "API for calculating portfolio performance metrics."
 authors = ["sandeepgajbi@gmail.com"]
@@ -53,3 +53,5 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 ignore = ["E501"]
+
+

--- a/rfcs/RFC-0001-pa-coverage-hardening-wave-1.md
+++ b/rfcs/RFC-0001-pa-coverage-hardening-wave-1.md
@@ -10,7 +10,7 @@ Proposed
 
 ## Problem Statement
 
-`performanceAnalytics` was below target meaningful coverage and had concentrated gaps in PAS integration adapter paths, observability helpers, and endpoint negative-path validation.
+`lotus-performance` was below target meaningful coverage and had concentrated gaps in PAS integration adapter paths, observability helpers, and endpoint negative-path validation.
 
 ## Decision
 
@@ -40,4 +40,5 @@ Deliver an incremental hardening wave focused on highest-risk uncovered backend 
 Wave 2 will target remaining concentrated misses in:
 - `app/api/endpoints/performance.py`
 - `app/services/lineage_service.py`
+
 


### PR DESCRIPTION
## Summary
- align standards/docs/config references to lotus naming
- remove legacy cross-service repo names from active paths

## Validation
- platform naming conformance report shows lotus-performance=ok