### PR TITLE
docs: align RFC history references to lotus naming

### DIFF
--- a/docs/RFCs/RFC 001 - Performance Engine V2 - Vectorization & Architectural Refactor.MD
+++ b/docs/RFCs/RFC 001 - Performance Engine V2 - Vectorization & Architectural Refactor.MD
@@ -52,7 +52,7 @@ The V2 engine will be built on the following principles:
 The project will be restructured to reflect a clear separation of concerns.
 
 ```plaintext
-└── sgajbi-performanceanalytics/
+└── sgajbi-lotus-performance/
     ├── app/                # FastAPI application layer
     │   ├── api/
     │   │   └── endpoints/

--- a/docs/RFCs/RFC 014 - Cross-Cutting Consistency & Diagnostics Framework.md
+++ b/docs/RFCs/RFC 014 - Cross-Cutting Consistency & Diagnostics Framework.md
@@ -16,7 +16,7 @@ This initiative strengthens correctness, enhances configurability, improves obse
 
 ## 2\. Current State Analysis
 
-An analysis of the current `sgajbi-performanceanalytics` repository reveals a mature but inconsistent API surface across its primary services.
+An analysis of the current `sgajbi-lotus-performance` repository reveals a mature but inconsistent API surface across its primary services.
 
   * **Inconsistent API Contracts:** The request and response models for `/performance/twr`, `/performance/mwr`, `/performance/contribution`, and `/performance/attribution` have evolved independently. They lack common fields for controlling fundamental calculation parameters.
   * **Limited Configurability:** Clients cannot control crucial aspects like calculation precision, annualization logic, or calendar conventions directly via the API.

--- a/docs/RFCs/RFC 019 - Multi‑Level Contribution API.md
+++ b/docs/RFCs/RFC 019 - Multi‑Level Contribution API.md
@@ -1,7 +1,7 @@
 # RFC 019: Multi‑Level Contribution API (Final)
 
 **Status:** Final (For Approval)  
-**Owner:** Sandeep (Cyclops/PerformanceAnalytics)  
+**Owner:** Sandeep (Cyclops/lotus-performance)  
 **Reviewers:** Perf Engine, Risk, Platform  
 **Target Release:** v0.4.x  
 **Related:** RFC‑014 (Envelope/Diagnostics), RFC‑015 (TWR), RFC‑017 (Contribution Enhancements), RFC‑018 (Attribution)


### PR DESCRIPTION
RFC/documentation naming alignment only.