### PR TITLE
refactor: lotus-performance capability ownership cleanup

### DIFF
--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -64,8 +64,6 @@ async def get_integration_capabilities(
     mwr_enabled = _env_bool("PA_CAP_MWR_ENABLED", True)
     contribution_enabled = _env_bool("PA_CAP_CONTRIBUTION_ENABLED", True)
     attribution_enabled = _env_bool("PA_CAP_ATTRIBUTION_ENABLED", True)
-    risk_enabled = _env_bool("PA_CAP_RISK_ENABLED", True)
-    concentration_enabled = _env_bool("PA_CAP_CONCENTRATION_ENABLED", True)
     pas_ref_mode_enabled = _env_bool("PA_CAP_INPUT_MODE_PAS_REF_ENABLED", True)
     inline_bundle_mode_enabled = _env_bool("PA_CAP_INPUT_MODE_INLINE_BUNDLE_ENABLED", True)
 
@@ -95,18 +93,6 @@ async def get_integration_capabilities(
             description="Attribution analytics APIs.",
         ),
         FeatureCapability(
-            key="pa.analytics.risk",
-            enabled=risk_enabled,
-            owner_service="PA",
-            description="Risk analytics APIs.",
-        ),
-        FeatureCapability(
-            key="pa.analytics.concentration",
-            enabled=concentration_enabled,
-            owner_service="PA",
-            description="Concentration analytics APIs.",
-        ),
-        FeatureCapability(
             key="pa.execution.stateful_pas_ref",
             enabled=pas_ref_mode_enabled,
             owner_service="PA",
@@ -133,11 +119,9 @@ async def get_integration_capabilities(
         ),
         WorkflowCapability(
             workflow_key="workbench_analytics",
-            enabled=risk_enabled and concentration_enabled and twr_enabled,
+            enabled=twr_enabled,
             required_features=[
                 "pa.analytics.twr",
-                "pa.analytics.risk",
-                "pa.analytics.concentration",
             ],
         ),
         WorkflowCapability(
@@ -160,7 +144,7 @@ async def get_integration_capabilities(
 
     return IntegrationCapabilitiesResponse(
         contractVersion="v1",
-        sourceService="performance-analytics",
+        sourceService="lotus-performance",
         consumerSystem=consumer_system,
         tenantId=tenant_id,
         generatedAt=datetime.now(UTC),

--- a/app/enterprise_readiness.py
+++ b/app/enterprise_readiness.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 
 logger = logging.getLogger("enterprise_readiness")
 
-_SERVICE_NAME = "performance-analytics"
+_SERVICE_NAME = "lotus-performance"
 _WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 _REQUIRED_HEADERS = {"x-actor-id", "x-tenant-id", "x-role", "x-correlation-id"}
 _REDACT_FIELDS = {

--- a/app/models/pas_connected_responses.py
+++ b/app/models/pas_connected_responses.py
@@ -21,7 +21,7 @@ class PasConnectedTwrResponse(BaseModel):
     )
     as_of_date: date
     source_mode: Literal["pas_ref"] = "pas_ref"
-    source_service: str = "performance-analytics"
+    source_service: str = "lotus-performance"
     pas_contract_version: str = Field(..., alias="pasContractVersion")
     consumer_system: str | None = Field(default=None, alias="consumerSystem")
     results_by_period: dict[str, PasConnectedPeriodResult] = Field(alias="resultsByPeriod")

--- a/app/models/positions_analytics_responses.py
+++ b/app/models/positions_analytics_responses.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 class PositionAnalyticsResponse(BaseModel):
     source_mode: str = "pas_ref"
-    source_service: str = "performance-analytics"
+    source_service: str = "lotus-performance"
     portfolio_id: str = Field(..., alias="portfolioId")
     as_of_date: date = Field(..., alias="asOfDate")
     total_market_value: float = Field(..., alias="totalMarketValue")
@@ -19,7 +19,7 @@ class PositionAnalyticsResponse(BaseModel):
         "json_schema_extra": {
             "example": {
                 "source_mode": "pas_ref",
-                "source_service": "performance-analytics",
+                "source_service": "lotus-performance",
                 "portfolioId": "DEMO_DPM_EUR_001",
                 "asOfDate": "2026-02-24",
                 "totalMarketValue": 1250000.0,

--- a/app/models/workbench_analytics_responses.py
+++ b/app/models/workbench_analytics_responses.py
@@ -32,7 +32,7 @@ class WorkbenchRiskProxy(BaseModel):
 
 class WorkbenchAnalyticsResponse(BaseModel):
     source_mode: str = "pa_calc"
-    source_service: str = Field("performance-analytics", alias="sourceService")
+    source_service: str = Field("lotus-performance", alias="sourceService")
     portfolio_id: str = Field(alias="portfolioId")
     period: str
     group_by: str = Field(alias="groupBy")

--- a/app/observability.py
+++ b/app/observability.py
@@ -19,7 +19,7 @@ class JsonFormatter(logging.Formatter):
         payload = {
             "timestamp": datetime.now(UTC).isoformat(),
             "level": record.levelname,
-            "service": os.getenv("SERVICE_NAME", "performance-analytics"),
+            "service": os.getenv("SERVICE_NAME", "lotus-performance"),
             "environment": os.getenv("ENVIRONMENT", "local"),
             "logger": record.name,
             "message": record.getMessage(),

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -16,7 +16,7 @@ def test_e2e_platform_readiness_and_capabilities_contract() -> None:
 
     body = capabilities.json()
     assert body["contractVersion"] == "v1"
-    assert body["sourceService"] == "performance-analytics"
+    assert body["sourceService"] == "lotus-performance"
     assert "pas_ref" in body["supportedInputModes"]
     assert "inline_bundle" in body["supportedInputModes"]
 

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -10,15 +10,13 @@ def test_integration_capabilities_default_contract():
     assert response.status_code == 200
     body = response.json()
     assert body["contractVersion"] == "v1"
-    assert body["sourceService"] == "performance-analytics"
+    assert body["sourceService"] == "lotus-performance"
     assert body["consumerSystem"] == "BFF"
     assert body["tenantId"] == "default"
     assert body["supportedInputModes"] == ["pas_ref", "inline_bundle"]
-    assert len(body["features"]) >= 6
+    assert len(body["features"]) >= 4
     assert len(body["workflows"]) >= 3
     features = {item["key"] for item in body["features"]}
-    assert "pa.analytics.risk" in features
-    assert "pa.analytics.concentration" in features
     assert "pa.execution.stateful_pas_ref" in features
     assert "pa.execution.stateless_inline_bundle" in features
     assert response.headers.get("X-Correlation-Id")


### PR DESCRIPTION
## Summary\n- remove risk/concentration claims from lotus-performance capabilities\n- keep workbench workflow keyed to performance outputs only\n- normalize service naming to lotus-performance across models/observability/readiness\n- update integration/e2e tests\n\n## Why\n- enforce bounded-context ownership between lotus-performance and lotus-risk\n