### PR TITLE
Patch-level dependency refresh for lotus-performance

### DIFF
--- a/app/enterprise_readiness.py
+++ b/app/enterprise_readiness.py
@@ -158,9 +158,9 @@ def emit_audit_event(
     )
 
 
-def build_enterprise_audit_middleware() -> Callable[
-    [Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]
-]:
+def build_enterprise_audit_middleware() -> (
+    Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]
+):
     async def middleware(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
         max_write_payload_bytes = _env_int("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", 1_048_576)
         try:


### PR DESCRIPTION
## Summary
- bump low-risk patch versions in equirements.txt:
  - certifi 2025.8.3 -> 2026.2.25
  - pytest-mock 3.15.0 -> 3.15.1
  - 	zdata 2025.2 -> 2025.3
- normalize pp/enterprise_readiness.py formatting for current ruff parity used by CI/preflight

## Validation
- external isolated env install: C:/Users/Sandeep/venvs/lotus-performance-depslice
- full gate: make ci-local (pass)
  - lint/typecheck pass
  - unit/integration/e2e pass
  - coverage report: 99%+ (reported 99% with 1 missed line)
  - pip check pass in isolated env
- platform preflight: utomation/Preflight-PR.ps1 -Repo lotus-performance -Mode fast (pass)

## Notes
- Used isolated venv intentionally to avoid cross-repo package conflicts in shared user site-packages.