### PR TITLE
feat(observability): align access logs with duration contract

### DIFF
--- a/tests/integration/test_observability_runtime_contract.py
+++ b/tests/integration/test_observability_runtime_contract.py
@@ -1,0 +1,27 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+def test_health_request_emits_duration_log_and_propagates_correlation_headers(caplog):
+    with caplog.at_level(logging.INFO, logger="http.access"):
+        with TestClient(app) as client:
+            response = client.get("/health", headers={"X-Correlation-Id": "corr-runtime-1"})
+
+    assert response.status_code == 200
+    assert response.headers.get("X-Correlation-Id") == "corr-runtime-1"
+    assert response.headers.get("X-Request-Id")
+    assert response.headers.get("X-Trace-Id")
+
+    matching = [
+        record
+        for record in caplog.records
+        if record.name == "http.access" and record.getMessage() == "request.completed"
+    ]
+    assert matching
+    fields = getattr(matching[-1], "extra_fields", {})
+    assert fields["endpoint"] == "/health"
+    assert fields["http_method"] == "GET"
+    assert fields["duration_ms"] >= 0


### PR DESCRIPTION
## Summary
- refactor observability access-log field assembly into build_access_log_fields
- emit duration_ms in runtime access logs to satisfy Lotus platform observability contract
- retain legacy latency_ms key for compatibility
- add integration regression test validating correlation header propagation and duration-bearing access log fields
- extend unit tests for formatter payload and access-log field construction

## Compliance Measurement
- QA before change (Invoke-Platform-QA.ps1 -Repo lotus-performance -BringUp): 1 finding (logs-pattern-duration)
- QA after change (Invoke-Platform-QA.ps1 -Repo lotus-performance -BringUp): 0 findings

## Validation
- make ci-local
- Preflight-PR.ps1 -Repo lotus-performance -Mode fast
- Invoke-Platform-QA.ps1 -Repo lotus-performance -BringUp