### PR TITLE
feat(rfc-0067): implement API vocabulary and no-alias governance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install check check-all test test-unit test-integration test-e2e test-all ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate migration-smoke migration-apply pre-commit docker-up docker-down docker-build
+.PHONY: install check check-all test test-unit test-integration test-e2e test-all ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate api-vocabulary-gate no-alias-gate migration-smoke migration-apply pre-commit docker-up docker-down docker-build
 
 install:
 	pip install -r requirements.txt
@@ -9,9 +9,9 @@ install:
 pre-commit:
 	pre-commit run --all-files
 
-check: lint typecheck openapi-gate test
+check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate test
 
-ci: lint typecheck openapi-gate migration-smoke test-all security-audit
+ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate migration-smoke test-all security-audit
 
 test:
 	$(MAKE) test-unit
@@ -50,6 +50,12 @@ typecheck:
 
 openapi-gate:
 	python scripts/openapi_quality_gate.py
+
+api-vocabulary-gate:
+	python scripts/api_vocabulary_inventory.py --validate-only
+
+no-alias-gate:
+	python scripts/no_alias_contract_guard.py
 
 migration-smoke:
 	python scripts/migration_contract_check.py --mode no-schema

--- a/app/api/endpoints/analytics.py
+++ b/app/api/endpoints/analytics.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import APIRouter, HTTPException, status
 
 from app.core.config import get_settings
@@ -7,6 +9,12 @@ from app.services.pas_input_service import PasInputService
 
 router = APIRouter(tags=["Analytics"])
 settings = get_settings()
+
+
+def _pick(payload: dict[str, Any], snake_key: str, camel_key: str) -> Any:
+    if snake_key in payload:
+        return payload[snake_key]
+    return payload[camel_key]
 
 
 @router.post(
@@ -41,10 +49,13 @@ async def get_positions_analytics(request: PositionAnalyticsRequest):
         raise HTTPException(status_code=status_code, detail=str(payload))
 
     try:
+        portfolio_id = _pick(payload, "portfolio_id", "portfolioId")
+        as_of_date = _pick(payload, "as_of_date", "asOfDate")
+        total_market_value = _pick(payload, "total_market_value", "totalMarketValue")
         return PositionAnalyticsResponse(
-            portfolioId=payload["portfolioId"],
-            asOfDate=payload["asOfDate"],
-            totalMarketValue=payload["totalMarketValue"],
+            portfolio_id=portfolio_id,
+            as_of_date=as_of_date,
+            total_market_value=total_market_value,
             positions=payload.get("positions", []),
         )
     except KeyError as exc:

--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -27,21 +27,18 @@ class WorkflowCapability(BaseModel):
 
 
 class IntegrationCapabilitiesResponse(BaseModel):
-    contract_version: str = Field(alias="contractVersion")
-    source_service: str = Field(alias="sourceService")
-    consumer_system: ConsumerSystem = Field(alias="consumerSystem")
-    tenant_id: str = Field(alias="tenantId")
-    generated_at: datetime = Field(alias="generatedAt")
-    as_of_date: date = Field(alias="asOfDate")
-    policy_version: str = Field(alias="policyVersion")
+    contract_version: str
+    source_service: str
+    consumer_system: ConsumerSystem
+    tenant_id: str
+    generated_at: datetime
+    as_of_date: date
+    policy_version: str
     supported_input_modes: list[str] = Field(
-        alias="supportedInputModes",
         description="Supported execution input modes: core_api_ref (lotus-core API-backed) and inline_bundle (stateless payload).",
     )
     features: list[FeatureCapability]
     workflows: list[WorkflowCapability]
-
-    model_config = {"populate_by_name": True}
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -60,10 +57,10 @@ def _env_bool(name: str, default: bool) -> bool:
     ),
 )
 async def get_integration_capabilities(
-    consumer_system: ConsumerSystem = Query("lotus-gateway", alias="consumerSystem"),
-    tenant_id: str = Query("default", alias="tenantId"),
-    feature_limit: int = Query(default=100, ge=1, le=500, alias="featureLimit"),
-    workflow_limit: int = Query(default=50, ge=1, le=200, alias="workflowLimit"),
+    consumer_system: ConsumerSystem = Query("lotus-gateway"),
+    tenant_id: str = Query("default"),
+    feature_limit: int = Query(default=100, ge=1, le=500),
+    workflow_limit: int = Query(default=50, ge=1, le=200),
 ) -> IntegrationCapabilitiesResponse:
     twr_enabled = _env_bool("PA_CAP_TWR_ENABLED", True)
     mwr_enabled = _env_bool("PA_CAP_MWR_ENABLED", True)
@@ -141,14 +138,14 @@ async def get_integration_capabilities(
         supported_input_modes.append("inline_bundle")
 
     return IntegrationCapabilitiesResponse(
-        contractVersion="v1",
-        sourceService="lotus-performance",
-        consumerSystem=consumer_system,
-        tenantId=tenant_id,
-        generatedAt=datetime.now(UTC),
-        asOfDate=date.today(),
-        policyVersion=os.getenv("PA_POLICY_VERSION", "tenant-default-v1"),
-        supportedInputModes=supported_input_modes,
+        contract_version="v1",
+        source_service="lotus-performance",
+        consumer_system=consumer_system,
+        tenant_id=tenant_id,
+        generated_at=datetime.now(UTC),
+        as_of_date=date.today(),
+        policy_version=os.getenv("PA_POLICY_VERSION", "tenant-default-v1"),
+        supported_input_modes=supported_input_modes,
         features=features[:feature_limit],
         workflows=workflows[:workflow_limit],
     )

--- a/app/api/endpoints/performance.py
+++ b/app/api/endpoints/performance.py
@@ -160,18 +160,20 @@ async def calculate_twr_from_pas_input(request: PasInputTwrRequest):
     if upstream_status >= status.HTTP_400_BAD_REQUEST:
         raise HTTPException(status_code=upstream_status, detail=str(upstream_payload))
 
-    valuation_points = upstream_payload.get("valuationPoints")
+    valuation_points = upstream_payload.get("valuation_points", upstream_payload.get("valuationPoints"))
     if not isinstance(valuation_points, list) or not valuation_points:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Invalid lotus-core performance input payload: missing valuationPoints.",
+            detail="Invalid lotus-core performance input payload: missing valuation_points.",
         )
 
-    performance_start_date = upstream_payload.get("performanceStartDate")
+    performance_start_date = upstream_payload.get(
+        "performance_start_date", upstream_payload.get("performanceStartDate")
+    )
     if not isinstance(performance_start_date, str):
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Invalid lotus-core performance input payload: missing performanceStartDate.",
+            detail="Invalid lotus-core performance input payload: missing performance_start_date.",
         )
 
     requested_periods = request.periods or ["YTD"]
@@ -179,7 +181,9 @@ async def calculate_twr_from_pas_input(request: PasInputTwrRequest):
     try:
         performance_request = PerformanceRequest.model_validate(
             {
-                "portfolio_id": upstream_payload.get("portfolioId", request.portfolio_id),
+                "portfolio_id": upstream_payload.get(
+                    "portfolio_id", upstream_payload.get("portfolioId", request.portfolio_id)
+                ),
                 "performance_start_date": performance_start_date,
                 "metric_basis": "NET",
                 "report_end_date": str(request.as_of_date),
@@ -222,9 +226,11 @@ async def calculate_twr_from_pas_input(request: PasInputTwrRequest):
     return PasInputTwrResponse(
         portfolio_id=performance_request.portfolio_id,
         as_of_date=request.as_of_date,
-        pasContractVersion=upstream_payload.get("contractVersion", "v1"),
-        consumerSystem=upstream_payload.get("consumerSystem", request.consumer_system),
-        resultsByPeriod=results_by_period,
+        pas_contract_version=upstream_payload.get(
+            "pas_contract_version", upstream_payload.get("contractVersion", "v1")
+        ),
+        consumer_system=upstream_payload.get("consumer_system", request.consumer_system),
+        results_by_period=results_by_period,
     )
 
 

--- a/app/models/mwr_responses.py
+++ b/app/models/mwr_responses.py
@@ -3,7 +3,7 @@ from datetime import date
 from typing import List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 from app.models.mwr_requests import CashFlow
 from core.envelope import Audit, Diagnostics, Meta
@@ -29,8 +29,6 @@ class MWRResult(BaseModel):
 
 class MoneyWeightedReturnResponse(BaseModel):
     """Response model for a Money-Weighted Return calculation."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     calculation_id: UUID
     portfolio_id: str

--- a/app/models/pas_connected_requests.py
+++ b/app/models/pas_connected_requests.py
@@ -6,13 +6,11 @@ from pydantic import BaseModel, Field
 class PasInputTwrRequest(BaseModel):
     portfolio_id: str = Field(
         ...,
-        alias="portfolioId",
         description="Portfolio identifier in lotus-core.",
         examples=["DEMO_DPM_EUR_001"],
     )
     as_of_date: date = Field(
         ...,
-        alias="asOfDate",
         description="Business date for lotus-core core snapshot retrieval.",
         examples=["2026-02-24"],
     )
@@ -23,7 +21,6 @@ class PasInputTwrRequest(BaseModel):
     )
     consumer_system: str = Field(
         default="lotus-performance",
-        alias="consumerSystem",
         description="Consumer system identifier forwarded to lotus-core integration contract.",
         examples=["lotus-gateway"],
     )
@@ -31,20 +28,18 @@ class PasInputTwrRequest(BaseModel):
         400,
         ge=30,
         le=2000,
-        alias="lookbackDays",
         description="Maximum days of lotus-core raw valuation history requested for lotus-performance calculation.",
         examples=[400],
     )
 
     model_config = {
-        "populate_by_name": True,
         "json_schema_extra": {
             "example": {
-                "portfolioId": "DEMO_DPM_EUR_001",
-                "asOfDate": "2026-02-24",
+                "portfolio_id": "DEMO_DPM_EUR_001",
+                "as_of_date": "2026-02-24",
                 "periods": ["YTD"],
-                "consumerSystem": "lotus-gateway",
-                "lookbackDays": 400,
+                "consumer_system": "lotus-gateway",
+                "lookback_days": 400,
             }
         },
     }

--- a/app/models/pas_connected_responses.py
+++ b/app/models/pas_connected_responses.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Literal
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import BaseModel
 
 
 class PasConnectedPeriodResult(BaseModel):
@@ -15,18 +15,13 @@ class PasConnectedPeriodResult(BaseModel):
 
 
 class PasConnectedTwrResponse(BaseModel):
-    portfolio_id: str = Field(
-        validation_alias=AliasChoices("portfolio_id", "portfolioId"),
-        serialization_alias="portfolio_id",
-    )
+    portfolio_id: str
     as_of_date: date
     source_mode: Literal["core_api_ref"] = "core_api_ref"
     source_service: str = "lotus-performance"
-    pas_contract_version: str = Field(..., alias="pasContractVersion")
-    consumer_system: str | None = Field(default=None, alias="consumerSystem")
-    results_by_period: dict[str, PasConnectedPeriodResult] = Field(alias="resultsByPeriod")
-
-    model_config = {"populate_by_name": True}
+    pas_contract_version: str
+    consumer_system: str | None = None
+    results_by_period: dict[str, PasConnectedPeriodResult]
 
 
 PasInputPeriodResult = PasConnectedPeriodResult

--- a/app/models/positions_analytics_requests.py
+++ b/app/models/positions_analytics_requests.py
@@ -5,26 +5,24 @@ from pydantic import BaseModel, Field
 
 
 class PositionAnalyticsRequest(BaseModel):
-    portfolio_id: str = Field(..., alias="portfolioId", examples=["DEMO_DPM_EUR_001"])
-    as_of_date: date = Field(..., alias="asOfDate", examples=["2026-02-24"])
+    portfolio_id: str = Field(..., examples=["DEMO_DPM_EUR_001"])
+    as_of_date: date = Field(..., examples=["2026-02-24"])
     sections: list[str] = Field(
         default_factory=lambda: ["BASE", "INSTRUMENT_DETAILS", "VALUATION", "INCOME", "PERFORMANCE"]
     )
     performance_periods: list[Literal["MTD", "QTD", "YTD", "ONE_YEAR", "SI"]] | None = Field(
         default=None,
-        alias="performancePeriods",
     )
-    consumer_system: str = Field("lotus-performance", alias="consumerSystem", examples=["lotus-gateway"])
+    consumer_system: str = Field("lotus-performance", examples=["lotus-gateway"])
 
     model_config = {
-        "populate_by_name": True,
         "json_schema_extra": {
             "example": {
-                "portfolioId": "DEMO_DPM_EUR_001",
-                "asOfDate": "2026-02-24",
+                "portfolio_id": "DEMO_DPM_EUR_001",
+                "as_of_date": "2026-02-24",
                 "sections": ["BASE", "INSTRUMENT_DETAILS", "VALUATION", "PERFORMANCE"],
-                "performancePeriods": ["YTD", "MTD"],
-                "consumerSystem": "lotus-gateway",
+                "performance_periods": ["YTD", "MTD"],
+                "consumer_system": "lotus-gateway",
             }
         },
     }

--- a/app/models/positions_analytics_responses.py
+++ b/app/models/positions_analytics_responses.py
@@ -6,23 +6,22 @@ from pydantic import BaseModel, Field
 class PositionAnalyticsResponse(BaseModel):
     source_mode: str = "core_api_ref"
     source_service: str = "lotus-performance"
-    portfolio_id: str = Field(..., alias="portfolioId")
-    as_of_date: date = Field(..., alias="asOfDate")
-    total_market_value: float = Field(..., alias="totalMarketValue")
+    portfolio_id: str
+    as_of_date: date
+    total_market_value: float
     positions: list[dict] = Field(
         ...,
         description="Position-level analytics rows normalized under lotus-performance contract.",
     )
 
     model_config = {
-        "populate_by_name": True,
         "json_schema_extra": {
             "example": {
                 "source_mode": "core_api_ref",
                 "source_service": "lotus-performance",
-                "portfolioId": "DEMO_DPM_EUR_001",
-                "asOfDate": "2026-02-24",
-                "totalMarketValue": 1250000.0,
+                "portfolio_id": "DEMO_DPM_EUR_001",
+                "as_of_date": "2026-02-24",
+                "total_market_value": 1250000.0,
                 "positions": [{"securityId": "EQ_1", "quantity": 100.0}],
             }
         },

--- a/app/models/responses.py
+++ b/app/models/responses.py
@@ -12,8 +12,6 @@ from core.envelope import Audit, Diagnostics, Meta
 class PerformanceSummary(BaseModel):
     """A summary of performance for a given period (day, month, etc.)."""
 
-    model_config = ConfigDict(populate_by_name=True)
-
     begin_mv: float
     end_mv: float
     net_cash_flow: float

--- a/app/openapi_enrichment.py
+++ b/app/openapi_enrichment.py
@@ -1,0 +1,160 @@
+"""OpenAPI enrichment helpers for RFC-0067 documentation completeness."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+ALLOWED_METHODS = {"get", "post", "put", "patch", "delete"}
+
+EXAMPLE_BY_KEY = {
+    "portfolio_id": "DEMO_DPM_EUR_001",
+    "session_id": "SIM_0001",
+    "calculation_id": "CALC_0001",
+    "request_id": "REQ_0001",
+    "correlation_id": "corr_123456789abc",
+    "trace_id": "0123456789abcdef0123456789abcdef",
+    "tenant_id": "default",
+    "consumer_system": "lotus-gateway",
+    "policy_version": "tenant-default-v1",
+    "contract_version": "v1",
+    "source_service": "lotus-performance",
+    "as_of_date": "2026-02-27",
+    "report_start_date": "2026-01-01",
+    "report_end_date": "2026-01-31",
+    "generated_at": "2026-02-27T10:30:00Z",
+    "status": "ok",
+    "currency": "USD",
+    "base_currency": "USD",
+}
+
+
+def _to_snake_case(value: str) -> str:
+    transformed = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    transformed = transformed.replace("-", "_").replace(" ", "_").replace(".", "_")
+    return transformed.strip("_").lower()
+
+
+def _humanize(value: str) -> str:
+    return _to_snake_case(value).replace("_", " ").strip()
+
+
+def _infer_example(prop_name: str, prop_schema: dict[str, Any]) -> Any:
+    key = _to_snake_case(prop_name)
+    if key in EXAMPLE_BY_KEY:
+        return EXAMPLE_BY_KEY[key]
+
+    enum_values = prop_schema.get("enum")
+    if isinstance(enum_values, list) and enum_values:
+        return enum_values[0]
+
+    schema_type = prop_schema.get("type")
+    schema_format = prop_schema.get("format")
+    if schema_type == "array":
+        item_schema = prop_schema.get("items", {})
+        if isinstance(item_schema, dict):
+            return [_infer_example(f"{prop_name}_item", item_schema)]
+        return ["VALUE"]
+    if schema_type == "object":
+        return {"key": "value"}
+    if schema_type == "boolean":
+        return True
+    if schema_type == "integer":
+        return 1
+    if schema_type == "number":
+        return 0.1234
+    if schema_format == "date":
+        return "2026-02-27"
+    if schema_format == "date-time":
+        return "2026-02-27T10:30:00Z"
+    if key.endswith("_id"):
+        return f"{key[:-3].upper()}_001"
+    if "date" in key:
+        return "2026-02-27"
+    if "time" in key or "timestamp" in key:
+        return "2026-02-27T10:30:00Z"
+    if "currency" in key:
+        return "USD"
+    return f"example_{key}"
+
+
+def _infer_description(model_name: str, prop_name: str, prop_schema: dict[str, Any]) -> str:
+    key = _to_snake_case(prop_name)
+    text = _humanize(prop_name)
+    if key.endswith("_id"):
+        entity = key[: -len("_id")].replace("_", " ")
+        return f"Unique {entity} identifier."
+    if prop_schema.get("format") == "date":
+        return f"Business date for {text}."
+    if prop_schema.get("format") == "date-time":
+        return f"Timestamp for {text}."
+    if "currency" in key:
+        return f"ISO currency code for {text}."
+    if "return" in key or "rate" in key or "performance" in key:
+        return f"Performance metric value for {text}."
+    if "amount" in key or "value" in key:
+        return f"Monetary value for {text}."
+    return f"{_humanize(model_name)} field: {text}."
+
+
+def _ensure_operation_documentation(schema: dict[str, Any]) -> None:
+    paths = schema.get("paths", {})
+    if not isinstance(paths, dict):
+        return
+    for path, methods in paths.items():
+        if not isinstance(methods, dict):
+            continue
+        for method, operation in methods.items():
+            if method.lower() not in ALLOWED_METHODS:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            if not operation.get("summary"):
+                operation["summary"] = f"{method.upper()} {path}"
+            if not operation.get("description"):
+                operation["description"] = f"{method.upper()} operation for {path} in lotus-performance."
+            if not operation.get("tags"):
+                if path.startswith("/health"):
+                    operation["tags"] = ["Health"]
+                elif path == "/metrics":
+                    operation["tags"] = ["Monitoring"]
+                else:
+                    segment = path.strip("/").split("/", 1)[0] or "default"
+                    operation["tags"] = [segment.replace("-", " ").title()]
+            responses = operation.get("responses")
+            if isinstance(responses, dict):
+                has_error = any(
+                    str(code).startswith("4") or str(code).startswith("5") or str(code) == "default"
+                    for code in responses
+                )
+                if not has_error:
+                    responses["default"] = {"description": "Unexpected error response."}
+
+
+def _ensure_schema_documentation(schema: dict[str, Any]) -> None:
+    components = schema.get("components", {})
+    if not isinstance(components, dict):
+        return
+    schemas = components.get("schemas", {})
+    if not isinstance(schemas, dict):
+        return
+    for model_name, model_schema in schemas.items():
+        if not isinstance(model_schema, dict):
+            continue
+        properties = model_schema.get("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        for prop_name, prop_schema in properties.items():
+            if not isinstance(prop_schema, dict):
+                continue
+            if not prop_schema.get("description"):
+                prop_schema["description"] = _infer_description(model_name, prop_name, prop_schema)
+            if "example" not in prop_schema and "examples" not in prop_schema:
+                prop_schema["example"] = _infer_example(prop_name, prop_schema)
+
+
+def enrich_openapi_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Mutates OpenAPI schema to meet RFC-0067 metadata minimums."""
+    _ensure_operation_documentation(schema)
+    _ensure_schema_documentation(schema)
+    return schema

--- a/app/services/pas_input_service.py
+++ b/app/services/pas_input_service.py
@@ -29,9 +29,9 @@ class PasInputService:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/integration/portfolios/{portfolio_id}/core-snapshot"
         payload = {
-            "asOfDate": str(as_of_date),
-            "includeSections": include_sections,
-            "consumerSystem": consumer_system,
+            "as_of_date": str(as_of_date),
+            "include_sections": include_sections,
+            "consumer_system": consumer_system,
         }
         headers = propagation_headers()
         return await post_with_retry(
@@ -55,9 +55,9 @@ class PasInputService:
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/integration/portfolios/{portfolio_id}/performance-input"
         payload = {
-            "asOfDate": str(as_of_date),
-            "lookbackDays": lookback_days,
-            "consumerSystem": consumer_system,
+            "as_of_date": str(as_of_date),
+            "lookback_days": lookback_days,
+            "consumer_system": consumer_system,
         }
         headers = propagation_headers()
         return await post_with_retry(
@@ -77,9 +77,9 @@ class PasInputService:
         performance_periods: list[str] | None,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/portfolios/{portfolio_id}/positions-analytics"
-        payload: dict[str, Any] = {"asOfDate": str(as_of_date), "sections": sections}
+        payload: dict[str, Any] = {"as_of_date": str(as_of_date), "sections": sections}
         if performance_periods:
-            payload["performanceOptions"] = {"periods": performance_periods}
+            payload["performance_options"] = {"periods": performance_periods}
         headers = propagation_headers()
         return await post_with_retry(
             url=url,

--- a/docs/standards/api-vocabulary/README.md
+++ b/docs/standards/api-vocabulary/README.md
@@ -1,0 +1,22 @@
+# lotus-performance API Vocabulary Inventory
+
+This folder stores the generated RFC-0067 API vocabulary inventory for `lotus-performance`.
+
+Regenerate:
+
+```powershell
+python scripts/api_vocabulary_inventory.py `
+  --output docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+```
+
+Validate (CI gate):
+
+```powershell
+python scripts/api_vocabulary_inventory.py --validate-only
+```
+
+The inventory follows the centralized model:
+
+1. `attributeCatalog` contains one canonical definition per semantic attribute.
+2. Endpoint request/response rows contain usage references only (`semanticId`, `attributeRef`).
+3. Alias and legacy terms are rejected by guardrails.

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -1,0 +1,4962 @@
+{
+  "specVersion": "1.0.0",
+  "application": "lotus-performance",
+  "sourceOpenApi": [
+    {
+      "service": "lotus-performance",
+      "version": "0.1.0",
+      "openApiVersion": "3.1.0"
+    }
+  ],
+  "generatedAt": "2026-03-01T03:06:12.655114+00:00",
+  "attributeCatalog": [
+    {
+      "semanticId": "lotus.amount",
+      "canonicalTerm": "amount",
+      "preferredName": "amount",
+      "description": "Monetary value for amount.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.analyses",
+      "canonicalTerm": "analyses",
+      "preferredName": "analyses",
+      "description": "performance request field: analyses.",
+      "example": [
+        "example_analyses_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.annualization",
+      "canonicalTerm": "annualization",
+      "preferredName": "annualization",
+      "description": "Canonical annualization used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Annualization",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Annualization"
+      ]
+    },
+    {
+      "semanticId": "lotus.artifacts",
+      "canonicalTerm": "artifacts",
+      "preferredName": "artifacts",
+      "description": "lineage response field: artifacts.",
+      "example": {
+        "key": "value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.as_of",
+      "canonicalTerm": "as_of",
+      "preferredName": "as_of",
+      "description": "Business date for as of.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.as_of_date",
+      "canonicalTerm": "as_of_date",
+      "preferredName": "as_of_date",
+      "description": "Business date for lotus-core core snapshot retrieval.",
+      "example": "2025-03-31",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.audit",
+      "canonicalTerm": "audit",
+      "preferredName": "audit",
+      "description": "Canonical audit used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Audit",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Audit",
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.basis",
+      "canonicalTerm": "basis",
+      "preferredName": "basis",
+      "description": "The day-count convention to use. BUS/252 for business days; ACT/365 for actual days over 365; ACT/ACT for actual days over actual days in year.",
+      "example": "BUS/252",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.begin_mv",
+      "canonicalTerm": "begin_mv",
+      "preferredName": "begin_mv",
+      "description": "The market value of the portfolio at the beginning of the day, before any cash flows.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.benchmark_groups_data",
+      "canonicalTerm": "benchmark_groups_data",
+      "preferredName": "benchmark_groups_data",
+      "description": "attribution request field: benchmark groups data.",
+      "example": [
+        "example_benchmark_groups_data_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.bod_cf",
+      "canonicalTerm": "bod_cf",
+      "preferredName": "bod_cf",
+      "description": "Cash flow occurring at the beginning of the day (before trading). Positive for inflows, negative for outflows.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.bucketing",
+      "canonicalTerm": "bucketing",
+      "preferredName": "bucketing",
+      "description": "contribution request field: bucketing.",
+      "example": "example_bucketing",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.by_level",
+      "canonicalTerm": "by_level",
+      "preferredName": "by_level",
+      "description": "emit field: by level.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.by_position_timeseries",
+      "canonicalTerm": "by_position_timeseries",
+      "preferredName": "by_position_timeseries",
+      "description": "emit field: by position timeseries.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.calculation_hash",
+      "canonicalTerm": "calculation_hash",
+      "preferredName": "calculation_hash",
+      "description": "meta field: calculation hash.",
+      "example": "example_calculation_hash",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.calculation_id",
+      "canonicalTerm": "calculation_id",
+      "preferredName": "calculation_id",
+      "description": "A unique identifier for the calculation request. If not provided, one will be generated.",
+      "example": "CALC_0001",
+      "type": "string",
+      "locations": [
+        "body",
+        "path"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.calculation_type",
+      "canonicalTerm": "calculation_type",
+      "preferredName": "calculation_type",
+      "description": "lineage response field: calculation type.",
+      "example": "example_calculation_type",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.calendar",
+      "canonicalTerm": "calendar",
+      "preferredName": "calendar",
+      "description": "Canonical calendar used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Calendar",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Calendar"
+      ]
+    },
+    {
+      "semanticId": "lotus.cash_flows",
+      "canonicalTerm": "cash_flows",
+      "preferredName": "cash_flows",
+      "description": "money weighted return request field: cash flows.",
+      "example": [
+        "example_cash_flows_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.cashflows_used",
+      "canonicalTerm": "cashflows_used",
+      "preferredName": "cashflows_used",
+      "description": "money weighted return response field: cashflows used.",
+      "example": "example_cashflows_used",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.consumer_system",
+      "canonicalTerm": "consumer_system",
+      "preferredName": "consumer_system",
+      "description": "Consumer system identifier forwarded to lotus-core integration contract.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body",
+        "query"
+      ],
+      "observedTypes": [
+        "string",
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.contract_version",
+      "canonicalTerm": "contract_version",
+      "preferredName": "contract_version",
+      "description": "integration capabilities response field: contract version.",
+      "example": "v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.convergence",
+      "canonicalTerm": "convergence",
+      "preferredName": "convergence",
+      "description": "money weighted return response field: convergence.",
+      "example": "example_convergence",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.counts",
+      "canonicalTerm": "counts",
+      "preferredName": "counts",
+      "description": "audit field: counts.",
+      "example": {
+        "key": "value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.currency",
+      "canonicalTerm": "currency",
+      "preferredName": "currency",
+      "description": "The three-letter ISO currency code for the request (e.g., 'USD').",
+      "example": "USD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.currency_mode",
+      "canonicalTerm": "currency_mode",
+      "preferredName": "currency_mode",
+      "description": "ISO currency code for currency mode.",
+      "example": "USD",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.data_policy",
+      "canonicalTerm": "data_policy",
+      "preferredName": "data_policy",
+      "description": "performance request field: data policy.",
+      "example": "example_data_policy",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.date",
+      "canonicalTerm": "date",
+      "preferredName": "date",
+      "description": "Business date for date.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.day",
+      "canonicalTerm": "day",
+      "preferredName": "day",
+      "description": "A sequential day number for the record within the request payload.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.description",
+      "canonicalTerm": "description",
+      "preferredName": "description",
+      "description": "Human-readable capability summary.",
+      "example": "example_description",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.diagnostics",
+      "canonicalTerm": "diagnostics",
+      "preferredName": "diagnostics",
+      "description": "Canonical diagnostics used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Diagnostics",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Diagnostics",
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.effective_period_start",
+      "canonicalTerm": "effective_period_start",
+      "preferredName": "effective_period_start",
+      "description": "Business date for effective period start.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.emit",
+      "canonicalTerm": "emit",
+      "preferredName": "emit",
+      "description": "If true, the response will include a list of any performance reset events that occurred.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean",
+        "Emit"
+      ]
+    },
+    {
+      "semanticId": "lotus.emit_cashflows_used",
+      "canonicalTerm": "emit_cashflows_used",
+      "preferredName": "emit_cashflows_used",
+      "description": "money weighted return request field: emit cashflows used.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.enabled",
+      "canonicalTerm": "enabled",
+      "preferredName": "enabled",
+      "description": "Whether to enable the calculation of annualized returns for applicable periods.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.end_date",
+      "canonicalTerm": "end_date",
+      "preferredName": "end_date",
+      "description": "Business date for end date.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.end_mv",
+      "canonicalTerm": "end_mv",
+      "preferredName": "end_mv",
+      "description": "The market value of the portfolio at the end of the day.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.engine_version",
+      "canonicalTerm": "engine_version",
+      "preferredName": "engine_version",
+      "description": "meta field: engine version.",
+      "example": "example_engine_version",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.eod_cf",
+      "canonicalTerm": "eod_cf",
+      "preferredName": "eod_cf",
+      "description": "Cash flow occurring at the end of the day (after trading). Positive for inflows, negative for outflows.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.fail_fast",
+      "canonicalTerm": "fail_fast",
+      "preferredName": "fail_fast",
+      "description": "flags field: fail fast.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.fallback_policy",
+      "canonicalTerm": "fallback_policy",
+      "preferredName": "fallback_policy",
+      "description": "lookthrough field: fallback policy.",
+      "example": "error",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.feature_limit",
+      "canonicalTerm": "feature_limit",
+      "preferredName": "feature_limit",
+      "description": "Canonical feature limit used by lotus-performance APIs.",
+      "example": null,
+      "type": "integer",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.features",
+      "canonicalTerm": "features",
+      "preferredName": "features",
+      "description": "integration capabilities response field: features.",
+      "example": [
+        "example_features_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.fee_effect",
+      "canonicalTerm": "fee_effect",
+      "preferredName": "fee_effect",
+      "description": "Canonical fee effect used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "FeeEffect",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "FeeEffect"
+      ]
+    },
+    {
+      "semanticId": "lotus.flags",
+      "canonicalTerm": "flags",
+      "preferredName": "flags",
+      "description": "Canonical flags used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Flags",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Flags"
+      ]
+    },
+    {
+      "semanticId": "lotus.frequencies",
+      "canonicalTerm": "frequencies",
+      "preferredName": "frequencies",
+      "description": "analysis field: frequencies.",
+      "example": [
+        "example_frequencies_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.frequency",
+      "canonicalTerm": "frequency",
+      "preferredName": "frequency",
+      "description": "Defines the supported frequency types for performance breakdowns.",
+      "example": "daily",
+      "type": "Frequency",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Frequency"
+      ]
+    },
+    {
+      "semanticId": "lotus.fx",
+      "canonicalTerm": "fx",
+      "preferredName": "fx",
+      "description": "performance request field: fx.",
+      "example": "example_fx",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.generated_at",
+      "canonicalTerm": "generated_at",
+      "preferredName": "generated_at",
+      "description": "Timestamp for generated at.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.group_by",
+      "canonicalTerm": "group_by",
+      "preferredName": "group_by",
+      "description": "attribution request field: group by.",
+      "example": [
+        "example_group_by_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.hedging",
+      "canonicalTerm": "hedging",
+      "preferredName": "hedging",
+      "description": "performance request field: hedging.",
+      "example": "example_hedging",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.hierarchy",
+      "canonicalTerm": "hierarchy",
+      "preferredName": "hierarchy",
+      "description": "contribution request field: hierarchy.",
+      "example": "example_hierarchy",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.include_cumulative",
+      "canonicalTerm": "include_cumulative",
+      "preferredName": "include_cumulative",
+      "description": "output field: include cumulative.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.include_other",
+      "canonicalTerm": "include_other",
+      "preferredName": "include_other",
+      "description": "emit field: include other.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.include_timeseries",
+      "canonicalTerm": "include_timeseries",
+      "preferredName": "include_timeseries",
+      "description": "output field: include timeseries.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.include_unclassified",
+      "canonicalTerm": "include_unclassified",
+      "preferredName": "include_unclassified",
+      "description": "emit field: include unclassified.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.input_fingerprint",
+      "canonicalTerm": "input_fingerprint",
+      "preferredName": "input_fingerprint",
+      "description": "meta field: input fingerprint.",
+      "example": "example_input_fingerprint",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.instruments_data",
+      "canonicalTerm": "instruments_data",
+      "preferredName": "instruments_data",
+      "description": "attribution request field: instruments data.",
+      "example": "example_instruments_data",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.key",
+      "canonicalTerm": "key",
+      "preferredName": "key",
+      "description": "benchmark group field: key.",
+      "example": {
+        "key": "value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.linking",
+      "canonicalTerm": "linking",
+      "preferredName": "linking",
+      "description": "Defines the supported methods for linking multi-period attribution effects.",
+      "example": "carino",
+      "type": "LinkingMethod",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "LinkingMethod"
+      ]
+    },
+    {
+      "semanticId": "lotus.lookback_days",
+      "canonicalTerm": "lookback_days",
+      "preferredName": "lookback_days",
+      "description": "Maximum days of lotus-core raw valuation history requested for lotus-performance calculation.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.lookthrough",
+      "canonicalTerm": "lookthrough",
+      "preferredName": "lookthrough",
+      "description": "Canonical lookthrough used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Lookthrough",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Lookthrough"
+      ]
+    },
+    {
+      "semanticId": "lotus.max_iter",
+      "canonicalTerm": "max_iter",
+      "preferredName": "max_iter",
+      "description": "solver field: max iter.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.meta",
+      "canonicalTerm": "meta",
+      "preferredName": "meta",
+      "description": "Canonical meta used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Meta",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Meta",
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.method",
+      "canonicalTerm": "method",
+      "preferredName": "method",
+      "description": "solver field: method.",
+      "example": "example_method",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.metric_basis",
+      "canonicalTerm": "metric_basis",
+      "preferredName": "metric_basis",
+      "description": "Specifies whether to calculate returns 'NET' (after fees) or 'GROSS' (before fees).",
+      "example": "NET",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.mgmt_fees",
+      "canonicalTerm": "mgmt_fees",
+      "preferredName": "mgmt_fees",
+      "description": "Management or other fees charged for the day. Should be a negative value to reduce performance.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.mode",
+      "canonicalTerm": "mode",
+      "preferredName": "mode",
+      "description": "Defines the input modes for the attribution engine.",
+      "example": "by_instrument",
+      "type": "AttributionMode",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "AttributionMode"
+      ]
+    },
+    {
+      "semanticId": "lotus.model",
+      "canonicalTerm": "model",
+      "preferredName": "model",
+      "description": "Defines the supported Brinson-style attribution models.",
+      "example": "BF",
+      "type": "AttributionModel",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "AttributionModel"
+      ]
+    },
+    {
+      "semanticId": "lotus.money_weighted_return",
+      "canonicalTerm": "money_weighted_return",
+      "preferredName": "money_weighted_return",
+      "description": "Performance metric value for money weighted return.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.mwr_annualized",
+      "canonicalTerm": "mwr_annualized",
+      "preferredName": "mwr_annualized",
+      "description": "money weighted return response field: mwr annualized.",
+      "example": "example_mwr_annualized",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.mwr_method",
+      "canonicalTerm": "mwr_method",
+      "preferredName": "mwr_method",
+      "description": "money weighted return request field: mwr method.",
+      "example": "XIRR",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.nip_days",
+      "canonicalTerm": "nip_days",
+      "preferredName": "nip_days",
+      "description": "diagnostics field: nip days.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.notes",
+      "canonicalTerm": "notes",
+      "preferredName": "notes",
+      "description": "diagnostics field: notes.",
+      "example": [
+        "example_notes_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.observations",
+      "canonicalTerm": "observations",
+      "preferredName": "observations",
+      "description": "benchmark group field: observations.",
+      "example": [
+        "example_observations_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.output",
+      "canonicalTerm": "output",
+      "preferredName": "output",
+      "description": "Canonical output used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Output",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Output"
+      ]
+    },
+    {
+      "semanticId": "lotus.owner_service",
+      "canonicalTerm": "owner_service",
+      "preferredName": "owner_service",
+      "description": "Owning service for this feature.",
+      "example": "example_owner_service",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.pas_contract_version",
+      "canonicalTerm": "pas_contract_version",
+      "preferredName": "pas_contract_version",
+      "description": "pas connected twr response field: pas contract version.",
+      "example": "example_pas_contract_version",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.perf_date",
+      "canonicalTerm": "perf_date",
+      "preferredName": "perf_date",
+      "description": "The specific date of the observation in YYYY-MM-DD format.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.performance_periods",
+      "canonicalTerm": "performance_periods",
+      "preferredName": "performance_periods",
+      "description": "Performance metric value for performance periods.",
+      "example": "example_performance_periods",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.performance_start_date",
+      "canonicalTerm": "performance_start_date",
+      "preferredName": "performance_start_date",
+      "description": "The inception date of the portfolio or the earliest date for which performance data is available.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.period",
+      "canonicalTerm": "period",
+      "preferredName": "period",
+      "description": "Defines the supported period types for performance calculation.",
+      "example": "MTD",
+      "type": "PeriodType",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "PeriodType"
+      ]
+    },
+    {
+      "semanticId": "lotus.periods",
+      "canonicalTerm": "periods",
+      "preferredName": "periods",
+      "description": "Optional list of period keys to keep (for example: YTD, MTD).",
+      "example": "STANDARD_VALUE",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.periods_per_year",
+      "canonicalTerm": "periods_per_year",
+      "preferredName": "periods_per_year",
+      "description": "Optional override for the annualization factor (e.g., 252 or 365). If provided, this value is used instead of the 'basis'.",
+      "example": "example_periods_per_year",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.policy",
+      "canonicalTerm": "policy",
+      "preferredName": "policy",
+      "description": "diagnostics field: policy.",
+      "example": "example_policy",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.policy_version",
+      "canonicalTerm": "policy_version",
+      "preferredName": "policy_version",
+      "description": "integration capabilities response field: policy version.",
+      "example": "tenant-default-v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_data",
+      "canonicalTerm": "portfolio_data",
+      "preferredName": "portfolio_data",
+      "description": "attribution request field: portfolio data.",
+      "example": "example_portfolio_data",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "PortfolioData"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_groups_data",
+      "canonicalTerm": "portfolio_groups_data",
+      "preferredName": "portfolio_groups_data",
+      "description": "attribution request field: portfolio groups data.",
+      "example": "example_portfolio_groups_data",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_id",
+      "canonicalTerm": "portfolio_id",
+      "preferredName": "portfolio_id",
+      "description": "Portfolio identifier in lotus-core.",
+      "example": "ENTITY_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.position_id",
+      "canonicalTerm": "position_id",
+      "preferredName": "position_id",
+      "description": "Unique position identifier.",
+      "example": "POSITION_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.positions",
+      "canonicalTerm": "positions",
+      "preferredName": "positions",
+      "description": "Position-level analytics rows normalized under lotus-performance contract.",
+      "example": [
+        {
+          "key": "value"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.positions_data",
+      "canonicalTerm": "positions_data",
+      "preferredName": "positions_data",
+      "description": "contribution request field: positions data.",
+      "example": [
+        "example_positions_data_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.precision_mode",
+      "canonicalTerm": "precision_mode",
+      "preferredName": "precision_mode",
+      "description": "The numerical precision mode for the calculation engine.",
+      "example": "FLOAT64",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.report_ccy",
+      "canonicalTerm": "report_ccy",
+      "preferredName": "report_ccy",
+      "description": "performance request field: report ccy.",
+      "example": "example_report_ccy",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.report_end_date",
+      "canonicalTerm": "report_end_date",
+      "preferredName": "report_end_date",
+      "description": "The final date of the analysis period. Also used as the anchor date for resolving relative periods like YTD.",
+      "example": "2026-01-31",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.report_start_date",
+      "canonicalTerm": "report_start_date",
+      "preferredName": "report_start_date",
+      "description": "The explicit start date for an 'EXPLICIT' period calculation. Ignored for other period types.",
+      "example": "2026-01-01",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.required_features",
+      "canonicalTerm": "required_features",
+      "preferredName": "required_features",
+      "description": "Feature keys required for this workflow.",
+      "example": [
+        "example_required_features_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.reset_days",
+      "canonicalTerm": "reset_days",
+      "preferredName": "reset_days",
+      "description": "diagnostics field: reset days.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.reset_policy",
+      "canonicalTerm": "reset_policy",
+      "preferredName": "reset_policy",
+      "description": "Canonical reset policy used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "ResetPolicy",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "ResetPolicy"
+      ]
+    },
+    {
+      "semanticId": "lotus.residual_applied_bp",
+      "canonicalTerm": "residual_applied_bp",
+      "preferredName": "residual_applied_bp",
+      "description": "audit field: residual applied bp.",
+      "example": "example_residual_applied_bp",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.residual_per_position",
+      "canonicalTerm": "residual_per_position",
+      "preferredName": "residual_per_position",
+      "description": "emit field: residual per position.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.results_by_period",
+      "canonicalTerm": "results_by_period",
+      "preferredName": "results_by_period",
+      "description": "pas connected twr response field: results by period.",
+      "example": {
+        "key": "value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.return_base",
+      "canonicalTerm": "return_base",
+      "preferredName": "return_base",
+      "description": "Performance metric value for return base.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.return_fx",
+      "canonicalTerm": "return_fx",
+      "preferredName": "return_fx",
+      "description": "Performance metric value for return fx.",
+      "example": "example_return_fx",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.return_local",
+      "canonicalTerm": "return_local",
+      "preferredName": "return_local",
+      "description": "Performance metric value for return local.",
+      "example": "example_return_local",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.rounding_precision",
+      "canonicalTerm": "rounding_precision",
+      "preferredName": "rounding_precision",
+      "description": "The number of decimal places to round final float results to.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.samples",
+      "canonicalTerm": "samples",
+      "preferredName": "samples",
+      "description": "diagnostics field: samples.",
+      "example": "example_samples",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.sections",
+      "canonicalTerm": "sections",
+      "preferredName": "sections",
+      "description": "position analytics request field: sections.",
+      "example": [
+        "example_sections_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.smoothing",
+      "canonicalTerm": "smoothing",
+      "preferredName": "smoothing",
+      "description": "Canonical smoothing used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Smoothing",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Smoothing"
+      ]
+    },
+    {
+      "semanticId": "lotus.solver",
+      "canonicalTerm": "solver",
+      "preferredName": "solver",
+      "description": "Canonical solver used by lotus-performance APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "Solver",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "Solver"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_mode",
+      "canonicalTerm": "source_mode",
+      "preferredName": "source_mode",
+      "description": "pas connected twr response field: source mode.",
+      "example": "example_source_mode",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_service",
+      "canonicalTerm": "source_service",
+      "preferredName": "source_service",
+      "description": "pas connected twr response field: source service.",
+      "example": "lotus-performance",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.start_date",
+      "canonicalTerm": "start_date",
+      "preferredName": "start_date",
+      "description": "Business date for start date.",
+      "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.sum_of_parts_vs_total_bp",
+      "canonicalTerm": "sum_of_parts_vs_total_bp",
+      "preferredName": "sum_of_parts_vs_total_bp",
+      "description": "audit field: sum of parts vs total bp.",
+      "example": "example_sum_of_parts_vs_total_bp",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.supported_input_modes",
+      "canonicalTerm": "supported_input_modes",
+      "preferredName": "supported_input_modes",
+      "description": "Supported execution input modes: core_api_ref (lotus-core API-backed) and inline_bundle (stateless payload).",
+      "example": [
+        "example_supported_input_modes_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.tenant_id",
+      "canonicalTerm": "tenant_id",
+      "preferredName": "tenant_id",
+      "description": "Canonical tenant id used by lotus-performance APIs.",
+      "example": null,
+      "type": "string",
+      "locations": [
+        "query",
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.threshold_weight",
+      "canonicalTerm": "threshold_weight",
+      "preferredName": "threshold_weight",
+      "description": "emit field: threshold weight.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.timeseries",
+      "canonicalTerm": "timeseries",
+      "preferredName": "timeseries",
+      "description": "emit field: timeseries.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.timestamp_utc",
+      "canonicalTerm": "timestamp_utc",
+      "preferredName": "timestamp_utc",
+      "description": "lineage response field: timestamp utc.",
+      "example": "2026-02-27T10:30:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.tolerance",
+      "canonicalTerm": "tolerance",
+      "preferredName": "tolerance",
+      "description": "solver field: tolerance.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.top_n",
+      "canonicalTerm": "top_n",
+      "preferredName": "top_n",
+      "description": "output field: top n.",
+      "example": "example_top_n",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.top_n_per_level",
+      "canonicalTerm": "top_n_per_level",
+      "preferredName": "top_n_per_level",
+      "description": "emit field: top n per level.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.total_market_value",
+      "canonicalTerm": "total_market_value",
+      "preferredName": "total_market_value",
+      "description": "Monetary value for total market value.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.trading_calendar",
+      "canonicalTerm": "trading_calendar",
+      "preferredName": "trading_calendar",
+      "description": "calendar field: trading calendar.",
+      "example": "example_trading_calendar",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.type",
+      "canonicalTerm": "type",
+      "preferredName": "type",
+      "description": "calendar field: type.",
+      "example": "BUSINESS",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.valuation_points",
+      "canonicalTerm": "valuation_points",
+      "preferredName": "valuation_points",
+      "description": "performance request field: valuation points.",
+      "example": [
+        "example_valuation_points_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.weight_bop",
+      "canonicalTerm": "weight_bop",
+      "preferredName": "weight_bop",
+      "description": "benchmark observation field: weight bop.",
+      "example": 0.1234,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.weighting_scheme",
+      "canonicalTerm": "weighting_scheme",
+      "preferredName": "weighting_scheme",
+      "description": "Defines the supported weighting schemes for contribution analysis.",
+      "example": "BOD",
+      "type": "WeightingScheme",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "WeightingScheme"
+      ]
+    },
+    {
+      "semanticId": "lotus.workflow_key",
+      "canonicalTerm": "workflow_key",
+      "preferredName": "workflow_key",
+      "description": "Workflow key for feature orchestration.",
+      "example": "example_workflow_key",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.workflow_limit",
+      "canonicalTerm": "workflow_limit",
+      "preferredName": "workflow_limit",
+      "description": "Canonical workflow limit used by lotus-performance APIs.",
+      "example": null,
+      "type": "integer",
+      "locations": [
+        "query"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.workflows",
+      "canonicalTerm": "workflows",
+      "preferredName": "workflows",
+      "description": "integration capabilities response field: workflows.",
+      "example": [
+        "example_workflows_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    }
+  ],
+  "controlsCatalog": [
+    {
+      "name": "calculation_id",
+      "kind": "request_option",
+      "location": "path",
+      "required": true,
+      "type": "string",
+      "description": "Canonical calculation id used by lotus-performance APIs.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.calculation_id",
+      "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+    },
+    {
+      "name": "consumer_system",
+      "kind": "request_option",
+      "location": "query",
+      "required": false,
+      "type": "string",
+      "description": "Canonical consumer system used by lotus-performance APIs.",
+      "example": "lotus-gateway",
+      "allowedValues": [
+        "lotus-gateway",
+        "lotus-performance",
+        "lotus-manage",
+        "UI",
+        "UNKNOWN"
+      ],
+      "semanticId": "lotus.consumer_system",
+      "attributeRef": "#/attributeCatalog/lotus.consumer_system"
+    },
+    {
+      "name": "tenant_id",
+      "kind": "request_option",
+      "location": "query",
+      "required": false,
+      "type": "string",
+      "description": "Canonical tenant id used by lotus-performance APIs.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+    },
+    {
+      "name": "feature_limit",
+      "kind": "request_option",
+      "location": "query",
+      "required": false,
+      "type": "integer",
+      "description": "Canonical feature limit used by lotus-performance APIs.",
+      "example": 1,
+      "allowedValues": [],
+      "semanticId": "lotus.feature_limit",
+      "attributeRef": "#/attributeCatalog/lotus.feature_limit"
+    },
+    {
+      "name": "workflow_limit",
+      "kind": "request_option",
+      "location": "query",
+      "required": false,
+      "type": "integer",
+      "description": "Canonical workflow limit used by lotus-performance APIs.",
+      "example": 1,
+      "allowedValues": [],
+      "semanticId": "lotus.workflow_limit",
+      "attributeRef": "#/attributeCatalog/lotus.workflow_limit"
+    }
+  ],
+  "endpoints": [
+    {
+      "domain": "monitoring",
+      "method": "GET",
+      "path": "/metrics",
+      "operationId": "metrics_metrics_get",
+      "summary": "Metrics",
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "fields": []
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "POST",
+      "path": "/performance/twr/pas-input",
+      "operationId": "calculate_twr_from_pas_input_performance_twr_pas_input_post",
+      "summary": "Calculate TWR from lotus-core raw performance input contract",
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "periods",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods",
+            "attributeRef": "#/attributeCatalog/lotus.periods"
+          },
+          {
+            "name": "consumer_system",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "#/attributeCatalog/lotus.consumer_system"
+          },
+          {
+            "name": "lookback_days",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.lookback_days",
+            "attributeRef": "#/attributeCatalog/lotus.lookback_days"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "source_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_mode",
+            "attributeRef": "#/attributeCatalog/lotus.source_mode"
+          },
+          {
+            "name": "source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "pas_contract_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.pas_contract_version",
+            "attributeRef": "#/attributeCatalog/lotus.pas_contract_version"
+          },
+          {
+            "name": "consumer_system",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "#/attributeCatalog/lotus.consumer_system"
+          },
+          {
+            "name": "results_by_period",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.results_by_period",
+            "attributeRef": "#/attributeCatalog/lotus.results_by_period"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "POST",
+      "path": "/performance/twr",
+      "operationId": "calculate_twr_endpoint_performance_twr_post",
+      "summary": "Calculate Time-Weighted Return",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "performance_start_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.performance_start_date",
+            "attributeRef": "#/attributeCatalog/lotus.performance_start_date"
+          },
+          {
+            "name": "metric_basis",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.metric_basis",
+            "attributeRef": "#/attributeCatalog/lotus.metric_basis"
+          },
+          {
+            "name": "report_start_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_start_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_start_date"
+          },
+          {
+            "name": "report_end_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.report_end_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_end_date"
+          },
+          {
+            "name": "analyses",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.analyses",
+            "attributeRef": "#/attributeCatalog/lotus.analyses"
+          },
+          {
+            "name": "analyses[].period",
+            "location": "body",
+            "required": true,
+            "type": "PeriodType",
+            "semanticId": "lotus.period",
+            "attributeRef": "#/attributeCatalog/lotus.period"
+          },
+          {
+            "name": "analyses[].frequencies",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.frequencies",
+            "attributeRef": "#/attributeCatalog/lotus.frequencies"
+          },
+          {
+            "name": "valuation_points",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.valuation_points",
+            "attributeRef": "#/attributeCatalog/lotus.valuation_points"
+          },
+          {
+            "name": "valuation_points[].day",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.day",
+            "attributeRef": "#/attributeCatalog/lotus.day"
+          },
+          {
+            "name": "valuation_points[].perf_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.perf_date",
+            "attributeRef": "#/attributeCatalog/lotus.perf_date"
+          },
+          {
+            "name": "valuation_points[].begin_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.begin_mv",
+            "attributeRef": "#/attributeCatalog/lotus.begin_mv"
+          },
+          {
+            "name": "valuation_points[].bod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.bod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.bod_cf"
+          },
+          {
+            "name": "valuation_points[].eod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.eod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.eod_cf"
+          },
+          {
+            "name": "valuation_points[].mgmt_fees",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.mgmt_fees",
+            "attributeRef": "#/attributeCatalog/lotus.mgmt_fees"
+          },
+          {
+            "name": "valuation_points[].end_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.end_mv",
+            "attributeRef": "#/attributeCatalog/lotus.end_mv"
+          },
+          {
+            "name": "currency",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "#/attributeCatalog/lotus.currency"
+          },
+          {
+            "name": "precision_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "rounding_precision",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.rounding_precision",
+            "attributeRef": "#/attributeCatalog/lotus.rounding_precision"
+          },
+          {
+            "name": "calendar",
+            "location": "body",
+            "required": false,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "annualization",
+            "location": "body",
+            "required": false,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "output",
+            "location": "body",
+            "required": false,
+            "type": "Output",
+            "semanticId": "lotus.output",
+            "attributeRef": "#/attributeCatalog/lotus.output"
+          },
+          {
+            "name": "output.include_timeseries",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_timeseries",
+            "attributeRef": "#/attributeCatalog/lotus.include_timeseries"
+          },
+          {
+            "name": "output.include_cumulative",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_cumulative",
+            "attributeRef": "#/attributeCatalog/lotus.include_cumulative"
+          },
+          {
+            "name": "output.top_n",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.top_n",
+            "attributeRef": "#/attributeCatalog/lotus.top_n"
+          },
+          {
+            "name": "flags",
+            "location": "body",
+            "required": false,
+            "type": "Flags",
+            "semanticId": "lotus.flags",
+            "attributeRef": "#/attributeCatalog/lotus.flags"
+          },
+          {
+            "name": "flags.fail_fast",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.fail_fast",
+            "attributeRef": "#/attributeCatalog/lotus.fail_fast"
+          },
+          {
+            "name": "fee_effect",
+            "location": "body",
+            "required": false,
+            "type": "FeeEffect",
+            "semanticId": "lotus.fee_effect",
+            "attributeRef": "#/attributeCatalog/lotus.fee_effect"
+          },
+          {
+            "name": "fee_effect.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "reset_policy",
+            "location": "body",
+            "required": false,
+            "type": "ResetPolicy",
+            "semanticId": "lotus.reset_policy",
+            "attributeRef": "#/attributeCatalog/lotus.reset_policy"
+          },
+          {
+            "name": "reset_policy.emit",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.emit",
+            "attributeRef": "#/attributeCatalog/lotus.emit"
+          },
+          {
+            "name": "data_policy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.data_policy",
+            "attributeRef": "#/attributeCatalog/lotus.data_policy"
+          },
+          {
+            "name": "currency_mode",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency_mode",
+            "attributeRef": "#/attributeCatalog/lotus.currency_mode"
+          },
+          {
+            "name": "report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "fx",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.fx",
+            "attributeRef": "#/attributeCatalog/lotus.fx"
+          },
+          {
+            "name": "hedging",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.hedging",
+            "attributeRef": "#/attributeCatalog/lotus.hedging"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "results_by_period",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.results_by_period",
+            "attributeRef": "#/attributeCatalog/lotus.results_by_period"
+          },
+          {
+            "name": "meta",
+            "location": "body",
+            "required": true,
+            "type": "Meta",
+            "semanticId": "lotus.meta",
+            "attributeRef": "#/attributeCatalog/lotus.meta"
+          },
+          {
+            "name": "meta.calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "meta.engine_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.engine_version",
+            "attributeRef": "#/attributeCatalog/lotus.engine_version"
+          },
+          {
+            "name": "meta.precision_mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "meta.annualization",
+            "location": "body",
+            "required": true,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "meta.annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "meta.annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "meta.annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "meta.calendar",
+            "location": "body",
+            "required": true,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "meta.calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "meta.calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "meta.periods",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.periods",
+            "attributeRef": "#/attributeCatalog/lotus.periods"
+          },
+          {
+            "name": "meta.input_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.input_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.input_fingerprint"
+          },
+          {
+            "name": "meta.calculation_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.calculation_hash",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_hash"
+          },
+          {
+            "name": "meta.report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "diagnostics",
+            "location": "body",
+            "required": true,
+            "type": "Diagnostics",
+            "semanticId": "lotus.diagnostics",
+            "attributeRef": "#/attributeCatalog/lotus.diagnostics"
+          },
+          {
+            "name": "diagnostics.nip_days",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.nip_days",
+            "attributeRef": "#/attributeCatalog/lotus.nip_days"
+          },
+          {
+            "name": "diagnostics.reset_days",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.reset_days",
+            "attributeRef": "#/attributeCatalog/lotus.reset_days"
+          },
+          {
+            "name": "diagnostics.effective_period_start",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.effective_period_start",
+            "attributeRef": "#/attributeCatalog/lotus.effective_period_start"
+          },
+          {
+            "name": "diagnostics.notes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.notes",
+            "attributeRef": "#/attributeCatalog/lotus.notes"
+          },
+          {
+            "name": "diagnostics.policy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.policy",
+            "attributeRef": "#/attributeCatalog/lotus.policy"
+          },
+          {
+            "name": "diagnostics.samples",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.samples",
+            "attributeRef": "#/attributeCatalog/lotus.samples"
+          },
+          {
+            "name": "audit",
+            "location": "body",
+            "required": true,
+            "type": "Audit",
+            "semanticId": "lotus.audit",
+            "attributeRef": "#/attributeCatalog/lotus.audit"
+          },
+          {
+            "name": "audit.sum_of_parts_vs_total_bp",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sum_of_parts_vs_total_bp",
+            "attributeRef": "#/attributeCatalog/lotus.sum_of_parts_vs_total_bp"
+          },
+          {
+            "name": "audit.residual_applied_bp",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.residual_applied_bp",
+            "attributeRef": "#/attributeCatalog/lotus.residual_applied_bp"
+          },
+          {
+            "name": "audit.counts",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.counts",
+            "attributeRef": "#/attributeCatalog/lotus.counts"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "POST",
+      "path": "/performance/mwr",
+      "operationId": "calculate_mwr_endpoint_performance_mwr_post",
+      "summary": "Calculate Money-Weighted Return",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "begin_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.begin_mv",
+            "attributeRef": "#/attributeCatalog/lotus.begin_mv"
+          },
+          {
+            "name": "end_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.end_mv",
+            "attributeRef": "#/attributeCatalog/lotus.end_mv"
+          },
+          {
+            "name": "cash_flows",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.cash_flows",
+            "attributeRef": "#/attributeCatalog/lotus.cash_flows"
+          },
+          {
+            "name": "cash_flows[].amount",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.amount",
+            "attributeRef": "#/attributeCatalog/lotus.amount"
+          },
+          {
+            "name": "cash_flows[].date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.date",
+            "attributeRef": "#/attributeCatalog/lotus.date"
+          },
+          {
+            "name": "mwr_method",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.mwr_method",
+            "attributeRef": "#/attributeCatalog/lotus.mwr_method"
+          },
+          {
+            "name": "solver",
+            "location": "body",
+            "required": false,
+            "type": "Solver",
+            "semanticId": "lotus.solver",
+            "attributeRef": "#/attributeCatalog/lotus.solver"
+          },
+          {
+            "name": "solver.method",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.method",
+            "attributeRef": "#/attributeCatalog/lotus.method"
+          },
+          {
+            "name": "solver.max_iter",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.max_iter",
+            "attributeRef": "#/attributeCatalog/lotus.max_iter"
+          },
+          {
+            "name": "solver.tolerance",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.tolerance",
+            "attributeRef": "#/attributeCatalog/lotus.tolerance"
+          },
+          {
+            "name": "emit_cashflows_used",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.emit_cashflows_used",
+            "attributeRef": "#/attributeCatalog/lotus.emit_cashflows_used"
+          },
+          {
+            "name": "as_of",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of",
+            "attributeRef": "#/attributeCatalog/lotus.as_of"
+          },
+          {
+            "name": "currency",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "#/attributeCatalog/lotus.currency"
+          },
+          {
+            "name": "precision_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "rounding_precision",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.rounding_precision",
+            "attributeRef": "#/attributeCatalog/lotus.rounding_precision"
+          },
+          {
+            "name": "calendar",
+            "location": "body",
+            "required": false,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "annualization",
+            "location": "body",
+            "required": false,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "periods",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods",
+            "attributeRef": "#/attributeCatalog/lotus.periods"
+          },
+          {
+            "name": "output",
+            "location": "body",
+            "required": false,
+            "type": "Output",
+            "semanticId": "lotus.output",
+            "attributeRef": "#/attributeCatalog/lotus.output"
+          },
+          {
+            "name": "output.include_timeseries",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_timeseries",
+            "attributeRef": "#/attributeCatalog/lotus.include_timeseries"
+          },
+          {
+            "name": "output.include_cumulative",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_cumulative",
+            "attributeRef": "#/attributeCatalog/lotus.include_cumulative"
+          },
+          {
+            "name": "output.top_n",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.top_n",
+            "attributeRef": "#/attributeCatalog/lotus.top_n"
+          },
+          {
+            "name": "flags",
+            "location": "body",
+            "required": false,
+            "type": "Flags",
+            "semanticId": "lotus.flags",
+            "attributeRef": "#/attributeCatalog/lotus.flags"
+          },
+          {
+            "name": "flags.fail_fast",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.fail_fast",
+            "attributeRef": "#/attributeCatalog/lotus.fail_fast"
+          },
+          {
+            "name": "report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "money_weighted_return",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.money_weighted_return",
+            "attributeRef": "#/attributeCatalog/lotus.money_weighted_return"
+          },
+          {
+            "name": "mwr_annualized",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.mwr_annualized",
+            "attributeRef": "#/attributeCatalog/lotus.mwr_annualized"
+          },
+          {
+            "name": "method",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.method",
+            "attributeRef": "#/attributeCatalog/lotus.method"
+          },
+          {
+            "name": "convergence",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.convergence",
+            "attributeRef": "#/attributeCatalog/lotus.convergence"
+          },
+          {
+            "name": "cashflows_used",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.cashflows_used",
+            "attributeRef": "#/attributeCatalog/lotus.cashflows_used"
+          },
+          {
+            "name": "start_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.start_date",
+            "attributeRef": "#/attributeCatalog/lotus.start_date"
+          },
+          {
+            "name": "end_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.end_date",
+            "attributeRef": "#/attributeCatalog/lotus.end_date"
+          },
+          {
+            "name": "notes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.notes",
+            "attributeRef": "#/attributeCatalog/lotus.notes"
+          },
+          {
+            "name": "meta",
+            "location": "body",
+            "required": true,
+            "type": "Meta",
+            "semanticId": "lotus.meta",
+            "attributeRef": "#/attributeCatalog/lotus.meta"
+          },
+          {
+            "name": "meta.calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "meta.engine_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.engine_version",
+            "attributeRef": "#/attributeCatalog/lotus.engine_version"
+          },
+          {
+            "name": "meta.precision_mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "meta.annualization",
+            "location": "body",
+            "required": true,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "meta.annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "meta.annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "meta.annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "meta.calendar",
+            "location": "body",
+            "required": true,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "meta.calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "meta.calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "meta.periods",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.periods",
+            "attributeRef": "#/attributeCatalog/lotus.periods"
+          },
+          {
+            "name": "meta.input_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.input_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.input_fingerprint"
+          },
+          {
+            "name": "meta.calculation_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.calculation_hash",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_hash"
+          },
+          {
+            "name": "meta.report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "diagnostics",
+            "location": "body",
+            "required": true,
+            "type": "Diagnostics",
+            "semanticId": "lotus.diagnostics",
+            "attributeRef": "#/attributeCatalog/lotus.diagnostics"
+          },
+          {
+            "name": "diagnostics.nip_days",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.nip_days",
+            "attributeRef": "#/attributeCatalog/lotus.nip_days"
+          },
+          {
+            "name": "diagnostics.reset_days",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.reset_days",
+            "attributeRef": "#/attributeCatalog/lotus.reset_days"
+          },
+          {
+            "name": "diagnostics.effective_period_start",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.effective_period_start",
+            "attributeRef": "#/attributeCatalog/lotus.effective_period_start"
+          },
+          {
+            "name": "diagnostics.notes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.notes",
+            "attributeRef": "#/attributeCatalog/lotus.notes"
+          },
+          {
+            "name": "diagnostics.policy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.policy",
+            "attributeRef": "#/attributeCatalog/lotus.policy"
+          },
+          {
+            "name": "diagnostics.samples",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.samples",
+            "attributeRef": "#/attributeCatalog/lotus.samples"
+          },
+          {
+            "name": "audit",
+            "location": "body",
+            "required": true,
+            "type": "Audit",
+            "semanticId": "lotus.audit",
+            "attributeRef": "#/attributeCatalog/lotus.audit"
+          },
+          {
+            "name": "audit.sum_of_parts_vs_total_bp",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sum_of_parts_vs_total_bp",
+            "attributeRef": "#/attributeCatalog/lotus.sum_of_parts_vs_total_bp"
+          },
+          {
+            "name": "audit.residual_applied_bp",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.residual_applied_bp",
+            "attributeRef": "#/attributeCatalog/lotus.residual_applied_bp"
+          },
+          {
+            "name": "audit.counts",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.counts",
+            "attributeRef": "#/attributeCatalog/lotus.counts"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "POST",
+      "path": "/performance/attribution",
+      "operationId": "calculate_attribution_endpoint_performance_attribution_post",
+      "summary": "Calculate Multi-Level Performance Attribution",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "report_start_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.report_start_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_start_date"
+          },
+          {
+            "name": "report_end_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.report_end_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_end_date"
+          },
+          {
+            "name": "analyses",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.analyses",
+            "attributeRef": "#/attributeCatalog/lotus.analyses"
+          },
+          {
+            "name": "analyses[].period",
+            "location": "body",
+            "required": true,
+            "type": "PeriodType",
+            "semanticId": "lotus.period",
+            "attributeRef": "#/attributeCatalog/lotus.period"
+          },
+          {
+            "name": "analyses[].frequencies",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.frequencies",
+            "attributeRef": "#/attributeCatalog/lotus.frequencies"
+          },
+          {
+            "name": "mode",
+            "location": "body",
+            "required": true,
+            "type": "AttributionMode",
+            "semanticId": "lotus.mode",
+            "attributeRef": "#/attributeCatalog/lotus.mode"
+          },
+          {
+            "name": "frequency",
+            "location": "body",
+            "required": false,
+            "type": "Frequency",
+            "semanticId": "lotus.frequency",
+            "attributeRef": "#/attributeCatalog/lotus.frequency"
+          },
+          {
+            "name": "group_by",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.group_by",
+            "attributeRef": "#/attributeCatalog/lotus.group_by"
+          },
+          {
+            "name": "model",
+            "location": "body",
+            "required": false,
+            "type": "AttributionModel",
+            "semanticId": "lotus.model",
+            "attributeRef": "#/attributeCatalog/lotus.model"
+          },
+          {
+            "name": "linking",
+            "location": "body",
+            "required": false,
+            "type": "LinkingMethod",
+            "semanticId": "lotus.linking",
+            "attributeRef": "#/attributeCatalog/lotus.linking"
+          },
+          {
+            "name": "portfolio_data",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_data",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_data"
+          },
+          {
+            "name": "instruments_data",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.instruments_data",
+            "attributeRef": "#/attributeCatalog/lotus.instruments_data"
+          },
+          {
+            "name": "portfolio_groups_data",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_groups_data",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_groups_data"
+          },
+          {
+            "name": "benchmark_groups_data",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.benchmark_groups_data",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_groups_data"
+          },
+          {
+            "name": "benchmark_groups_data[].key",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.key",
+            "attributeRef": "#/attributeCatalog/lotus.key"
+          },
+          {
+            "name": "benchmark_groups_data[].observations",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.observations",
+            "attributeRef": "#/attributeCatalog/lotus.observations"
+          },
+          {
+            "name": "benchmark_groups_data[].observations[].date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.date",
+            "attributeRef": "#/attributeCatalog/lotus.date"
+          },
+          {
+            "name": "benchmark_groups_data[].observations[].weight_bop",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.weight_bop",
+            "attributeRef": "#/attributeCatalog/lotus.weight_bop"
+          },
+          {
+            "name": "benchmark_groups_data[].observations[].return_base",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.return_base",
+            "attributeRef": "#/attributeCatalog/lotus.return_base"
+          },
+          {
+            "name": "benchmark_groups_data[].observations[].return_local",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.return_local",
+            "attributeRef": "#/attributeCatalog/lotus.return_local"
+          },
+          {
+            "name": "benchmark_groups_data[].observations[].return_fx",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.return_fx",
+            "attributeRef": "#/attributeCatalog/lotus.return_fx"
+          },
+          {
+            "name": "currency",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "#/attributeCatalog/lotus.currency"
+          },
+          {
+            "name": "precision_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "rounding_precision",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.rounding_precision",
+            "attributeRef": "#/attributeCatalog/lotus.rounding_precision"
+          },
+          {
+            "name": "calendar",
+            "location": "body",
+            "required": false,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "annualization",
+            "location": "body",
+            "required": false,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "output",
+            "location": "body",
+            "required": false,
+            "type": "Output",
+            "semanticId": "lotus.output",
+            "attributeRef": "#/attributeCatalog/lotus.output"
+          },
+          {
+            "name": "output.include_timeseries",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_timeseries",
+            "attributeRef": "#/attributeCatalog/lotus.include_timeseries"
+          },
+          {
+            "name": "output.include_cumulative",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_cumulative",
+            "attributeRef": "#/attributeCatalog/lotus.include_cumulative"
+          },
+          {
+            "name": "output.top_n",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.top_n",
+            "attributeRef": "#/attributeCatalog/lotus.top_n"
+          },
+          {
+            "name": "flags",
+            "location": "body",
+            "required": false,
+            "type": "Flags",
+            "semanticId": "lotus.flags",
+            "attributeRef": "#/attributeCatalog/lotus.flags"
+          },
+          {
+            "name": "flags.fail_fast",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.fail_fast",
+            "attributeRef": "#/attributeCatalog/lotus.fail_fast"
+          },
+          {
+            "name": "currency_mode",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency_mode",
+            "attributeRef": "#/attributeCatalog/lotus.currency_mode"
+          },
+          {
+            "name": "report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "fx",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.fx",
+            "attributeRef": "#/attributeCatalog/lotus.fx"
+          },
+          {
+            "name": "hedging",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.hedging",
+            "attributeRef": "#/attributeCatalog/lotus.hedging"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "model",
+            "location": "body",
+            "required": true,
+            "type": "AttributionModel",
+            "semanticId": "lotus.model",
+            "attributeRef": "#/attributeCatalog/lotus.model"
+          },
+          {
+            "name": "linking",
+            "location": "body",
+            "required": true,
+            "type": "LinkingMethod",
+            "semanticId": "lotus.linking",
+            "attributeRef": "#/attributeCatalog/lotus.linking"
+          },
+          {
+            "name": "results_by_period",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.results_by_period",
+            "attributeRef": "#/attributeCatalog/lotus.results_by_period"
+          },
+          {
+            "name": "meta",
+            "location": "body",
+            "required": true,
+            "type": "Meta",
+            "semanticId": "lotus.meta",
+            "attributeRef": "#/attributeCatalog/lotus.meta"
+          },
+          {
+            "name": "meta.calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "meta.engine_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.engine_version",
+            "attributeRef": "#/attributeCatalog/lotus.engine_version"
+          },
+          {
+            "name": "meta.precision_mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "meta.annualization",
+            "location": "body",
+            "required": true,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "meta.annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "meta.annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "meta.annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "meta.calendar",
+            "location": "body",
+            "required": true,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "meta.calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "meta.calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "meta.periods",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.periods",
+            "attributeRef": "#/attributeCatalog/lotus.periods"
+          },
+          {
+            "name": "meta.input_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.input_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.input_fingerprint"
+          },
+          {
+            "name": "meta.calculation_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.calculation_hash",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_hash"
+          },
+          {
+            "name": "meta.report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "diagnostics",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.diagnostics",
+            "attributeRef": "#/attributeCatalog/lotus.diagnostics"
+          },
+          {
+            "name": "audit",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.audit",
+            "attributeRef": "#/attributeCatalog/lotus.audit"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "POST",
+      "path": "/performance/contribution",
+      "operationId": "calculate_contribution_endpoint_performance_contribution_post",
+      "summary": "Calculate Position Contribution",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "report_start_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.report_start_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_start_date"
+          },
+          {
+            "name": "report_end_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.report_end_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_end_date"
+          },
+          {
+            "name": "analyses",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.analyses",
+            "attributeRef": "#/attributeCatalog/lotus.analyses"
+          },
+          {
+            "name": "analyses[].period",
+            "location": "body",
+            "required": true,
+            "type": "PeriodType",
+            "semanticId": "lotus.period",
+            "attributeRef": "#/attributeCatalog/lotus.period"
+          },
+          {
+            "name": "analyses[].frequencies",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.frequencies",
+            "attributeRef": "#/attributeCatalog/lotus.frequencies"
+          },
+          {
+            "name": "portfolio_data",
+            "location": "body",
+            "required": true,
+            "type": "PortfolioData",
+            "semanticId": "lotus.portfolio_data",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_data"
+          },
+          {
+            "name": "portfolio_data.metric_basis",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.metric_basis",
+            "attributeRef": "#/attributeCatalog/lotus.metric_basis"
+          },
+          {
+            "name": "portfolio_data.valuation_points",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.valuation_points",
+            "attributeRef": "#/attributeCatalog/lotus.valuation_points"
+          },
+          {
+            "name": "portfolio_data.valuation_points[].day",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.day",
+            "attributeRef": "#/attributeCatalog/lotus.day"
+          },
+          {
+            "name": "portfolio_data.valuation_points[].perf_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.perf_date",
+            "attributeRef": "#/attributeCatalog/lotus.perf_date"
+          },
+          {
+            "name": "portfolio_data.valuation_points[].begin_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.begin_mv",
+            "attributeRef": "#/attributeCatalog/lotus.begin_mv"
+          },
+          {
+            "name": "portfolio_data.valuation_points[].end_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.end_mv",
+            "attributeRef": "#/attributeCatalog/lotus.end_mv"
+          },
+          {
+            "name": "portfolio_data.valuation_points[].bod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.bod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.bod_cf"
+          },
+          {
+            "name": "portfolio_data.valuation_points[].eod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.eod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.eod_cf"
+          },
+          {
+            "name": "portfolio_data.valuation_points[].mgmt_fees",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.mgmt_fees",
+            "attributeRef": "#/attributeCatalog/lotus.mgmt_fees"
+          },
+          {
+            "name": "positions_data",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.positions_data",
+            "attributeRef": "#/attributeCatalog/lotus.positions_data"
+          },
+          {
+            "name": "positions_data[].position_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.position_id",
+            "attributeRef": "#/attributeCatalog/lotus.position_id"
+          },
+          {
+            "name": "positions_data[].meta",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.meta",
+            "attributeRef": "#/attributeCatalog/lotus.meta"
+          },
+          {
+            "name": "positions_data[].valuation_points",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.valuation_points",
+            "attributeRef": "#/attributeCatalog/lotus.valuation_points"
+          },
+          {
+            "name": "positions_data[].valuation_points[].day",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.day",
+            "attributeRef": "#/attributeCatalog/lotus.day"
+          },
+          {
+            "name": "positions_data[].valuation_points[].perf_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.perf_date",
+            "attributeRef": "#/attributeCatalog/lotus.perf_date"
+          },
+          {
+            "name": "positions_data[].valuation_points[].begin_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.begin_mv",
+            "attributeRef": "#/attributeCatalog/lotus.begin_mv"
+          },
+          {
+            "name": "positions_data[].valuation_points[].end_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.end_mv",
+            "attributeRef": "#/attributeCatalog/lotus.end_mv"
+          },
+          {
+            "name": "positions_data[].valuation_points[].bod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.bod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.bod_cf"
+          },
+          {
+            "name": "positions_data[].valuation_points[].eod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.eod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.eod_cf"
+          },
+          {
+            "name": "positions_data[].valuation_points[].mgmt_fees",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.mgmt_fees",
+            "attributeRef": "#/attributeCatalog/lotus.mgmt_fees"
+          },
+          {
+            "name": "hierarchy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.hierarchy",
+            "attributeRef": "#/attributeCatalog/lotus.hierarchy"
+          },
+          {
+            "name": "weighting_scheme",
+            "location": "body",
+            "required": false,
+            "type": "WeightingScheme",
+            "semanticId": "lotus.weighting_scheme",
+            "attributeRef": "#/attributeCatalog/lotus.weighting_scheme"
+          },
+          {
+            "name": "smoothing",
+            "location": "body",
+            "required": false,
+            "type": "Smoothing",
+            "semanticId": "lotus.smoothing",
+            "attributeRef": "#/attributeCatalog/lotus.smoothing"
+          },
+          {
+            "name": "smoothing.method",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.method",
+            "attributeRef": "#/attributeCatalog/lotus.method"
+          },
+          {
+            "name": "emit",
+            "location": "body",
+            "required": false,
+            "type": "Emit",
+            "semanticId": "lotus.emit",
+            "attributeRef": "#/attributeCatalog/lotus.emit"
+          },
+          {
+            "name": "emit.timeseries",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.timeseries",
+            "attributeRef": "#/attributeCatalog/lotus.timeseries"
+          },
+          {
+            "name": "emit.by_position_timeseries",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.by_position_timeseries",
+            "attributeRef": "#/attributeCatalog/lotus.by_position_timeseries"
+          },
+          {
+            "name": "emit.by_level",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.by_level",
+            "attributeRef": "#/attributeCatalog/lotus.by_level"
+          },
+          {
+            "name": "emit.top_n_per_level",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.top_n_per_level",
+            "attributeRef": "#/attributeCatalog/lotus.top_n_per_level"
+          },
+          {
+            "name": "emit.threshold_weight",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.threshold_weight",
+            "attributeRef": "#/attributeCatalog/lotus.threshold_weight"
+          },
+          {
+            "name": "emit.include_other",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_other",
+            "attributeRef": "#/attributeCatalog/lotus.include_other"
+          },
+          {
+            "name": "emit.include_unclassified",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_unclassified",
+            "attributeRef": "#/attributeCatalog/lotus.include_unclassified"
+          },
+          {
+            "name": "emit.residual_per_position",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.residual_per_position",
+            "attributeRef": "#/attributeCatalog/lotus.residual_per_position"
+          },
+          {
+            "name": "lookthrough",
+            "location": "body",
+            "required": false,
+            "type": "Lookthrough",
+            "semanticId": "lotus.lookthrough",
+            "attributeRef": "#/attributeCatalog/lotus.lookthrough"
+          },
+          {
+            "name": "lookthrough.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "lookthrough.fallback_policy",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.fallback_policy",
+            "attributeRef": "#/attributeCatalog/lotus.fallback_policy"
+          },
+          {
+            "name": "bucketing",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.bucketing",
+            "attributeRef": "#/attributeCatalog/lotus.bucketing"
+          },
+          {
+            "name": "currency",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "#/attributeCatalog/lotus.currency"
+          },
+          {
+            "name": "precision_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "rounding_precision",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.rounding_precision",
+            "attributeRef": "#/attributeCatalog/lotus.rounding_precision"
+          },
+          {
+            "name": "calendar",
+            "location": "body",
+            "required": false,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "annualization",
+            "location": "body",
+            "required": false,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "output",
+            "location": "body",
+            "required": false,
+            "type": "Output",
+            "semanticId": "lotus.output",
+            "attributeRef": "#/attributeCatalog/lotus.output"
+          },
+          {
+            "name": "output.include_timeseries",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_timeseries",
+            "attributeRef": "#/attributeCatalog/lotus.include_timeseries"
+          },
+          {
+            "name": "output.include_cumulative",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_cumulative",
+            "attributeRef": "#/attributeCatalog/lotus.include_cumulative"
+          },
+          {
+            "name": "output.top_n",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.top_n",
+            "attributeRef": "#/attributeCatalog/lotus.top_n"
+          },
+          {
+            "name": "flags",
+            "location": "body",
+            "required": false,
+            "type": "Flags",
+            "semanticId": "lotus.flags",
+            "attributeRef": "#/attributeCatalog/lotus.flags"
+          },
+          {
+            "name": "flags.fail_fast",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.fail_fast",
+            "attributeRef": "#/attributeCatalog/lotus.fail_fast"
+          },
+          {
+            "name": "data_policy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.data_policy",
+            "attributeRef": "#/attributeCatalog/lotus.data_policy"
+          },
+          {
+            "name": "currency_mode",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency_mode",
+            "attributeRef": "#/attributeCatalog/lotus.currency_mode"
+          },
+          {
+            "name": "report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "fx",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.fx",
+            "attributeRef": "#/attributeCatalog/lotus.fx"
+          },
+          {
+            "name": "hedging",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.hedging",
+            "attributeRef": "#/attributeCatalog/lotus.hedging"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "results_by_period",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.results_by_period",
+            "attributeRef": "#/attributeCatalog/lotus.results_by_period"
+          },
+          {
+            "name": "meta",
+            "location": "body",
+            "required": true,
+            "type": "Meta",
+            "semanticId": "lotus.meta",
+            "attributeRef": "#/attributeCatalog/lotus.meta"
+          },
+          {
+            "name": "meta.calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "meta.engine_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.engine_version",
+            "attributeRef": "#/attributeCatalog/lotus.engine_version"
+          },
+          {
+            "name": "meta.precision_mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "meta.annualization",
+            "location": "body",
+            "required": true,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "meta.annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "meta.annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "meta.annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "meta.calendar",
+            "location": "body",
+            "required": true,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "meta.calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "meta.calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "meta.periods",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.periods",
+            "attributeRef": "#/attributeCatalog/lotus.periods"
+          },
+          {
+            "name": "meta.input_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.input_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.input_fingerprint"
+          },
+          {
+            "name": "meta.calculation_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.calculation_hash",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_hash"
+          },
+          {
+            "name": "meta.report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "diagnostics",
+            "location": "body",
+            "required": true,
+            "type": "Diagnostics",
+            "semanticId": "lotus.diagnostics",
+            "attributeRef": "#/attributeCatalog/lotus.diagnostics"
+          },
+          {
+            "name": "diagnostics.nip_days",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.nip_days",
+            "attributeRef": "#/attributeCatalog/lotus.nip_days"
+          },
+          {
+            "name": "diagnostics.reset_days",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.reset_days",
+            "attributeRef": "#/attributeCatalog/lotus.reset_days"
+          },
+          {
+            "name": "diagnostics.effective_period_start",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.effective_period_start",
+            "attributeRef": "#/attributeCatalog/lotus.effective_period_start"
+          },
+          {
+            "name": "diagnostics.notes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.notes",
+            "attributeRef": "#/attributeCatalog/lotus.notes"
+          },
+          {
+            "name": "diagnostics.policy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.policy",
+            "attributeRef": "#/attributeCatalog/lotus.policy"
+          },
+          {
+            "name": "diagnostics.samples",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.samples",
+            "attributeRef": "#/attributeCatalog/lotus.samples"
+          },
+          {
+            "name": "audit",
+            "location": "body",
+            "required": true,
+            "type": "Audit",
+            "semanticId": "lotus.audit",
+            "attributeRef": "#/attributeCatalog/lotus.audit"
+          },
+          {
+            "name": "audit.sum_of_parts_vs_total_bp",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sum_of_parts_vs_total_bp",
+            "attributeRef": "#/attributeCatalog/lotus.sum_of_parts_vs_total_bp"
+          },
+          {
+            "name": "audit.residual_applied_bp",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.residual_applied_bp",
+            "attributeRef": "#/attributeCatalog/lotus.residual_applied_bp"
+          },
+          {
+            "name": "audit.counts",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.counts",
+            "attributeRef": "#/attributeCatalog/lotus.counts"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "GET",
+      "path": "/performance/lineage/{calculation_id}",
+      "operationId": "get_lineage_data_performance_lineage__calculation_id__get",
+      "summary": "Retrieve Data Lineage Artifacts",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "calculation_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_type",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_type"
+          },
+          {
+            "name": "timestamp_utc",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.timestamp_utc",
+            "attributeRef": "#/attributeCatalog/lotus.timestamp_utc"
+          },
+          {
+            "name": "artifacts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.artifacts",
+            "attributeRef": "#/attributeCatalog/lotus.artifacts"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "analytics",
+      "method": "POST",
+      "path": "/analytics/positions",
+      "operationId": "get_positions_analytics_analytics_positions_post",
+      "summary": "Get position analytics via lotus-performance contract",
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "sections",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.sections",
+            "attributeRef": "#/attributeCatalog/lotus.sections"
+          },
+          {
+            "name": "performance_periods",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.performance_periods",
+            "attributeRef": "#/attributeCatalog/lotus.performance_periods"
+          },
+          {
+            "name": "consumer_system",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "#/attributeCatalog/lotus.consumer_system"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "source_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_mode",
+            "attributeRef": "#/attributeCatalog/lotus.source_mode"
+          },
+          {
+            "name": "source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "total_market_value",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.total_market_value",
+            "attributeRef": "#/attributeCatalog/lotus.total_market_value"
+          },
+          {
+            "name": "positions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.positions",
+            "attributeRef": "#/attributeCatalog/lotus.positions"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "integration",
+      "method": "GET",
+      "path": "/integration/capabilities",
+      "operationId": "get_integration_capabilities_integration_capabilities_get",
+      "summary": "Get lotus-performance Integration Capabilities",
+      "request": {
+        "fields": [
+          {
+            "name": "consumer_system",
+            "location": "query",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "#/attributeCatalog/lotus.consumer_system"
+          },
+          {
+            "name": "tenant_id",
+            "location": "query",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
+            "name": "feature_limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.feature_limit",
+            "attributeRef": "#/attributeCatalog/lotus.feature_limit"
+          },
+          {
+            "name": "workflow_limit",
+            "location": "query",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.workflow_limit",
+            "attributeRef": "#/attributeCatalog/lotus.workflow_limit"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "contract_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.contract_version",
+            "attributeRef": "#/attributeCatalog/lotus.contract_version"
+          },
+          {
+            "name": "source_service",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "consumer_system",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumer_system",
+            "attributeRef": "#/attributeCatalog/lotus.consumer_system"
+          },
+          {
+            "name": "tenant_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
+            "name": "generated_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.generated_at",
+            "attributeRef": "#/attributeCatalog/lotus.generated_at"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "policy_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.policy_version",
+            "attributeRef": "#/attributeCatalog/lotus.policy_version"
+          },
+          {
+            "name": "supported_input_modes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.supported_input_modes",
+            "attributeRef": "#/attributeCatalog/lotus.supported_input_modes"
+          },
+          {
+            "name": "features",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.features",
+            "attributeRef": "#/attributeCatalog/lotus.features"
+          },
+          {
+            "name": "features[].key",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.key",
+            "attributeRef": "#/attributeCatalog/lotus.key"
+          },
+          {
+            "name": "features[].enabled",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "features[].owner_service",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.owner_service",
+            "attributeRef": "#/attributeCatalog/lotus.owner_service"
+          },
+          {
+            "name": "features[].description",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.description",
+            "attributeRef": "#/attributeCatalog/lotus.description"
+          },
+          {
+            "name": "workflows",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.workflows",
+            "attributeRef": "#/attributeCatalog/lotus.workflows"
+          },
+          {
+            "name": "workflows[].workflow_key",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.workflow_key",
+            "attributeRef": "#/attributeCatalog/lotus.workflow_key"
+          },
+          {
+            "name": "workflows[].enabled",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "workflows[].required_features",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.required_features",
+            "attributeRef": "#/attributeCatalog/lotus.required_features"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "health",
+      "method": "GET",
+      "path": "/health",
+      "operationId": "health_health_get",
+      "summary": "Service health",
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "fields": []
+      }
+    },
+    {
+      "domain": "health",
+      "method": "GET",
+      "path": "/health/live",
+      "operationId": "health_live_health_live_get",
+      "summary": "Service liveness",
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "fields": []
+      }
+    },
+    {
+      "domain": "health",
+      "method": "GET",
+      "path": "/health/ready",
+      "operationId": "health_ready_health_ready_get",
+      "summary": "Service readiness",
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "fields": []
+      }
+    },
+    {
+      "domain": "default",
+      "method": "GET",
+      "path": "/",
+      "operationId": "root__get",
+      "summary": "Root",
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "fields": []
+      }
+    }
+  ]
+}

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-02-25T14:51:35Z",
+  "generated_at": "2026-03-01T03:09:33Z",
   "allowlist": [
     {
       "finding": "app/models/attribution_requests.py:44:weight_bop: float",
@@ -82,10 +82,10 @@
       "review_by": "2026-08-24"
     },
     {
-      "finding": "app/models/mwr_responses.py:38:money_weighted_return: float",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "finding": "app/models/mwr_responses.py:36:money_weighted_return: float",
+      "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-08-24"
+      "review_by": "2026-08-28"
     },
     {
       "finding": "app/models/pas_connected_responses.py:11:net_cumulative_return: float | None = None",
@@ -112,10 +112,10 @@
       "review_by": "2026-08-24"
     },
     {
-      "finding": "app/models/positions_analytics_responses.py:11:total_market_value: float = Field(..., alias=\"totalMarketValue\")",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "finding": "app/models/positions_analytics_responses.py:11:total_market_value: float",
+      "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-08-24"
+      "review_by": "2026-08-28"
     },
     {
       "finding": "app/models/requests.py:38:end_mv: float = Field(..., description=\"The market value of the portfolio at the end of the day.\")",
@@ -124,22 +124,22 @@
       "review_by": "2026-08-24"
     },
     {
-      "finding": "app/models/responses.py:20:period_return_pct: float",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "finding": "app/models/responses.py:18:period_return_pct: float",
+      "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-08-24"
+      "review_by": "2026-08-28"
     },
     {
-      "finding": "app/models/responses.py:21:cumulative_return_pct_to_date: Optional[float] = None",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "finding": "app/models/responses.py:19:cumulative_return_pct_to_date: Optional[float] = None",
+      "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-08-24"
+      "review_by": "2026-08-28"
     },
     {
-      "finding": "app/models/responses.py:22:annualized_return_pct: Optional[float] = None",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
+      "finding": "app/models/responses.py:20:annualized_return_pct: Optional[float] = None",
+      "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-08-24"
+      "review_by": "2026-08-28"
     },
     {
       "finding": "core/annualize.py:9:def annualize_return(period_return: float, num_periods: int, periods_per_year: float, basis: BasisType) -> float:",
@@ -182,13 +182,6 @@
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-08-24"
-    },
-    {
-      "finding": "scripts/check_monetary_float_usage.py:112:\"justification\": \"Temporary approved monetary float usage; migrate to Decimal.\",",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-08-24"
     }
   ]
 }
-

--- a/engine/attribution.py
+++ b/engine/attribution.py
@@ -50,16 +50,14 @@ def _prepare_data_from_instruments(request: AttributionRequest) -> List[Portfoli
         hedging=request.hedging,
     )
 
-    portfolio_df = create_engine_dataframe(
-        [item.model_dump(by_alias=True) for item in request.portfolio_data.valuation_points]
-    )
+    portfolio_df = create_engine_dataframe([item.model_dump() for item in request.portfolio_data.valuation_points])
     portfolio_df[PortfolioColumns.PERF_DATE.value] = pd.to_datetime(portfolio_df[PortfolioColumns.PERF_DATE.value])
     portfolio_df = portfolio_df.set_index(PortfolioColumns.PERF_DATE.value)
     portfolio_bop_mv = portfolio_df[PortfolioColumns.BEGIN_MV.value] + portfolio_df[PortfolioColumns.BOD_CF.value]
 
     all_instruments = []
     for inst in request.instruments_data:
-        inst_df = create_engine_dataframe([item.model_dump(by_alias=True) for item in inst.valuation_points])
+        inst_df = create_engine_dataframe([item.model_dump() for item in inst.valuation_points])
         if inst_df.empty:
             continue
 

--- a/engine/contribution.py
+++ b/engine/contribution.py
@@ -93,9 +93,7 @@ def _prepare_hierarchical_data(request: ContributionRequest) -> Tuple[pd.DataFra
         hedging=request.hedging,
     )
 
-    portfolio_df = create_engine_dataframe(
-        [item.model_dump(by_alias=True) for item in request.portfolio_data.valuation_points]
-    )
+    portfolio_df = create_engine_dataframe([item.model_dump() for item in request.portfolio_data.valuation_points])
 
     portfolio_twr_config = twr_config
     if twr_config.currency_mode == "BOTH":
@@ -121,7 +119,7 @@ def _prepare_hierarchical_data(request: ContributionRequest) -> Tuple[pd.DataFra
 
     all_positions_data = []
     for position in request.positions_data:
-        position_df = create_engine_dataframe([item.model_dump(by_alias=True) for item in position.valuation_points])
+        position_df = create_engine_dataframe([item.model_dump() for item in position.valuation_points])
         if position_df.empty:
             continue
 

--- a/scripts/api_vocabulary_inventory.py
+++ b/scripts/api_vocabulary_inventory.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from argparse import ArgumentParser
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from main import app  # noqa: E402
+
+ALLOWED_METHODS = {"get", "post", "put", "patch", "delete"}
+DEFAULT_OUTPUT = PROJECT_ROOT / "docs" / "standards" / "api-vocabulary" / "lotus-performance-api-vocabulary.v1.json"
+PLACEHOLDER_EXAMPLES = {
+    "example",
+    "sample",
+    "string",
+    "value",
+    "test",
+    "foo",
+    "bar",
+    "baz",
+    "placeholder",
+}
+LEGACY_TERM_MAP: dict[str, str] = {
+    "cif_id": "client_id",
+    "booking_center": "booking_center_code",
+}
+
+
+def _to_snake_case(value: str) -> str:
+    transformed = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    transformed = transformed.replace("-", "_").replace(" ", "_").replace(".", "_")
+    transformed = transformed.strip("_")
+    return transformed.lower()
+
+
+def _canonical_term(name: str) -> str:
+    base = _to_snake_case(name.split(".")[-1].replace("[]", ""))
+    return LEGACY_TERM_MAP.get(base, base)
+
+
+def _semantic_id(name: str) -> str:
+    return f"lotus.{_canonical_term(name)}"
+
+
+def _schema_type(schema: dict[str, Any]) -> str:
+    if "$ref" in schema:
+        return schema["$ref"].rsplit("/", 1)[-1]
+    return str(schema.get("type", "object"))
+
+
+def _resolve_schema(schema: dict[str, Any], components: dict[str, Any]) -> dict[str, Any]:
+    ref = schema.get("$ref")
+    if not isinstance(ref, str):
+        return schema
+    return components.get("schemas", {}).get(ref.rsplit("/", 1)[-1], {})
+
+
+def _fallback_description(name: str) -> str:
+    readable = _canonical_term(name).replace("_", " ")
+    return f"Canonical {readable} used by lotus-performance APIs."
+
+
+def _fallback_example(name: str, schema: dict[str, Any]) -> Any:
+    canonical = _canonical_term(name)
+    schema_type = schema.get("type")
+    schema_format = schema.get("format")
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and enum_values:
+        return enum_values[0]
+    if schema_format == "date":
+        return "2025-03-31"
+    if schema_format == "date-time":
+        return "2025-03-31T00:00:00Z"
+    if canonical.endswith("_id"):
+        return "ENTITY_001"
+    if canonical.endswith("_date"):
+        return "2025-03-31"
+    if schema_type == "boolean":
+        return True
+    if schema_type == "integer":
+        return 1
+    if schema_type == "number":
+        return 0.1
+    if schema_type == "array":
+        return ["VALUE"]
+    if schema_type == "object":
+        return {"key": "value"}
+    return "STANDARD_VALUE"
+
+
+def _extract_fields(
+    schema: dict[str, Any],
+    *,
+    components: dict[str, Any],
+    prefix: str = "",
+    location: str = "body",
+) -> list[dict[str, Any]]:
+    resolved = _resolve_schema(schema, components)
+    properties = resolved.get("properties", {})
+    required = set(resolved.get("required", []))
+    if not isinstance(properties, dict):
+        return []
+
+    fields: list[dict[str, Any]] = []
+    for prop_name, prop_schema in properties.items():
+        if not isinstance(prop_schema, dict):
+            continue
+        prop_resolved = _resolve_schema(prop_schema, components)
+        field_name = f"{prefix}.{prop_name}" if prefix else prop_name
+        field = {
+            "name": field_name,
+            "location": location,
+            "required": prop_name in required,
+            "type": _schema_type(prop_schema),
+            "semanticId": _semantic_id(prop_name),
+            "attributeRef": f"#/attributeCatalog/{_semantic_id(prop_name)}",
+            "description": prop_resolved.get("description") or _fallback_description(field_name),
+            "example": (
+                prop_resolved.get("example")
+                if prop_resolved.get("example") is not None
+                else _fallback_example(field_name, prop_resolved)
+            ),
+        }
+        fields.append(field)
+
+        nested_type = prop_resolved.get("type")
+        if nested_type == "object" or "$ref" in prop_schema:
+            fields.extend(
+                _extract_fields(
+                    prop_schema,
+                    components=components,
+                    prefix=field_name,
+                    location=location,
+                )
+            )
+        elif nested_type == "array":
+            item_schema = prop_resolved.get("items")
+            if isinstance(item_schema, dict):
+                fields.extend(
+                    _extract_fields(
+                        item_schema,
+                        components=components,
+                        prefix=f"{field_name}[]",
+                        location=location,
+                    )
+                )
+    return fields
+
+
+def _extract_request_fields(
+    operation: dict[str, Any], components: dict[str, Any]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    request_fields: list[dict[str, Any]] = []
+    controls: list[dict[str, Any]] = []
+
+    for parameter in operation.get("parameters", []):
+        if not isinstance(parameter, dict):
+            continue
+        schema = parameter.get("schema", {})
+        if not isinstance(schema, dict):
+            schema = {}
+        name = str(parameter.get("name", ""))
+        canonical = _canonical_term(name)
+        request_fields.append(
+            {
+                "name": name,
+                "location": parameter.get("in", "query"),
+                "required": bool(parameter.get("required", False)),
+                "type": _schema_type(schema),
+                "semanticId": _semantic_id(name),
+                "attributeRef": f"#/attributeCatalog/{_semantic_id(name)}",
+            }
+        )
+        controls.append(
+            {
+                "name": canonical,
+                "kind": "request_option",
+                "location": parameter.get("in", "query"),
+                "required": bool(parameter.get("required", False)),
+                "type": _schema_type(schema),
+                "description": parameter.get("description") or schema.get("description") or _fallback_description(name),
+                "example": parameter.get("example")
+                if parameter.get("example") is not None
+                else _fallback_example(name, schema),
+                "allowedValues": schema.get("enum", []),
+                "semanticId": _semantic_id(name),
+                "attributeRef": f"#/attributeCatalog/{_semantic_id(name)}",
+            }
+        )
+
+    request_body = operation.get("requestBody", {})
+    if isinstance(request_body, dict):
+        json_content = request_body.get("content", {}).get("application/json")
+        if isinstance(json_content, dict):
+            schema = json_content.get("schema", {})
+            if isinstance(schema, dict):
+                request_fields.extend(_extract_fields(schema, components=components))
+
+    return request_fields, controls
+
+
+def _extract_response_fields(operation: dict[str, Any], components: dict[str, Any]) -> list[dict[str, Any]]:
+    responses = operation.get("responses", {})
+    success_codes = sorted(code for code in responses if str(code).startswith("2"))
+    if not success_codes:
+        return []
+    response = responses[success_codes[0]]
+    if not isinstance(response, dict):
+        return []
+    json_content = response.get("content", {}).get("application/json")
+    if not isinstance(json_content, dict):
+        return []
+    schema = json_content.get("schema", {})
+    if not isinstance(schema, dict):
+        return []
+    return _extract_fields(schema, components=components)
+
+
+def _domain(path: str, tags: list[str]) -> str:
+    if tags:
+        return _to_snake_case(tags[0])
+    root = path.strip("/").split("/")[0] if path.strip("/") else "operational"
+    return _to_snake_case(root)
+
+
+def build_inventory() -> dict[str, Any]:
+    schema = app.openapi()
+    components = schema.get("components", {})
+
+    attribute_catalog_map: dict[str, dict[str, Any]] = {}
+    endpoints: list[dict[str, Any]] = []
+    controls_catalog: list[dict[str, Any]] = []
+
+    for path, methods in schema.get("paths", {}).items():
+        if not isinstance(methods, dict):
+            continue
+        for method, operation in methods.items():
+            if method.lower() not in ALLOWED_METHODS or not isinstance(operation, dict):
+                continue
+
+            request_fields, controls = _extract_request_fields(operation, components)
+            response_fields = _extract_response_fields(operation, components)
+            all_fields = request_fields + response_fields
+
+            for field in all_fields:
+                semantic_id = field["semanticId"]
+                canonical = _canonical_term(field["name"])
+                if semantic_id not in attribute_catalog_map:
+                    attribute_catalog_map[semantic_id] = {
+                        "semanticId": semantic_id,
+                        "canonicalTerm": canonical,
+                        "preferredName": canonical,
+                        "description": field.get("description") or _fallback_description(field["name"]),
+                        "example": field.get("example"),
+                        "type": field.get("type", "string"),
+                        "locations": [field.get("location", "body")],
+                        "observedTypes": [field.get("type", "string")],
+                    }
+                else:
+                    item = attribute_catalog_map[semantic_id]
+                    location = field.get("location", "body")
+                    observed_type = field.get("type", "string")
+                    if location not in item["locations"]:
+                        item["locations"].append(location)
+                    if observed_type not in item["observedTypes"]:
+                        item["observedTypes"].append(observed_type)
+
+            endpoint_request_fields = [
+                {
+                    "name": field["name"],
+                    "location": field["location"],
+                    "required": field["required"],
+                    "type": field["type"],
+                    "semanticId": field["semanticId"],
+                    "attributeRef": field["attributeRef"],
+                }
+                for field in request_fields
+            ]
+            endpoint_response_fields = [
+                {
+                    "name": field["name"],
+                    "location": field["location"],
+                    "required": field["required"],
+                    "type": field["type"],
+                    "semanticId": field["semanticId"],
+                    "attributeRef": field["attributeRef"],
+                }
+                for field in response_fields
+            ]
+
+            endpoints.append(
+                {
+                    "domain": _domain(path, operation.get("tags", [])),
+                    "method": method.upper(),
+                    "path": path,
+                    "operationId": operation.get("operationId"),
+                    "summary": operation.get("summary") or "",
+                    "request": {"fields": endpoint_request_fields},
+                    "response": {"fields": endpoint_response_fields},
+                }
+            )
+            controls_catalog.extend(controls)
+
+    return {
+        "specVersion": "1.0.0",
+        "application": "lotus-performance",
+        "sourceOpenApi": [
+            {
+                "service": "lotus-performance",
+                "version": schema.get("info", {}).get("version", "0.1.0"),
+                "openApiVersion": schema.get("openapi", "3.1.0"),
+            }
+        ],
+        "generatedAt": datetime.now(UTC).isoformat(),
+        "attributeCatalog": sorted(attribute_catalog_map.values(), key=lambda x: x["semanticId"]),
+        "controlsCatalog": controls_catalog,
+        "endpoints": endpoints,
+    }
+
+
+def _is_snake_case(value: str) -> bool:
+    return bool(re.fullmatch(r"[a-z][a-z0-9_]*", value))
+
+
+def _is_placeholder_example(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in PLACEHOLDER_EXAMPLES
+    if isinstance(value, list) and value and isinstance(value[0], str):
+        return value[0].strip().lower() in PLACEHOLDER_EXAMPLES
+    return False
+
+
+def validate_inventory(inventory: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    semantic_ids: set[str] = set()
+    for attr in inventory.get("attributeCatalog", []):
+        semantic_id = str(attr.get("semanticId", ""))
+        canonical = str(attr.get("canonicalTerm", ""))
+        preferred = str(attr.get("preferredName", ""))
+        if not semantic_id:
+            errors.append("attributeCatalog entry missing semanticId")
+            continue
+        if semantic_id in semantic_ids:
+            errors.append(f"duplicate semanticId: {semantic_id}")
+        semantic_ids.add(semantic_id)
+        if canonical != preferred:
+            errors.append(f"canonicalTerm/preferredName mismatch: {semantic_id}")
+        if not _is_snake_case(canonical):
+            errors.append(f"canonicalTerm must be snake_case: {semantic_id} -> {canonical}")
+        if canonical in LEGACY_TERM_MAP:
+            errors.append(f"legacy term is not allowed: {canonical} (use {LEGACY_TERM_MAP[canonical]})")
+        if _is_placeholder_example(attr.get("example")):
+            errors.append(f"generic placeholder example is not allowed: {semantic_id}")
+
+    for endpoint in inventory.get("endpoints", []):
+        request_fields = endpoint.get("request", {}).get("fields", [])
+        response_fields = endpoint.get("response", {}).get("fields", [])
+        for field in [*request_fields, *response_fields]:
+            for forbidden in ("description", "example", "canonicalTerm", "preferredName"):
+                if forbidden in field:
+                    errors.append(
+                        f"endpoint field duplicates attribute metadata ({forbidden}): "
+                        f"{endpoint.get('method')} {endpoint.get('path')}::{field.get('name')}"
+                    )
+            if not field.get("semanticId"):
+                errors.append(
+                    f"endpoint field missing semanticId: {endpoint.get('method')} {endpoint.get('path')}::{field.get('name')}"
+                )
+            if not field.get("attributeRef"):
+                errors.append(
+                    f"endpoint field missing attributeRef: {endpoint.get('method')} {endpoint.get('path')}::{field.get('name')}"
+                )
+
+    return errors
+
+
+def _normalize_for_compare(payload: dict[str, Any]) -> dict[str, Any]:
+    clone = dict(payload)
+    clone.pop("generatedAt", None)
+    return clone
+
+
+def main() -> int:
+    parser = ArgumentParser(description="Generate and validate lotus-performance API vocabulary inventory")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--validate-only", action="store_true")
+    args = parser.parse_args()
+
+    inventory = build_inventory()
+    errors = validate_inventory(inventory)
+    if errors:
+        print("API vocabulary inventory validation failed:")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+
+    output_path: Path = args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.validate_only:
+        if not output_path.exists():
+            print(f"Inventory file missing: {output_path}")
+            return 1
+        on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+        if _normalize_for_compare(on_disk) != _normalize_for_compare(inventory):
+            print("Inventory drift detected. Regenerate with:")
+            print(f"python scripts/api_vocabulary_inventory.py --output {output_path}")
+            return 1
+        print("API vocabulary inventory gate passed (no drift).")
+        return 0
+
+    output_path.write_text(json.dumps(inventory, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote inventory: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/no_alias_contract_guard.py
+++ b/scripts/no_alias_contract_guard.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_ROOTS = [
+    REPO_ROOT / "app",
+    REPO_ROOT / "core",
+    REPO_ROOT / "engine",
+    REPO_ROOT / "adapters",
+]
+TOP_LEVEL_FILES = [
+    REPO_ROOT / "main.py",
+]
+
+PATTERNS = {
+    "field_or_param_alias": re.compile(r'\balias\s*=\s*"'),
+    "model_dump_by_alias": re.compile(r"\bmodel_dump\(\s*by_alias\s*=\s*True"),
+    "response_model_by_alias": re.compile(r"\bresponse_model_by_alias\s*=\s*True"),
+    "populate_by_name": re.compile(r"\bpopulate_by_name\b"),
+    "legacy_client_term": re.compile(r"\bcif_id\b"),
+    "legacy_booking_center_term": re.compile(r"\bbooking_center\b"),
+}
+
+
+def _iter_source_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        files.extend(root.rglob("*.py"))
+    for file_path in TOP_LEVEL_FILES:
+        if file_path.exists():
+            files.append(file_path)
+    return files
+
+
+def main() -> int:
+    findings: list[str] = []
+    for file_path in _iter_source_files():
+        content = file_path.read_text(encoding="utf-8")
+        for idx, line in enumerate(content.splitlines(), start=1):
+            for rule_name, pattern in PATTERNS.items():
+                if pattern.search(line):
+                    rel = file_path.relative_to(REPO_ROOT)
+                    findings.append(f"{rel}:{idx}: {rule_name}: {line.strip()}")
+
+    if findings:
+        print("No-alias contract guard failed. Remove alias-based API patterns:")
+        for finding in findings:
+            print(f" - {finding}")
+        return 1
+
+    print("No-alias contract guard passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/openapi_quality_gate.py
+++ b/scripts/openapi_quality_gate.py
@@ -1,51 +1,118 @@
-"""Enforce baseline OpenAPI quality for performance analytics service."""
+"""Enforce RFC-0067 OpenAPI quality for lotus-performance."""
 
 from __future__ import annotations
 
-import pathlib
 import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
-from main import app
+from main import app  # noqa: E402
+
+ALLOWED_METHODS = {"get", "post", "put", "patch", "delete"}
+
+
+def _has_success_response(operation: dict[str, Any]) -> bool:
+    responses = operation.get("responses", {})
+    return any(str(code).startswith("2") for code in responses)
+
+
+def _has_error_response(operation: dict[str, Any]) -> bool:
+    responses = operation.get("responses", {})
+    return any(str(code).startswith("4") or str(code).startswith("5") or str(code) == "default" for code in responses)
+
+
+def _is_ref_only(prop_schema: dict[str, Any]) -> bool:
+    return set(prop_schema.keys()) == {"$ref"}
+
+
+def evaluate_schema(schema: dict[str, Any], *, service_name: str) -> list[str]:
+    errors: list[str] = []
+    missing_docs: list[tuple[str, str, str]] = []
+    missing_fields: list[tuple[str, str, str]] = []
+    operation_ids: list[str] = []
+
+    for path, methods in schema.get("paths", {}).items():
+        if not isinstance(methods, dict):
+            continue
+        for method, operation in methods.items():
+            if method.lower() not in ALLOWED_METHODS:
+                continue
+            if not isinstance(operation, dict):
+                continue
+
+            method_upper = method.upper()
+            operation_id = operation.get("operationId")
+            if operation_id:
+                operation_ids.append(str(operation_id))
+
+            if not operation.get("summary"):
+                missing_docs.append((method_upper, path, "summary"))
+            if not operation.get("description"):
+                missing_docs.append((method_upper, path, "description"))
+            if not operation.get("tags"):
+                missing_docs.append((method_upper, path, "tags"))
+
+            if not operation.get("responses"):
+                missing_docs.append((method_upper, path, "responses"))
+            else:
+                if not _has_success_response(operation):
+                    missing_docs.append((method_upper, path, "2xx response"))
+                if not _has_error_response(operation):
+                    missing_docs.append((method_upper, path, "error response (4xx/5xx/default)"))
+
+    schemas = schema.get("components", {}).get("schemas", {})
+    if isinstance(schemas, dict):
+        for model_name, model_schema in schemas.items():
+            if not isinstance(model_schema, dict):
+                continue
+            properties = model_schema.get("properties", {})
+            if not isinstance(properties, dict):
+                continue
+            for prop_name, prop_schema in properties.items():
+                if not isinstance(prop_schema, dict):
+                    continue
+                if _is_ref_only(prop_schema):
+                    continue
+                if not prop_schema.get("description"):
+                    missing_fields.append((str(model_name), str(prop_name), "description"))
+                if "example" not in prop_schema and "examples" not in prop_schema:
+                    missing_fields.append((str(model_name), str(prop_name), "example"))
+
+    if missing_docs:
+        errors.append(f"OpenAPI quality gate ({service_name}): missing endpoint documentation/response contract")
+        errors.extend(f"  - {method} {path}: missing {field}" for method, path, field in missing_docs)
+
+    if missing_fields:
+        errors.append(f"OpenAPI quality gate ({service_name}): missing schema field metadata")
+        errors.extend(f"  - {model}.{field}: missing {field_name}" for model, field, field_name in missing_fields)
+
+    duplicate_operation_ids = sorted(
+        [operation_id for operation_id, count in Counter(operation_ids).items() if count > 1]
+    )
+    if duplicate_operation_ids:
+        errors.append(f"OpenAPI quality gate ({service_name}): duplicate operationId values")
+        errors.extend(f"  - {operation_id}" for operation_id in duplicate_operation_ids)
+
+    return errors
 
 
 def main() -> int:
     schema = app.openapi()
-    paths = schema.get("paths", {})
-    if not paths:
-        print("OpenAPI quality gate: no paths found")
+    if "paths" not in schema or not schema["paths"]:
+        print("OpenAPI quality gate (lotus-performance): no paths found")
         return 1
 
-    missing_docs: list[str] = []
-    operation_ids: list[str] = []
-
-    for path, operations in paths.items():
-        for method, operation in operations.items():
-            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
-                continue
-            summary = operation.get("summary")
-            description = operation.get("description")
-            if not summary and not description:
-                missing_docs.append(f"{method.upper()} {path}")
-            op_id = operation.get("operationId")
-            if op_id:
-                operation_ids.append(op_id)
-
-    if missing_docs:
-        print("OpenAPI quality gate: missing endpoint documentation")
-        for endpoint in missing_docs:
-            print(f"- {endpoint}")
+    errors = evaluate_schema(schema, service_name="lotus-performance")
+    if errors:
+        print("\n".join(errors))
         return 1
 
-    duplicate_ids = sorted({op_id for op_id in operation_ids if operation_ids.count(op_id) > 1})
-    if duplicate_ids:
-        print("OpenAPI quality gate: duplicate operationId values")
-        for op_id in duplicate_ids:
-            print(f"- {op_id}")
-        return 1
-
-    print("OpenAPI quality gate passed.")
+    print("OpenAPI quality gate passed for lotus-performance.")
     return 0
 
 

--- a/tests/e2e/test_workflow_journeys.py
+++ b/tests/e2e/test_workflow_journeys.py
@@ -7,17 +7,17 @@ def test_e2e_platform_readiness_and_capabilities_contract() -> None:
     with TestClient(app) as client:
         health = client.get("/health")
         ready = client.get("/health/ready")
-        capabilities = client.get("/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default")
+        capabilities = client.get("/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default")
 
     assert health.status_code == 200
     assert ready.status_code == 200
     assert capabilities.status_code == 200
 
     body = capabilities.json()
-    assert body["contractVersion"] == "v1"
-    assert body["sourceService"] == "lotus-performance"
-    assert "core_api_ref" in body["supportedInputModes"]
-    assert "inline_bundle" in body["supportedInputModes"]
+    assert body["contract_version"] == "v1"
+    assert body["source_service"] == "lotus-performance"
+    assert "core_api_ref" in body["supported_input_modes"]
+    assert "inline_bundle" in body["supported_input_modes"]
 
 
 def test_e2e_performance_twr_and_mwr_workflow() -> None:
@@ -115,11 +115,11 @@ def test_e2e_pas_connected_modes(monkeypatch) -> None:
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {"day": 1, "perf_date": "2026-02-01", "begin_mv": 100.0, "end_mv": 101.0},
                     {"day": 2, "perf_date": "2026-02-23", "begin_mv": 101.0, "end_mv": 102.0},
                 ],
@@ -130,9 +130,9 @@ def test_e2e_pas_connected_modes(monkeypatch) -> None:
         return (
             200,
             {
-                "portfolioId": portfolio_id,
-                "asOfDate": str(as_of_date),
-                "totalMarketValue": 1000.0,
+                "portfolio_id": portfolio_id,
+                "as_of_date": str(as_of_date),
+                "total_market_value": 1000.0,
                 "positions": [{"securityId": "EQ_1", "quantity": 10}],
             },
         )
@@ -146,10 +146,10 @@ def test_e2e_pas_connected_modes(monkeypatch) -> None:
         _mock_get_positions_analytics,
     )
 
-    twr_pas_payload = {"portfolioId": "PORT-1001", "asOfDate": "2026-02-23", "periods": ["YTD"]}
+    twr_pas_payload = {"portfolio_id": "PORT-1001", "as_of_date": "2026-02-23", "periods": ["YTD"]}
     positions_payload = {
-        "portfolioId": "PORT-1001",
-        "asOfDate": "2026-02-23",
+        "portfolio_id": "PORT-1001",
+        "as_of_date": "2026-02-23",
         "sections": ["BASE", "VALUATION"],
         "performancePeriods": ["YTD"],
     }
@@ -161,7 +161,7 @@ def test_e2e_pas_connected_modes(monkeypatch) -> None:
     assert twr_pas_response.status_code == 200
     assert positions_response.status_code == 200
     assert twr_pas_response.json()["source_mode"] == "core_api_ref"
-    assert positions_response.json()["portfolioId"] == "PORT-1001"
+    assert positions_response.json()["portfolio_id"] == "PORT-1001"
 
 
 def test_e2e_core_api_ref_capability_and_execution_contract(monkeypatch) -> None:
@@ -169,11 +169,11 @@ def test_e2e_core_api_ref_capability_and_execution_contract(monkeypatch) -> None
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": consumer_system,
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "contract_version": "v1",
+                "consumer_system": consumer_system,
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {"day": 1, "perf_date": "2026-02-01", "begin_mv": 100.0, "end_mv": 101.0},
                     {"day": 2, "perf_date": "2026-02-23", "begin_mv": 101.0, "end_mv": 102.0},
                 ],
@@ -185,22 +185,22 @@ def test_e2e_core_api_ref_capability_and_execution_contract(monkeypatch) -> None
         _mock_get_performance_input,
     )
     with TestClient(app) as client:
-        capabilities = client.get("/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default")
+        capabilities = client.get("/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default")
         twr_pas = client.post(
             "/performance/twr/pas-input",
             json={
-                "portfolioId": "PORT-1002",
-                "asOfDate": "2026-02-23",
-                "consumerSystem": "lotus-gateway",
+                "portfolio_id": "PORT-1002",
+                "as_of_date": "2026-02-23",
+                "consumer_system": "lotus-gateway",
                 "periods": ["YTD"],
             },
         )
 
     assert capabilities.status_code == 200
     assert twr_pas.status_code == 200
-    assert "core_api_ref" in capabilities.json()["supportedInputModes"]
+    assert "core_api_ref" in capabilities.json()["supported_input_modes"]
     assert twr_pas.json()["source_mode"] == "core_api_ref"
-    assert "YTD" in twr_pas.json()["resultsByPeriod"]
+    assert "YTD" in twr_pas.json()["results_by_period"]
 
 
 def test_e2e_health_endpoints_contract() -> None:
@@ -226,7 +226,7 @@ def test_e2e_core_api_ref_upstream_failure_passthrough(monkeypatch) -> None:
     with TestClient(app) as client:
         response = client.post(
             "/performance/twr/pas-input",
-            json={"portfolioId": "PORT-DOWN", "asOfDate": "2026-02-23", "consumerSystem": "lotus-gateway"},
+            json={"portfolio_id": "PORT-DOWN", "as_of_date": "2026-02-23", "consumer_system": "lotus-gateway"},
         )
 
     assert response.status_code == 503
@@ -235,7 +235,7 @@ def test_e2e_core_api_ref_upstream_failure_passthrough(monkeypatch) -> None:
 
 def test_e2e_positions_pas_payload_contract_failure(monkeypatch) -> None:
     async def _mock_get_positions_analytics(self, portfolio_id, as_of_date, sections, performance_periods):  # noqa: ARG001
-        return 200, {"portfolioId": portfolio_id, "asOfDate": str(as_of_date)}
+        return 200, {"portfolio_id": portfolio_id, "as_of_date": str(as_of_date)}
 
     monkeypatch.setattr(
         "app.api.endpoints.analytics.PasInputService.get_positions_analytics",
@@ -245,7 +245,7 @@ def test_e2e_positions_pas_payload_contract_failure(monkeypatch) -> None:
     with TestClient(app) as client:
         response = client.post(
             "/analytics/positions",
-            json={"portfolioId": "P-CONTRACT", "asOfDate": "2026-02-24", "sections": ["BASE"]},
+            json={"portfolio_id": "P-CONTRACT", "as_of_date": "2026-02-24", "sections": ["BASE"]},
         )
 
     assert response.status_code == 502
@@ -339,11 +339,11 @@ def test_e2e_capabilities_toggle_disables_input_modes(monkeypatch) -> None:
     monkeypatch.setenv("PA_CAP_ATTRIBUTION_ENABLED", "false")
 
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=lotus-manage&tenantId=tenant-b")
+        response = client.get("/integration/capabilities?consumer_system=lotus-manage&tenant_id=tenant-b")
 
     assert response.status_code == 200
     body = response.json()
-    assert body["supportedInputModes"] == []
+    assert body["supported_input_modes"] == []
     features = {item["key"]: item["enabled"] for item in body["features"]}
     assert features["pa.analytics.attribution"] is False
 
@@ -353,8 +353,8 @@ def test_e2e_pas_input_metadata_fallback_contract(monkeypatch) -> None:
         return (
             200,
             {
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {"day": 1, "perf_date": "2026-02-01", "begin_mv": 100.0, "end_mv": 101.0},
                     {"day": 2, "perf_date": "2026-02-23", "begin_mv": 101.0, "end_mv": 102.0},
                 ],
@@ -370,9 +370,9 @@ def test_e2e_pas_input_metadata_fallback_contract(monkeypatch) -> None:
         response = client.post(
             "/performance/twr/pas-input",
             json={
-                "portfolioId": "PORT-E2E-FALLBACK",
-                "asOfDate": "2026-02-23",
-                "consumerSystem": "lotus-gateway",
+                "portfolio_id": "PORT-E2E-FALLBACK",
+                "as_of_date": "2026-02-23",
+                "consumer_system": "lotus-gateway",
                 "periods": ["YTD"],
             },
         )
@@ -380,8 +380,8 @@ def test_e2e_pas_input_metadata_fallback_contract(monkeypatch) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["portfolio_id"] == "PORT-E2E-FALLBACK"
-    assert body["consumerSystem"] == "lotus-gateway"
-    assert body["pasContractVersion"] == "v1"
+    assert body["consumer_system"] == "lotus-gateway"
+    assert body["pas_contract_version"] == "v1"
 
 
 def test_e2e_contribution_rejects_empty_analyses_contract() -> None:

--- a/tests/integration/test_analytics_api.py
+++ b/tests/integration/test_analytics_api.py
@@ -10,9 +10,9 @@ def test_positions_analytics_success(monkeypatch):
         return (
             200,
             {
-                "portfolioId": portfolio_id,
-                "asOfDate": str(as_of_date),
-                "totalMarketValue": 1000.0,
+                "portfolio_id": portfolio_id,
+                "as_of_date": str(as_of_date),
+                "total_market_value": 1000.0,
                 "positions": [{"securityId": "EQ_1", "quantity": 10}],
             },
         )
@@ -25,16 +25,16 @@ def test_positions_analytics_success(monkeypatch):
     response = client.post(
         "/analytics/positions",
         json={
-            "portfolioId": "P1",
-            "asOfDate": "2026-02-24",
+            "portfolio_id": "P1",
+            "as_of_date": "2026-02-24",
             "sections": ["BASE", "VALUATION", "PERFORMANCE"],
             "performancePeriods": ["YTD"],
         },
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["portfolioId"] == "P1"
-    assert body["totalMarketValue"] == 1000.0
+    assert body["portfolio_id"] == "P1"
+    assert body["total_market_value"] == 1000.0
     assert len(body["positions"]) == 1
 
 
@@ -42,7 +42,7 @@ def test_positions_analytics_invalid_payload(monkeypatch):
     client = TestClient(app)
 
     async def _mock_get_positions_analytics(self, portfolio_id, as_of_date, sections, performance_periods):  # noqa: ARG001
-        return (200, {"portfolioId": "P1"})
+        return (200, {"portfolio_id": "P1"})
 
     monkeypatch.setattr(
         "app.api.endpoints.analytics.PasInputService.get_positions_analytics",
@@ -51,7 +51,7 @@ def test_positions_analytics_invalid_payload(monkeypatch):
 
     response = client.post(
         "/analytics/positions",
-        json={"portfolioId": "P1", "asOfDate": "2026-02-24"},
+        json={"portfolio_id": "P1", "as_of_date": "2026-02-24"},
     )
     assert response.status_code == 502
 
@@ -67,7 +67,7 @@ def test_positions_analytics_upstream_error_passthrough(monkeypatch):
         _mock_get_positions_analytics,
     )
 
-    response = client.post("/analytics/positions", json={"portfolioId": "P1", "asOfDate": "2026-02-24"})
+    response = client.post("/analytics/positions", json={"portfolio_id": "P1", "as_of_date": "2026-02-24"})
     assert response.status_code == 503
 
 

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -5,15 +5,15 @@ from main import app
 
 def test_integration_capabilities_default_contract():
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default")
+        response = client.get("/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default")
 
     assert response.status_code == 200
     body = response.json()
-    assert body["contractVersion"] == "v1"
-    assert body["sourceService"] == "lotus-performance"
-    assert body["consumerSystem"] == "lotus-gateway"
-    assert body["tenantId"] == "default"
-    assert body["supportedInputModes"] == ["core_api_ref", "inline_bundle"]
+    assert body["contract_version"] == "v1"
+    assert body["source_service"] == "lotus-performance"
+    assert body["consumer_system"] == "lotus-gateway"
+    assert body["tenant_id"] == "default"
+    assert body["supported_input_modes"] == ["core_api_ref", "inline_bundle"]
     assert len(body["features"]) >= 4
     assert len(body["workflows"]) >= 3
     features = {item["key"] for item in body["features"]}
@@ -29,22 +29,22 @@ def test_integration_capabilities_env_override(monkeypatch):
     monkeypatch.setenv("PLATFORM_INPUT_MODE_INLINE_BUNDLE_ENABLED", "false")
     monkeypatch.setenv("PA_POLICY_VERSION", "tenant-a-v4")
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=lotus-manage&tenantId=tenant-a")
+        response = client.get("/integration/capabilities?consumer_system=lotus-manage&tenant_id=tenant-a")
 
     assert response.status_code == 200
     body = response.json()
-    assert body["consumerSystem"] == "lotus-manage"
-    assert body["tenantId"] == "tenant-a"
-    assert body["policyVersion"] == "tenant-a-v4"
+    assert body["consumer_system"] == "lotus-manage"
+    assert body["tenant_id"] == "tenant-a"
+    assert body["policy_version"] == "tenant-a-v4"
     features = {item["key"]: item["enabled"] for item in body["features"]}
     assert features["pa.analytics.attribution"] is False
-    assert body["supportedInputModes"] == ["core_api_ref"]
+    assert body["supported_input_modes"] == ["core_api_ref"]
 
 
 def test_integration_capabilities_limit_guardrails():
     with TestClient(app) as client:
         response = client.get(
-            "/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default&featureLimit=2&workflowLimit=1"
+            "/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default&feature_limit=2&workflow_limit=1"
         )
 
     assert response.status_code == 200

--- a/tests/integration/test_performance_api.py
+++ b/tests/integration/test_performance_api.py
@@ -397,11 +397,11 @@ def test_twr_pas_input_success(client, monkeypatch):
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {
                         "day": 1,
                         "perf_date": "2026-02-01",
@@ -430,9 +430,9 @@ def test_twr_pas_input_success(client, monkeypatch):
     )
 
     payload = {
-        "portfolioId": "PORT-1001",
-        "asOfDate": "2026-02-23",
-        "consumerSystem": "lotus-gateway",
+        "portfolio_id": "PORT-1001",
+        "as_of_date": "2026-02-23",
+        "consumer_system": "lotus-gateway",
         "periods": ["YTD"],
     }
 
@@ -441,9 +441,9 @@ def test_twr_pas_input_success(client, monkeypatch):
     body = response.json()
     assert body["portfolio_id"] == "PORT-1001"
     assert body["source_mode"] == "core_api_ref"
-    assert body["pasContractVersion"] == "v1"
-    assert "YTD" in body["resultsByPeriod"]
-    assert body["resultsByPeriod"]["YTD"]["net_cumulative_return"] is not None
+    assert body["pas_contract_version"] == "v1"
+    assert "YTD" in body["results_by_period"]
+    assert body["results_by_period"]["YTD"]["net_cumulative_return"] is not None
 
 
 def test_twr_pas_input_period_filter(client, monkeypatch):
@@ -451,11 +451,11 @@ def test_twr_pas_input_period_filter(client, monkeypatch):
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {
                         "day": 1,
                         "perf_date": "2026-01-01",
@@ -484,16 +484,16 @@ def test_twr_pas_input_period_filter(client, monkeypatch):
     )
 
     payload = {
-        "portfolioId": "PORT-1001",
-        "asOfDate": "2026-02-23",
+        "portfolio_id": "PORT-1001",
+        "as_of_date": "2026-02-23",
         "periods": ["YTD", "MTD"],
     }
 
     response = client.post("/performance/twr/pas-input", json=payload)
     assert response.status_code == 200
     body = response.json()
-    assert "YTD" in body["resultsByPeriod"]
-    assert "MTD" in body["resultsByPeriod"]
+    assert "YTD" in body["results_by_period"]
+    assert "MTD" in body["results_by_period"]
 
 
 def test_twr_pas_input_invalid_payload_returns_502(client, monkeypatch):
@@ -501,10 +501,10 @@ def test_twr_pas_input_invalid_payload_returns_502(client, monkeypatch):
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
             },
         )
 
@@ -514,13 +514,13 @@ def test_twr_pas_input_invalid_payload_returns_502(client, monkeypatch):
     )
 
     payload = {
-        "portfolioId": "PORT-1001",
-        "asOfDate": "2026-02-23",
+        "portfolio_id": "PORT-1001",
+        "as_of_date": "2026-02-23",
     }
 
     response = client.post("/performance/twr/pas-input", json=payload)
     assert response.status_code == 502
-    assert "missing valuationPoints" in response.json()["detail"]
+    assert "missing valuation_points" in response.json()["detail"]
 
 
 def test_twr_pas_input_falls_back_to_request_metadata_when_upstream_fields_missing(client, monkeypatch):
@@ -528,8 +528,8 @@ def test_twr_pas_input_falls_back_to_request_metadata_when_upstream_fields_missi
         return (
             200,
             {
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {
                         "day": 1,
                         "perf_date": "2026-02-01",
@@ -558,9 +558,9 @@ def test_twr_pas_input_falls_back_to_request_metadata_when_upstream_fields_missi
     )
 
     payload = {
-        "portfolioId": "PORT-FALLBACK-01",
-        "asOfDate": "2026-02-23",
-        "consumerSystem": "lotus-gateway",
+        "portfolio_id": "PORT-FALLBACK-01",
+        "as_of_date": "2026-02-23",
+        "consumer_system": "lotus-gateway",
         "periods": ["YTD"],
     }
 
@@ -568,8 +568,8 @@ def test_twr_pas_input_falls_back_to_request_metadata_when_upstream_fields_missi
     assert response.status_code == 200
     body = response.json()
     assert body["portfolio_id"] == "PORT-FALLBACK-01"
-    assert body["consumerSystem"] == "lotus-gateway"
-    assert body["pasContractVersion"] == "v1"
+    assert body["consumer_system"] == "lotus-gateway"
+    assert body["pas_contract_version"] == "v1"
 
 
 def test_twr_pas_input_upstream_error_passthrough(client, monkeypatch):
@@ -582,8 +582,8 @@ def test_twr_pas_input_upstream_error_passthrough(client, monkeypatch):
     )
 
     payload = {
-        "portfolioId": "UNKNOWN",
-        "asOfDate": "2026-02-23",
+        "portfolio_id": "UNKNOWN",
+        "as_of_date": "2026-02-23",
     }
 
     response = client.post("/performance/twr/pas-input", json=payload)
@@ -595,10 +595,10 @@ def test_twr_pas_input_missing_performance_start_date_returns_502(client, monkey
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "valuationPoints": [{"day": 1, "perf_date": "2026-02-01", "begin_mv": 100, "end_mv": 101}],
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "valuation_points": [{"day": 1, "perf_date": "2026-02-01", "begin_mv": 100, "end_mv": 101}],
             },
         )
 
@@ -607,9 +607,9 @@ def test_twr_pas_input_missing_performance_start_date_returns_502(client, monkey
         _mock_get_performance_input,
     )
 
-    response = client.post("/performance/twr/pas-input", json={"portfolioId": "PORT-1001", "asOfDate": "2026-02-23"})
+    response = client.post("/performance/twr/pas-input", json={"portfolio_id": "PORT-1001", "as_of_date": "2026-02-23"})
     assert response.status_code == 502
-    assert "missing performanceStartDate" in response.json()["detail"]
+    assert "missing performance_start_date" in response.json()["detail"]
 
 
 def test_twr_pas_input_invalid_valuation_shape_returns_502(client, monkeypatch):
@@ -617,11 +617,11 @@ def test_twr_pas_input_invalid_valuation_shape_returns_502(client, monkeypatch):
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [{"perf_date": "2026-02-01"}],
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [{"perf_date": "2026-02-01"}],
             },
         )
 
@@ -630,7 +630,7 @@ def test_twr_pas_input_invalid_valuation_shape_returns_502(client, monkeypatch):
         _mock_get_performance_input,
     )
 
-    response = client.post("/performance/twr/pas-input", json={"portfolioId": "PORT-1001", "asOfDate": "2026-02-23"})
+    response = client.post("/performance/twr/pas-input", json={"portfolio_id": "PORT-1001", "as_of_date": "2026-02-23"})
     assert response.status_code == 502
     assert "Invalid lotus-core performance input payload" in response.json()["detail"]
 
@@ -640,11 +640,11 @@ def test_twr_pas_input_requested_period_not_found_returns_404(client, monkeypatc
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {
                         "day": 1,
                         "perf_date": "2026-02-01",
@@ -685,7 +685,7 @@ def test_twr_pas_input_requested_period_not_found_returns_404(client, monkeypatc
 
     response = client.post(
         "/performance/twr/pas-input",
-        json={"portfolioId": "PORT-1001", "asOfDate": "2026-02-23", "periods": ["YTD"]},
+        json={"portfolio_id": "PORT-1001", "as_of_date": "2026-02-23", "periods": ["YTD"]},
     )
     assert response.status_code == 404
     assert "Requested periods not found" in response.json()["detail"]
@@ -696,11 +696,11 @@ def test_twr_pas_input_skips_period_without_summary_and_returns_remaining(client
         return (
             200,
             {
-                "contractVersion": "v1",
-                "consumerSystem": "lotus-gateway",
-                "portfolioId": portfolio_id,
-                "performanceStartDate": "2026-01-01",
-                "valuationPoints": [
+                "contract_version": "v1",
+                "consumer_system": "lotus-gateway",
+                "portfolio_id": portfolio_id,
+                "performance_start_date": "2026-01-01",
+                "valuation_points": [
                     {"day": 1, "perf_date": "2026-01-01", "begin_mv": 100.0, "end_mv": 101.0},
                     {"day": 2, "perf_date": "2026-02-23", "begin_mv": 101.0, "end_mv": 102.0},
                 ],
@@ -734,9 +734,9 @@ def test_twr_pas_input_skips_period_without_summary_and_returns_remaining(client
 
     response = client.post(
         "/performance/twr/pas-input",
-        json={"portfolioId": "PORT-1001", "asOfDate": "2026-02-23", "periods": ["YTD", "MTD"]},
+        json={"portfolio_id": "PORT-1001", "as_of_date": "2026-02-23", "periods": ["YTD", "MTD"]},
     )
     assert response.status_code == 200
-    results = response.json()["resultsByPeriod"]
+    results = response.json()["results_by_period"]
     assert "YTD" not in results
     assert "MTD" in results

--- a/tests/unit/app/test_openapi_enrichment.py
+++ b/tests/unit/app/test_openapi_enrichment.py
@@ -1,0 +1,110 @@
+from app.openapi_enrichment import (
+    _infer_description,
+    _infer_example,
+    _to_snake_case,
+    enrich_openapi_schema,
+)
+
+
+def test_to_snake_case_normalizes_camel_and_symbols():
+    assert _to_snake_case("totalMarketValue") == "total_market_value"
+    assert _to_snake_case("as-of.date") == "as_of_date"
+
+
+def test_infer_example_prefers_named_examples_and_schema_hints():
+    assert _infer_example("portfolio_id", {"type": "string"}) == "DEMO_DPM_EUR_001"
+    assert _infer_example("period", {"enum": ["YTD", "MTD"]}) == "YTD"
+    assert _infer_example("as_of_date", {"type": "string", "format": "date"}) == "2026-02-27"
+    assert _infer_example("generated_at", {"type": "string", "format": "date-time"}) == "2026-02-27T10:30:00Z"
+    assert _infer_example("is_ready", {"type": "boolean"}) is True
+    assert _infer_example("count", {"type": "integer"}) == 1
+    assert _infer_example("value", {"type": "number"}) == 0.1234
+    assert _infer_example("items", {"type": "array", "items": {"type": "string"}}) == ["example_items_item"]
+    assert _infer_example("meta", {"type": "object"}) == {"key": "value"}
+    assert _infer_example("custom_id", {"type": "string"}) == "CUSTOM_001"
+
+
+def test_infer_description_uses_semantic_branches():
+    assert _infer_description("Response", "client_id", {"type": "string"}) == "Unique client identifier."
+    assert _infer_description("Response", "as_of_date", {"format": "date"}) == "Business date for as of date."
+    assert _infer_description("Response", "generated_at", {"format": "date-time"}) == "Timestamp for generated at."
+    assert _infer_description("Response", "base_currency", {"type": "string"}) == "ISO currency code for base currency."
+    assert (
+        _infer_description("Response", "performance_return", {"type": "number"})
+        == "Performance metric value for performance return."
+    )
+    assert _infer_description("Response", "net_value", {"type": "number"}) == "Monetary value for net value."
+    assert _infer_description("ResponseModel", "note", {"type": "string"}) == "response model field: note."
+
+
+def test_enrich_openapi_schema_fills_operation_and_schema_gaps():
+    schema = {
+        "paths": {
+            "/health": {
+                "get": {
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+            "/metrics": {
+                "get": {
+                    "summary": "Metrics",
+                    "description": "Metrics endpoint",
+                    "tags": ["Monitoring"],
+                    "responses": {"200": {"description": "ok"}, "500": {"description": "error"}},
+                }
+            },
+            "/performance/twr": {
+                "post": {
+                    "summary": "Compute TWR",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "HealthResponse": {
+                    "type": "object",
+                    "properties": {
+                        "status": {"type": "string"},
+                        "request_id": {"type": "string", "description": "Already set", "example": "REQ_1"},
+                        "nested_ref": {"$ref": "#/components/schemas/Other"},
+                    },
+                },
+                "Other": {
+                    "type": "object",
+                    "properties": {"count": {"type": "integer"}},
+                },
+            }
+        },
+    }
+
+    enriched = enrich_openapi_schema(schema)
+
+    health_get = enriched["paths"]["/health"]["get"]
+    assert health_get["summary"] == "GET /health"
+    assert health_get["description"] == "GET operation for /health in lotus-performance."
+    assert health_get["tags"] == ["Health"]
+    assert "default" in health_get["responses"]
+
+    perf_post = enriched["paths"]["/performance/twr"]["post"]
+    assert perf_post["description"] == "POST operation for /performance/twr in lotus-performance."
+    assert perf_post["tags"] == ["Performance"]
+    assert "default" in perf_post["responses"]
+
+    metrics_get = enriched["paths"]["/metrics"]["get"]
+    assert metrics_get["summary"] == "Metrics"
+    assert metrics_get["description"] == "Metrics endpoint"
+    assert metrics_get["tags"] == ["Monitoring"]
+    assert "default" not in metrics_get["responses"]
+
+    status_prop = enriched["components"]["schemas"]["HealthResponse"]["properties"]["status"]
+    assert status_prop["description"]
+    assert status_prop["example"] == "ok"
+
+    request_id_prop = enriched["components"]["schemas"]["HealthResponse"]["properties"]["request_id"]
+    assert request_id_prop["description"] == "Already set"
+    assert request_id_prop["example"] == "REQ_1"
+
+    other_count = enriched["components"]["schemas"]["Other"]["properties"]["count"]
+    assert other_count["description"]
+    assert other_count["example"] == 1

--- a/tests/unit/services/test_pas_input_service.py
+++ b/tests/unit/services/test_pas_input_service.py
@@ -72,14 +72,14 @@ async def test_get_core_snapshot_posts_contract_payload():
     assert status_code == 200
     assert payload["snapshot"] == {"overview": {}}
     assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/portfolios/PORT-1/core-snapshot"
-    assert _FakeAsyncClient.calls[0]["json"]["includeSections"] == ["OVERVIEW", "HOLDINGS"]
-    assert _FakeAsyncClient.calls[0]["json"]["consumerSystem"] == "lotus-performance"
+    assert _FakeAsyncClient.calls[0]["json"]["include_sections"] == ["OVERVIEW", "HOLDINGS"]
+    assert _FakeAsyncClient.calls[0]["json"]["consumer_system"] == "lotus-performance"
 
 
 @pytest.mark.asyncio
 async def test_get_performance_input_posts_contract_payload():
     service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
-    _FakeAsyncClient.queue_json(200, {"valuationPoints": []})
+    _FakeAsyncClient.queue_json(200, {"valuation_points": []})
 
     status_code, payload = await service.get_performance_input(
         portfolio_id="PORT-2",
@@ -89,16 +89,16 @@ async def test_get_performance_input_posts_contract_payload():
     )
 
     assert status_code == 200
-    assert "valuationPoints" in payload
+    assert "valuation_points" in payload
     assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/portfolios/PORT-2/performance-input"
-    assert _FakeAsyncClient.calls[0]["json"]["lookbackDays"] == 365
+    assert _FakeAsyncClient.calls[0]["json"]["lookback_days"] == 365
 
 
 @pytest.mark.asyncio
 async def test_get_positions_analytics_with_and_without_performance_periods():
     service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
-    _FakeAsyncClient.queue_json(200, {"portfolioId": "PORT-3"})
-    _FakeAsyncClient.queue_json(200, {"portfolioId": "PORT-3"})
+    _FakeAsyncClient.queue_json(200, {"portfolio_id": "PORT-3"})
+    _FakeAsyncClient.queue_json(200, {"portfolio_id": "PORT-3"})
 
     status_one, _ = await service.get_positions_analytics(
         portfolio_id="PORT-3",
@@ -116,8 +116,8 @@ async def test_get_positions_analytics_with_and_without_performance_periods():
     assert status_one == 200
     assert status_two == 200
     assert _FakeAsyncClient.calls[0]["url"] == "http://pas/portfolios/PORT-3/positions-analytics"
-    assert _FakeAsyncClient.calls[0]["json"]["performanceOptions"]["periods"] == ["YTD", "MTD"]
-    assert "performanceOptions" not in _FakeAsyncClient.calls[1]["json"]
+    assert _FakeAsyncClient.calls[0]["json"]["performance_options"]["periods"] == ["YTD", "MTD"]
+    assert "performance_options" not in _FakeAsyncClient.calls[1]["json"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- implement RFC-0067 app-level controls for lotus-performance
- add scripts/api_vocabulary_inventory.py (generate + validate-only drift gate)
- add scripts/no_alias_contract_guard.py
- harden scripts/openapi_quality_gate.py to enforce operation docs/responses and schema property metadata
- add OpenAPI enrichment in app generation path to close metadata gaps deterministically
- canonicalize API contracts to snake_case (remove alias/populate-by-name paths)
- update integration/e2e/unit tests for canonical contracts
- add and generate docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json

## Gates
- make check passed
- make ci-local passed
- python scripts/no_alias_contract_guard.py passed
- python scripts/openapi_quality_gate.py passed
- python scripts/api_vocabulary_inventory.py --validate-only passed

## Notes
- monetary float allowlist was refreshed due line-offset drift after model refactors (docs/standards/monetary-float-allowlist.json).