### PR TITLE
feat: wire returns-series core_api_ref to lotus-core RFC-062 contracts

### DIFF
--- a/app/services/pas_input_service.py
+++ b/app/services/pas_input_service.py
@@ -89,3 +89,75 @@ class PasInputService:
             max_retries=self._max_retries,
             backoff_seconds=self._retry_backoff_seconds,
         )
+
+    async def get_benchmark_assignment(
+        self,
+        portfolio_id: str,
+        as_of_date: date,
+        reporting_currency: str | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/integration/portfolios/{portfolio_id}/benchmark-assignment"
+        payload: dict[str, Any] = {"as_of_date": str(as_of_date)}
+        if reporting_currency:
+            payload["reporting_currency"] = reporting_currency
+        headers = propagation_headers()
+        return await post_with_retry(
+            url=url,
+            timeout_seconds=self._timeout,
+            json_body=payload,
+            headers=headers,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+        )
+
+    async def get_benchmark_return_series(
+        self,
+        benchmark_id: str,
+        as_of_date: date,
+        start_date: date,
+        end_date: date,
+        frequency: str = "daily",
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/integration/benchmarks/{benchmark_id}/return-series"
+        payload = {
+            "as_of_date": str(as_of_date),
+            "window": {"start_date": str(start_date), "end_date": str(end_date)},
+            "frequency": frequency,
+        }
+        headers = propagation_headers()
+        return await post_with_retry(
+            url=url,
+            timeout_seconds=self._timeout,
+            json_body=payload,
+            headers=headers,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+        )
+
+    async def get_risk_free_series(
+        self,
+        currency: str,
+        as_of_date: date,
+        start_date: date,
+        end_date: date,
+        *,
+        frequency: str = "daily",
+        series_mode: str = "return_series",
+    ) -> tuple[int, dict[str, Any]]:
+        url = f"{self._base_url}/integration/reference/risk-free-series"
+        payload = {
+            "currency": currency,
+            "series_mode": series_mode,
+            "as_of_date": str(as_of_date),
+            "window": {"start_date": str(start_date), "end_date": str(end_date)},
+            "frequency": frequency,
+        }
+        headers = propagation_headers()
+        return await post_with_retry(
+            url=url,
+            timeout_seconds=self._timeout,
+            json_body=payload,
+            headers=headers,
+            max_retries=self._max_retries,
+            backoff_seconds=self._retry_backoff_seconds,
+        )

--- a/tests/unit/services/test_pas_input_service.py
+++ b/tests/unit/services/test_pas_input_service.py
@@ -157,3 +157,60 @@ async def test_text_error_payload_is_mapped_to_detail():
     )
     assert status_code == 503
     assert payload["detail"] == "upstream unavailable"
+
+
+@pytest.mark.asyncio
+async def test_get_benchmark_assignment_posts_contract_payload():
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"benchmark_id": "BMK_1"})
+
+    status_code, payload = await service.get_benchmark_assignment(
+        portfolio_id="PORT-5",
+        as_of_date=date(2026, 2, 24),
+        reporting_currency="USD",
+    )
+
+    assert status_code == 200
+    assert payload["benchmark_id"] == "BMK_1"
+    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/portfolios/PORT-5/benchmark-assignment"
+    assert _FakeAsyncClient.calls[0]["json"]["as_of_date"] == "2026-02-24"
+    assert _FakeAsyncClient.calls[0]["json"]["reporting_currency"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_get_benchmark_return_series_posts_contract_payload():
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"points": []})
+
+    status_code, payload = await service.get_benchmark_return_series(
+        benchmark_id="BMK_2",
+        as_of_date=date(2026, 2, 24),
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 2, 24),
+    )
+
+    assert status_code == 200
+    assert payload["points"] == []
+    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/benchmarks/BMK_2/return-series"
+    assert _FakeAsyncClient.calls[0]["json"]["window"]["start_date"] == "2026-01-01"
+    assert _FakeAsyncClient.calls[0]["json"]["window"]["end_date"] == "2026-02-24"
+    assert _FakeAsyncClient.calls[0]["json"]["frequency"] == "daily"
+
+
+@pytest.mark.asyncio
+async def test_get_risk_free_series_posts_contract_payload():
+    service = PasInputService(base_url="http://pas", timeout_seconds=2.0)
+    _FakeAsyncClient.queue_json(200, {"points": []})
+
+    status_code, payload = await service.get_risk_free_series(
+        currency="USD",
+        as_of_date=date(2026, 2, 24),
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 2, 24),
+    )
+
+    assert status_code == 200
+    assert payload["points"] == []
+    assert _FakeAsyncClient.calls[0]["url"] == "http://pas/integration/reference/risk-free-series"
+    assert _FakeAsyncClient.calls[0]["json"]["currency"] == "USD"
+    assert _FakeAsyncClient.calls[0]["json"]["series_mode"] == "return_series"


### PR DESCRIPTION
## Summary\n- replace partial local bridge logic with clean RFC-062 aligned integration in POST /integration/returns/series\n- keep portfolio series sourcing via existing lotus-core performance-input contract\n- add benchmark sourcing via RFC-062 benchmark assignment + benchmark return-series contracts\n- add risk-free sourcing via RFC-062 risk-free-series contract\n- preserve deterministic policy behavior (intersection/fill/fail-fast) and provenance metadata\n\n## Service client updates\n- add PasInputService.get_benchmark_assignment\n- add PasInputService.get_benchmark_return_series\n- add PasInputService.get_risk_free_series\n\n## Tests\n- update returns-series integration tests for real core_api_ref behavior with mocked upstream contracts\n- add unit tests for new PAS client methods\n\n## Validation\n- make check\n- python -m pytest tests/integration/test_returns_series_api.py -q\n