### PR TITLE
docs(methodology): add lotus-performance metric methodology set

### DIFF
--- a/docs/methodologies/metrics/master-index.md
+++ b/docs/methodologies/metrics/master-index.md
@@ -1,0 +1,42 @@
+# Lotus-Performance Metrics Methodology Index
+
+This index maps implemented lotus-performance metrics to detailed methodology documents.
+
+| Metric | Primary Endpoint(s) | Modes | Document |
+|---|---|---|---|
+| TWR Base Return | POST /performance/twr | Stateless | [metric-twr-base-return.md](./metric-twr-base-return.md) |
+| TWR Local Return | POST /performance/twr | Stateless | [metric-twr-local-return.md](./metric-twr-local-return.md) |
+| TWR FX Return | POST /performance/twr | Stateless | [metric-twr-fx-return.md](./metric-twr-fx-return.md) |
+| MWR (XIRR) | POST /performance/mwr | Stateless | [metric-mwr-xirr.md](./metric-mwr-xirr.md) |
+| MWR (Dietz fallback / explicit) | POST /performance/mwr | Stateless | [metric-mwr-dietz.md](./metric-mwr-dietz.md) |
+| Position Total Contribution | POST /performance/contribution | Stateless | [metric-contribution-total.md](./metric-contribution-total.md) |
+| Position Local Contribution | POST /performance/contribution | Stateless | [metric-contribution-local.md](./metric-contribution-local.md) |
+| Position FX Contribution | POST /performance/contribution | Stateless | [metric-contribution-fx.md](./metric-contribution-fx.md) |
+| Attribution Allocation Effect | POST /performance/attribution | Stateless | [metric-attribution-allocation.md](./metric-attribution-allocation.md) |
+| Attribution Selection Effect | POST /performance/attribution | Stateless | [metric-attribution-selection.md](./metric-attribution-selection.md) |
+| Attribution Interaction Effect | POST /performance/attribution | Stateless | [metric-attribution-interaction.md](./metric-attribution-interaction.md) |
+| Attribution Total Active Return | POST /performance/attribution | Stateless | [metric-attribution-active-return.md](./metric-attribution-active-return.md) |
+| Currency Local Allocation | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-local-allocation.md](./metric-currency-local-allocation.md) |
+| Currency Local Selection | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-local-selection.md](./metric-currency-local-selection.md) |
+| Currency Allocation | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-allocation.md](./metric-currency-allocation.md) |
+| Currency Selection | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-selection.md](./metric-currency-selection.md) |
+| Portfolio Return Series | POST /integration/returns/series | Stateless + Stateful | [metric-returns-series-portfolio.md](./metric-returns-series-portfolio.md) |
+| Benchmark Return Series | POST /integration/returns/series | Stateless + Stateful | [metric-returns-series-benchmark.md](./metric-returns-series-benchmark.md) |
+| Risk-Free Return Series | POST /integration/returns/series | Stateless + Stateful | [metric-returns-series-risk-free.md](./metric-returns-series-risk-free.md) |
+
+## Notes
+- simulation mode is not exposed on lotus-performance public analytics contracts in this slice.
+- Stateful execution currently applies to the returns-series integration endpoint; core performance analytics endpoints remain request-data driven.
+- In current engine behavior, `mwr_method=MODIFIED_DIETZ` is mapped to the same Dietz computation path as `DIETZ`.
+
+
+## Documentation Standard
+Each metric document in this set follows the same architecture review template:
+- endpoint and mode scope
+- upstream data dependencies
+- explicit inputs
+- formulas and methodology
+- output field semantics
+- configuration levers
+- assumptions and edge-case handling
+- worked numerical example

--- a/docs/methodologies/metrics/metric-attribution-active-return.md
+++ b/docs/methodologies/metrics/metric-attribution-active-return.md
@@ -1,0 +1,39 @@
+# Metric: Total Active Return (Attribution Reconciliation)
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution`.
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request payload portfolio and benchmark grouped data.
+
+## Inputs
+- Per-period portfolio and benchmark returns (derived from group panels).
+
+## Methodology and Formulas
+- Arithmetic (no linking): `AR = Σ_t (R_p,t - R_b,t)`.
+- Linked mode: geometric active return from compounded portfolio minus compounded benchmark.
+- Reconciliation: `residual = total_active_return - sum_of_effects`.
+
+## Outputs
+- `reconciliation.total_active_return`, `sum_of_effects`, `residual`.
+
+## Configuration Options
+- `linking` setting controls arithmetic vs scaled linked effects.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- If portfolio period return 6% and benchmark 5%, active return = 1.00%.
+
+
+

--- a/docs/methodologies/metrics/metric-attribution-allocation.md
+++ b/docs/methodologies/metrics/metric-attribution-allocation.md
@@ -1,0 +1,39 @@
+# Metric: Attribution Allocation Effect
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution`.
+
+## Supported Calculation Modes
+- Stateless (`by_group` or `by_instrument`).
+
+## Upstream Data Sources and Exact Data Points
+- Request payload portfolio/benchmark grouped observations; optional instrument metadata path.
+
+## Inputs
+- Portfolio and benchmark start weights (`w_p`, `w_b`), benchmark return terms, model choice.
+
+## Methodology and Formulas
+- Brinson-Fachler: `Allocation = (w_p - w_b) * (r_b_group - r_b_total)`.
+- Brinson-Hood-Beebower: `Allocation = (w_p - w_b) * r_b_group`.
+- Aggregated across requested hierarchy and optionally linked across periods.
+
+## Outputs
+- `levels[].groups[].allocation`, level totals, reconciliation block.
+
+## Configuration Options
+- `model` (`BRINSON_FACHLER|BRINSON_HOOD_BEEBOWER`), `linking` (`NONE|...`).
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- `w_p=0.6`, `w_b=0.5`, `r_b_group=4%`, `r_b_total=3%` => BF allocation `0.1*(0.04-0.03)=0.10%`.
+
+
+

--- a/docs/methodologies/metrics/metric-attribution-interaction.md
+++ b/docs/methodologies/metrics/metric-attribution-interaction.md
@@ -1,0 +1,37 @@
+# Metric: Attribution Interaction Effect
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution`.
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request payload grouped returns and weights.
+
+## Inputs
+- Weight difference and relative return difference.
+
+## Methodology and Formulas
+- Both models: `Interaction = (w_p - w_b) * (r_p - r_b)`.
+
+## Outputs
+- `levels[].groups[].interaction` and totals.
+
+## Configuration Options
+- `group_by`, `linking`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- `w_p-w_b=0.1`, `r_p-r_b=1%` => interaction `0.10%`.
+
+
+

--- a/docs/methodologies/metrics/metric-attribution-selection.md
+++ b/docs/methodologies/metrics/metric-attribution-selection.md
@@ -1,0 +1,38 @@
+# Metric: Attribution Selection Effect
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution`.
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request payload grouped returns.
+
+## Inputs
+- Portfolio and benchmark group returns, benchmark weights or portfolio weights depending on model.
+
+## Methodology and Formulas
+- Brinson-Fachler: `Selection = w_b * (r_p - r_b)`.
+- BHB: `Selection = w_p * (r_p - r_b)`.
+
+## Outputs
+- `levels[].groups[].selection` and totals.
+
+## Configuration Options
+- `model`, `mode`, `group_by`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- BF: `w_b=0.5`, `r_p=5%`, `r_b=4%` => selection `0.5*1%=0.50%`.
+
+
+

--- a/docs/methodologies/metrics/metric-contribution-fx.md
+++ b/docs/methodologies/metrics/metric-contribution-fx.md
@@ -1,0 +1,38 @@
+# Metric: Position FX Contribution
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/contribution` (multi-currency path).
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request valuation/FX inputs.
+
+## Inputs
+- Total contribution and local contribution by position/day.
+
+## Methodology and Formulas
+- Daily FX contribution derived as residual: `fx_contribution = total_contribution - local_contribution`.
+- Period FX contribution is aggregated across days/groups.
+
+## Outputs
+- `fx_contribution` fields in position rows and summaries.
+
+## Configuration Options
+- `currency_mode=BOTH`, `fx`, smoothing mode.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- If period total contribution=1.10% and local=0.80%, FX contribution=0.30%.
+
+
+

--- a/docs/methodologies/metrics/metric-contribution-local.md
+++ b/docs/methodologies/metrics/metric-contribution-local.md
@@ -1,0 +1,38 @@
+# Metric: Position Local Contribution
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/contribution` (multi-currency path).
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request valuation points + FX context when `currency_mode=BOTH`.
+
+## Inputs
+- Daily weight and daily local return (`local_ror`).
+
+## Methodology and Formulas
+- `local_contribution_i,t = w_i,t * local_ror_i,t`.
+- Period local contribution is sum across days (and hierarchy aggregation as applicable).
+
+## Outputs
+- `local_contribution` fields in position rows and summaries.
+
+## Configuration Options
+- `currency_mode=BOTH`, `fx`, `report_ccy`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- `w=0.5`, local daily returns 1% and 0.5% => local contribution `0.5*(0.01+0.005)=0.75%`.
+
+
+

--- a/docs/methodologies/metrics/metric-contribution-total.md
+++ b/docs/methodologies/metrics/metric-contribution-total.md
@@ -1,0 +1,40 @@
+# Metric: Position Total Contribution
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/contribution`.
+
+## Supported Calculation Modes
+- Stateless input bundle (`portfolio_data`, `positions_data`).
+
+## Upstream Data Sources and Exact Data Points
+- Request payload only.
+
+## Inputs
+- Position and portfolio valuation series, weighting scheme (`BOD`), smoothing method.
+
+## Methodology and Formulas
+- Daily weight: `w_i,t = capital_i,t / capital_port,t`, where `capital = begin_mv + bod_cf` for BOD mode.
+- Raw contribution: `c_i,t = w_i,t * r_i,t`.
+- Multi-period linking uses Carino smoothing when configured, plus residual allocation by average weight so sum of position contributions reconciles to portfolio return.
+
+## Outputs
+- `results_by_period[*].position_contributions[].total_contribution`
+- Period `total_contribution` and `total_portfolio_return`.
+
+## Configuration Options
+- `weighting_scheme`, `smoothing.method`, `hierarchy`, `currency_mode`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- If two days have `w=0.6`, returns 1% and 2%, raw contribution = `0.6*0.01 + 0.6*0.02 = 1.8%` before smoothing/residual.
+
+
+

--- a/docs/methodologies/metrics/metric-currency-allocation.md
+++ b/docs/methodologies/metrics/metric-currency-allocation.md
@@ -1,0 +1,37 @@
+# Metric: Currency Attribution Currency Allocation
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution` with `currency_mode=BOTH`.
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request currency benchmark return components.
+
+## Inputs
+- `w_p`, `w_b`, `r_local_b`, `r_fx_b`.
+
+## Methodology and Formulas
+- Currency allocation: `(w_p - w_b) * (1 + r_local_b) * r_fx_b`.
+
+## Outputs
+- `currency_attribution[].effects.currency_allocation`.
+
+## Configuration Options
+- `currency_mode=BOTH`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- `w diff=0.05`, `r_local_b=2%`, `r_fx_b=1%` => `0.05*1.02*0.01=0.051%`.
+
+
+

--- a/docs/methodologies/metrics/metric-currency-local-allocation.md
+++ b/docs/methodologies/metrics/metric-currency-local-allocation.md
@@ -1,0 +1,37 @@
+# Metric: Currency Attribution Local Allocation
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution` with `currency_mode=BOTH`.
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request benchmark/portfolio local and FX return inputs by currency group.
+
+## Inputs
+- `w_p`, `w_b`, benchmark local return `r_local_b`.
+
+## Methodology and Formulas
+- Karnosky-Singer local allocation: `(w_p - w_b) * r_local_b`.
+
+## Outputs
+- `currency_attribution[].effects.local_allocation`.
+
+## Configuration Options
+- `currency_mode=BOTH`, grouped currency data present.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- `w_p=0.55`, `w_b=0.50`, `r_local_b=2%` => `0.05*0.02=0.10%`.
+
+
+

--- a/docs/methodologies/metrics/metric-currency-local-selection.md
+++ b/docs/methodologies/metrics/metric-currency-local-selection.md
@@ -1,0 +1,37 @@
+# Metric: Currency Attribution Local Selection
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution` with `currency_mode=BOTH`.
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request local return series by currency.
+
+## Inputs
+- `w_b`, `r_local_p`, `r_local_b`.
+
+## Methodology and Formulas
+- Local selection: `w_b * (r_local_p - r_local_b)`.
+
+## Outputs
+- `currency_attribution[].effects.local_selection`.
+
+## Configuration Options
+- `currency_mode=BOTH`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- `w_b=0.5`, local excess=0.5% => `0.25%`.
+
+
+

--- a/docs/methodologies/metrics/metric-currency-selection.md
+++ b/docs/methodologies/metrics/metric-currency-selection.md
@@ -1,0 +1,37 @@
+# Metric: Currency Attribution Currency Selection
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/attribution` with `currency_mode=BOTH`.
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request currency local/FX components.
+
+## Inputs
+- `w_b`, `(r_local_p-r_local_b)`, `r_fx_b`.
+
+## Methodology and Formulas
+- Currency selection: `w_b * (r_local_p - r_local_b) * r_fx_b`.
+
+## Outputs
+- `currency_attribution[].effects.currency_selection`; total effect is sum of four currency effects.
+
+## Configuration Options
+- `currency_mode=BOTH`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- `w_b=0.5`, local excess=0.5%, `r_fx_b=1%` => `0.5*0.005*0.01=0.0025%`.
+
+
+

--- a/docs/methodologies/metrics/metric-mwr-dietz.md
+++ b/docs/methodologies/metrics/metric-mwr-dietz.md
@@ -1,0 +1,42 @@
+# Metric: Money-Weighted Return (Simple Dietz Fallback)
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/mwr` (fallback from XIRR failure, or explicit `DIETZ`/`MODIFIED_DIETZ` request).
+
+## Supported Calculation Modes
+- Stateless.
+
+## Upstream Data Sources and Exact Data Points
+- Request payload only.
+
+## Inputs
+- `begin_mv`, `end_mv`, net cash flow `ΣCF`.
+
+## Methodology and Formulas
+- Periodic rate: `r = (end_mv - begin_mv - ΣCF) / (begin_mv + ΣCF/2)`.
+- If denominator is zero, return `0` with explanatory note.
+- If annualization enabled: `r_ann = (1+r)^{ppy/days}-1` where `ppy` from basis (`ACT/ACT`=>365.25 else 365).
+- Current implementation note: `MODIFIED_DIETZ` requests are handled by this same Dietz formula path in the engine.
+
+## Outputs
+- `money_weighted_return` (%), optional `mwr_annualized`, `method="DIETZ"` in fallback path.
+
+## Configuration Options
+- `annualization.enabled`, `annualization.basis`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.
+
+## Worked Example
+- begin=100, end=112, CF=+10 => `r=(112-100-10)/(100+5)=1.9048%`.
+
+
+

--- a/docs/methodologies/metrics/metric-mwr-xirr.md
+++ b/docs/methodologies/metrics/metric-mwr-xirr.md
@@ -1,0 +1,39 @@
+# Metric: Money-Weighted Return (XIRR)
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/mwr` with `mwr_method="XIRR"`.
+
+## Supported Calculation Modes
+- Stateless (cash-flow schedule supplied in request).
+
+## Upstream Data Sources and Exact Data Points
+- Request payload only: `begin_mv`, `end_mv`, `cash_flows[]`, `as_of`.
+
+## Inputs
+- Cash-flow amounts/dates, initial value (negative sign in solver), terminal value.
+
+## Methodology and Formulas
+- Solve rate `r` such that `Σ CF_i/(1+r)^{t_i}=0` using Brent root finder over `[-0.99,100]`.
+- Time exponent uses year fraction from earliest cash-flow date with 365.25 day denominator.
+- If no sign change or convergence fails, engine falls back to Dietz.
+
+## Outputs
+- `money_weighted_return` (%), `mwr_annualized` (% for XIRR path), `method`, `convergence`, `notes`.
+
+## Configuration Options
+- `mwr_method`, `annualization` block, solver metadata fields (currently informational at API layer).
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- Request from integration test returns ~`11.7234%` for given schedule (100000 -> 115000 with +10000 and -5000 intra-year flows).
+
+
+

--- a/docs/methodologies/metrics/metric-returns-series-benchmark.md
+++ b/docs/methodologies/metrics/metric-returns-series-benchmark.md
@@ -1,0 +1,40 @@
+# Metric: Canonical Benchmark Return Series
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /integration/returns/series` with `series_selection.include_benchmark=true`.
+
+## Supported Calculation Modes
+- Stateless or stateful.
+
+## Upstream Data Sources and Exact Data Points
+- Stateless: `stateless_input.benchmark_returns[]`.
+- Stateful lotus-core:
+  - `POST /integration/portfolios/{portfolio_id}/benchmark-assignment` (if benchmark not provided)
+  - `POST /integration/benchmarks/{benchmark_id}/return-series`.
+
+## Inputs
+- Benchmark point list (`series_date`, `benchmark_return`) and window/policy controls.
+
+## Methodology and Formulas
+- Normalize points, enforce window, resample by geometric linking, optionally align/fill against portfolio date set.
+
+## Outputs
+- `series.benchmark_returns[]`; diagnostics include gap and coverage effects.
+
+## Configuration Options
+- `benchmark.benchmark_id`, `series_selection.include_benchmark`, `data_policy.*`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- Two daily benchmark returns 0.1%, 0.2% => 2-day linked = `(1.001*1.002)-1=0.3002%`.
+
+
+

--- a/docs/methodologies/metrics/metric-returns-series-portfolio.md
+++ b/docs/methodologies/metrics/metric-returns-series-portfolio.md
@@ -1,0 +1,43 @@
+# Metric: Canonical Portfolio Return Series
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /integration/returns/series`.
+
+## Supported Calculation Modes
+- `input_mode=stateless` or `input_mode=stateful`.
+
+## Upstream Data Sources and Exact Data Points
+- Stateless: caller supplies `stateless_input.portfolio_returns[]`.
+- Stateful: lotus-core APIs via `CoreIntegrationService`:
+  - `POST /integration/portfolios/{portfolio_id}/analytics/portfolio-timeseries`
+  - transformed to valuation points and computed through lotus-performance TWR daily engine.
+
+## Inputs
+- Date/value return points (decimal form), frequency/window, data policy.
+
+## Methodology and Formulas
+- Validate/sort/filter window.
+- If sourced from portfolio-timeseries, derive daily return using TWR formula from valuation points.
+- Resample weekly/monthly by geometric linking.
+- Apply alignment/fill/missing-data policies.
+
+## Outputs
+- `series.portfolio_returns[]`, plus diagnostics (`coverage`, `gaps`, warnings).
+
+## Configuration Options
+- `window`, `frequency`, `metric_basis`, `data_policy.*`, `series_selection`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- Daily decimal returns: 0.01, 0.005, -0.0025, 0.003, 0.0015 => weekly linked return `(1.01*1.005*0.9975*1.003*1.0015)-1`.
+
+
+

--- a/docs/methodologies/metrics/metric-returns-series-risk-free.md
+++ b/docs/methodologies/metrics/metric-returns-series-risk-free.md
@@ -1,0 +1,38 @@
+# Metric: Canonical Risk-Free Return Series
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /integration/returns/series` with `series_selection.include_risk_free=true`.
+
+## Supported Calculation Modes
+- Stateless or stateful.
+
+## Upstream Data Sources and Exact Data Points
+- Stateless: `stateless_input.risk_free_returns[]`.
+- Stateful lotus-core: `POST /integration/reference/risk-free-series` (`series_mode=return_series`, currency required).
+
+## Inputs
+- Risk-free return points, reporting currency (stateful), policy/window controls.
+
+## Methodology and Formulas
+- Normalize/filter/resample risk-free points; apply fill/alignment policy relative to portfolio series dates where requested.
+
+## Outputs
+- `series.risk_free_returns[]` and diagnostics.
+
+## Configuration Options
+- `reporting_currency` (required in stateful), `series_selection.include_risk_free`, `data_policy.*`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- Daily risk-free points 0.01%,0.01%,0.01% => 3-day linked `(1.0001^3)-1=0.030003%`.
+
+
+

--- a/docs/methodologies/metrics/metric-twr-base-return.md
+++ b/docs/methodologies/metrics/metric-twr-base-return.md
@@ -1,0 +1,45 @@
+# Metric: TWR Base Return
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/twr`
+
+## Supported Calculation Modes
+- Stateless request payload (caller provides valuation points).
+
+## Upstream Data Sources and Exact Data Points
+- Primary: request payload `valuation_points[]` (`perf_date`, `begin_mv`, `end_mv`, `bod_cf`, `eod_cf`, `mgmt_fees`).
+- No runtime upstream service call for this endpoint.
+
+## Inputs
+- Daily valuation series in portfolio/reporting base view.
+- `metric_basis` (`NET` includes `mgmt_fees`; `GROSS` excludes).
+- Period definitions via `analyses[]` and date anchors.
+
+## Methodology and Formulas
+- Daily return (percent): `daily_ror = ((end_mv - bod_cf - begin_mv - eod_cf + fee_adjustment) / abs(begin_mv + bod_cf)) * 100`, where `fee_adjustment = mgmt_fees` only for `NET`.
+- Multi-day period return: geometric link `R_period = (Π(1 + daily_ror_t/100) - 1) * 100`.
+- With reset events, period total is derived from cumulative return ladders before/after reset boundaries (see `engine/ror.py` + endpoint reset slice logic).
+
+## Outputs
+- `results_by_period[*].portfolio_return.base`
+- Breakdown summaries `period_return_pct`, optional `cumulative_return_pct_to_date`, optional `annualized_return_pct`.
+
+## Configuration Options
+- `metric_basis`, `analyses[]`, `annualization.*`, `output.include_*`, `rounding_precision`, `data_policy`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- Day1: begin 1000, end 1010, CF=0 => `r1=1.0%`
+- Day2: begin 1010, end 1020.1, CF=0 => `r2=1.0%`
+- TWR base = `(1.01*1.01 - 1)*100 = 2.01%`.
+
+
+

--- a/docs/methodologies/metrics/metric-twr-fx-return.md
+++ b/docs/methodologies/metrics/metric-twr-fx-return.md
@@ -1,0 +1,38 @@
+# Metric: TWR FX Return
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/twr` (when `currency_mode=BOTH`).
+
+## Supported Calculation Modes
+- Stateless request payload with FX rates.
+
+## Upstream Data Sources and Exact Data Points
+- Request `fx.rates[]` by date/currency; optional hedge ratios from request.
+
+## Inputs
+- Start and end FX rates per day (`start_rate`, `end_rate`) and optional hedge ratio.
+
+## Methodology and Formulas
+- Daily FX return: `fx_ror_t = (end_rate_t/start_rate_t - 1)`, adjusted by hedge: `fx_ror_t *= (1-hedge_ratio_t)` when configured.
+- Base return relation: `(1+R_base) = (1+R_local)*(1+R_fx)`, so period FX return reported as `R_fx = ((1+R_base)/(1+R_local)-1)*100`.
+
+## Outputs
+- `results_by_period[*].portfolio_return.fx`.
+
+## Configuration Options
+- `currency_mode`, `fx.rates`, `hedging.mode/series`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- If period base=4.98228% and local=3.02%, then `fx=((1.0498228/1.0302)-1)*100=1.90476%`.
+
+
+

--- a/docs/methodologies/metrics/metric-twr-local-return.md
+++ b/docs/methodologies/metrics/metric-twr-local-return.md
@@ -1,0 +1,40 @@
+# Metric: TWR Local Return
+
+## Quantitative Conventions
+- Unless explicitly noted otherwise, endpoint-level performance and attribution outputs are expressed in **percentage points**.
+- `returns/series` payload values are expressed in **decimal return form** (`0.0012 = 12 bps`).
+- Geometric linking uses `Π(1+r_t)-1`.
+- Annualization uses the configured day-count basis and annualization factor.
+
+## Lotus-Performance Endpoint(s)
+- `POST /performance/twr` (when `currency_mode=BOTH`).
+
+## Supported Calculation Modes
+- Stateless request payload with FX context.
+
+## Upstream Data Sources and Exact Data Points
+- Primary: request `valuation_points[]`.
+- FX path: request `fx.rates[]`; optional `hedging.series[]`.
+
+## Inputs
+- Same valuation points as base TWR.
+- Local path isolates asset return before FX.
+
+## Methodology and Formulas
+- Engine computes local leg daily return (`local_ror`) from valuation equation before FX translation.
+- Period local return is geometric link of daily local returns: `R_local = Π(1 + local_ror_t) - 1` (scaled to % in response).
+
+## Outputs
+- `results_by_period[*].portfolio_return.local`.
+
+## Configuration Options
+- `currency_mode=BOTH`, `report_ccy`, `fx`, optional `hedging`, `metric_basis`.
+
+## Assumptions and Edge Cases
+- Input series are expected to be date-valid, sortable, and semantically aligned with the request window.
+- For insufficient observations or invalid denominator conditions, the engine returns deterministic error semantics (HTTP validation error and/or metric-level error details depending on endpoint contract).
+- Where configured, policy controls (missing-data policy, fill method, reset rules, robustness policies) can materially change results and must be interpreted with diagnostics.`r`n`r`n## Worked Example
+- Local daily returns: 2.00%, 1.00% => `R_local=(1.02*1.01-1)*100=3.02%`.
+
+
+


### PR DESCRIPTION
## Summary
- add a full metric methodology pack under docs/methodologies/metrics
- add a master index mapping all implemented lotus-performance metrics to dedicated docs
- include per-metric sections for inputs, formulas, outputs, config options, upstream sources, endpoint mapping, supported modes, and worked examples
- add standardized quantitative conventions and edge-case assumptions across all metric docs
- document current implementation nuance: mwr_method=MODIFIED_DIETZ maps to Dietz computation path

## Scope
- documentation only (no runtime code changes)

## Files
- docs/methodologies/metrics/master-index.md
- 19 per-metric methodology docs in docs/methodologies/metrics/metric-*.md
