### PR TITLE
Adopt platform development workflow standard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,28 @@
 ## Summary
+- 
 
-- What changed:
-- Why:
+## Why
+- 
 
-## Validation
+## Scope
+- [ ] Single RFC/slice scope
+- [ ] No unrelated refactors mixed in
 
-- [ ] `make check`
-- [ ] `make ci-local` (or explain why not run)
+## Validation (local)
+- [ ] `make lint`
+- [ ] `make typecheck`
+- [ ] `make test-unit`
+- [ ] Additional targeted checks for changed area
 
-## Documentation Sync (Required)
+## CI Expectations
+- [ ] Fast PR gates are green
+- [ ] Heavy gates run in scheduled/manual tier where applicable
 
-- [ ] Docs updated to match code changes in this PR
-- [ ] API contract/examples updated (if endpoint behavior changed)
-- [ ] README/runbook commands updated (if tooling/commands changed)
-- [ ] RFC/ADR/ownership docs updated (if architecture/boundary changed)
+## Governance/Docs
+- [ ] RFC/docs updated where behavior or standards changed
+- [ ] API/OpenAPI/vocabulary updates included if contract changed
 
-## Risk
-
-- Risk level: low / medium / high
-- Rollback plan:
+## Post-Merge Hygiene
+- [ ] Delete remote feature branch
+- [ ] Delete local feature branch
+- [ ] Sync local main with origin/main (`local = remote = main`)

--- a/docs/operations/development-workflow-and-ci-strategy.md
+++ b/docs/operations/development-workflow-and-ci-strategy.md
@@ -1,0 +1,14 @@
+# Development Workflow and CI Strategy
+
+This repository follows the platform standard for engineering workflow, CI tiering, and merge hygiene.
+
+Canonical standard:
+- `lotus-platform/platform-standards/Development-Workflow-and-CI-Strategy-Standard.md`
+
+## Required model
+1. Branch from `main` and keep one branch per RFC/slice.
+2. Use PR-first delivery (no direct commits to `main`).
+3. Keep PR checks fast and meaningful (blocking).
+4. Run heavier checks in scheduled/manual/mainline tiers.
+5. Merge only with green required checks.
+6. Always finish with `local = remote = main`.


### PR DESCRIPTION
## Summary
- add standardized PR template
- add repository workflow guide aligned to lotus-platform standard

## Reference
- lotus-platform/platform-standards/Development-Workflow-and-CI-Strategy-Standard.md

## Scope
- documentation-only change