### PR TITLE
Add attribution compute executor flow

### DIFF
--- a/app/api/endpoints/performance.py
+++ b/app/api/endpoints/performance.py
@@ -1,6 +1,9 @@
 # app/api/endpoints/performance.py
+from uuid import UUID
+
 import pandas as pd
 from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
 
 from adapters.api_adapter import (
     create_engine_config,
@@ -9,7 +12,7 @@ from adapters.api_adapter import (
 )
 from app.core.config import get_settings
 from app.models.attribution_requests import AttributionRequest
-from app.models.attribution_responses import AttributionResponse
+from app.models.attribution_responses import AttributionAcceptedResponse, AttributionResponse
 from app.models.mwr_requests import MoneyWeightedReturnRequest
 from app.models.mwr_responses import MoneyWeightedReturnResponse
 from app.models.requests import PerformanceRequest
@@ -19,12 +22,13 @@ from app.models.responses import (
     ResetEvent,
     SinglePeriodPerformanceResult,
 )
+from app.services.attribution_service import calculate_attribution
+from app.services.compute_job_store import ComputeJobStatus, compute_job_store
 from app.services.execution_registry import execution_registry
 from app.services.lineage_service import lineage_service
 from core.envelope import Audit, Diagnostics, Meta
 from core.periods import resolve_periods
 from core.repro import generate_canonical_hash
-from engine.attribution import aggregate_attribution_results, run_attribution_calculations
 from engine.breakdown import generate_performance_breakdowns
 from engine.compute import run_calculations
 from engine.exceptions import EngineCalculationError, InvalidEngineInputError
@@ -417,136 +421,95 @@ async def calculate_mwr_endpoint(request: MoneyWeightedReturnRequest):
 
 
 @router.post(
-    "/attribution", response_model=AttributionResponse, summary="Calculate Multi-Level Performance Attribution"
+    "/attribution",
+    response_model=AttributionResponse | AttributionAcceptedResponse,
+    summary="Calculate Multi-Level Performance Attribution",
 )
-async def calculate_attribution_endpoint(request: AttributionRequest):
+async def calculate_attribution_endpoint(request: AttributionRequest) -> AttributionResponse | JSONResponse:
     """
     Calculates multi-level, Brinson-style performance attribution, decomposing
     active return into allocation, selection, and interaction effects.
     """
     input_fingerprint, calculation_hash = generate_canonical_hash(request, settings.APP_VERSION)
+    execution_registry.create_schema()
+    compute_job_store.create_schema()
+    execution_mode = "async" if _should_offload_attribution(request) else "sync"
     execution_registry.create_execution(
         calculation_id=request.calculation_id,
         analytics_type="Attribution",
         portfolio_id=request.portfolio_id,
+        execution_mode=execution_mode,
         requested_window={
             "report_start_date": str(request.report_start_date),
             "report_end_date": str(request.report_end_date),
             "requested_periods": [analysis.period.value for analysis in request.analyses],
+            "input_count": _attribution_input_count(request),
+            "mode": request.mode.value,
+            "group_by": request.group_by,
         },
         input_fingerprint=input_fingerprint,
         calculation_hash=calculation_hash,
     )
-    execution_registry.mark_running(request.calculation_id)
-    execution_stage_started = False
-    lineage_stage_started = False
-
-    try:
-        execution_registry.start_stage(request.calculation_id, "execution")
-        execution_stage_started = True
-        periods_to_resolve = [analysis.period for analysis in request.analyses]
-        resolved_periods = resolve_periods(periods_to_resolve, request.report_end_date, request.report_start_date)
-
-        if not resolved_periods:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid periods could be resolved.")
-
-        master_start_date = min(p.start_date for p in resolved_periods)
-        master_end_date = max(p.end_date for p in resolved_periods)
-
-        master_request = request.model_copy(deep=True)
-        master_request.report_start_date = master_start_date
-        master_request.report_end_date = master_end_date
-
-        effects_df, lineage_data = run_attribution_calculations(master_request)
-
-        results_by_period = {}
-        for period in resolved_periods:
-            period_slice_df = effects_df[
-                (effects_df.index.get_level_values("date") >= pd.to_datetime(period.start_date))
-                & (effects_df.index.get_level_values("date") <= pd.to_datetime(period.end_date))
-            ].copy()
-
-            if period_slice_df.empty:
-                continue
-
-            period_result, aggregation_lineage = aggregate_attribution_results(period_slice_df, request)
-            if aggregation_lineage:
-                lineage_data.update({f"{period.name}_{k}": v for k, v in aggregation_lineage.items()})
-            results_by_period[period.name] = period_result
-
-        meta = Meta(
+    if execution_mode == "async":
+        execution_registry.start_stage(request.calculation_id, "submission")
+        compute_job_store.enqueue_job(
             calculation_id=request.calculation_id,
-            engine_version=settings.APP_VERSION,
-            precision_mode=request.precision_mode,
-            annualization=request.annualization,
-            calendar=request.calendar,
-            periods={
-                "requested": [p.value for p in periods_to_resolve],
-                "master_start": str(master_start_date),
-                "master_end": str(master_end_date),
-            },
-            input_fingerprint=input_fingerprint,
-            calculation_hash=calculation_hash,
+            analytics_type="Attribution",
+            request_payload=request.model_dump(mode="json"),
         )
-
-        response_model = AttributionResponse(
-            calculation_id=request.calculation_id,
-            portfolio_id=request.portfolio_id,
-            model=request.model,
-            linking=request.linking,
-            results_by_period=results_by_period,
-            meta=meta,
-        )
-
         execution_registry.complete_stage(
             request.calculation_id,
-            "execution",
-            details={"period_count": len(results_by_period)},
+            "submission",
+            details={"offload_reason": "large_attribution_input_set"},
         )
-        execution_stage_started = False
-        execution_registry.start_stage(request.calculation_id, "lineage_materialization")
-        lineage_stage_started = True
-        lineage_service.enqueue_capture(
-            calculation_id=request.calculation_id,
-            calculation_type="Attribution",
-            request_model=request,
-            response_model=response_model,
-            calculation_details=lineage_data,
-        )
-        execution_registry.mark_complete(request.calculation_id)
-        return response_model
-    except (InvalidEngineInputError, ValueError, NotImplementedError) as e:
-        _record_execution_failure(
-            calculation_id=request.calculation_id,
-            message=str(e),
-            execution_stage_started=execution_stage_started,
-            lineage_stage_started=lineage_stage_started,
-        )
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except EngineCalculationError as e:
-        _record_execution_failure(
-            calculation_id=request.calculation_id,
-            message=f"Calculation Error: {e.message}",
-            execution_stage_started=execution_stage_started,
-            lineage_stage_started=lineage_stage_started,
-        )
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Calculation Error: {e.message}")
-    except HTTPException:
-        _record_execution_failure(
-            calculation_id=request.calculation_id,
-            message="HTTPException raised during attribution execution.",
-            execution_stage_started=execution_stage_started,
-            lineage_stage_started=lineage_stage_started,
-        )
-        raise
-    except Exception as e:
-        _record_execution_failure(
-            calculation_id=request.calculation_id,
-            message=f"An unexpected server error occurred: {str(e)}",
-            execution_stage_started=execution_stage_started,
-            lineage_stage_started=lineage_stage_started,
-        )
+        accepted = _accepted_attribution_response(request.calculation_id)
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=accepted.model_dump(mode="json"))
+
+    return calculate_attribution(
+        request,
+        input_fingerprint=input_fingerprint,
+        calculation_hash=calculation_hash,
+    )
+
+
+def _attribution_input_count(request: AttributionRequest) -> int:
+    return (
+        len(request.instruments_data or [])
+        + len(request.portfolio_groups_data or [])
+        + len(request.benchmark_groups_data)
+    )
+
+
+def _should_offload_attribution(request: AttributionRequest) -> bool:
+    return _attribution_input_count(request) >= settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT
+
+
+def _accepted_attribution_response(calculation_id) -> AttributionAcceptedResponse:
+    return AttributionAcceptedResponse(
+        calculation_id=calculation_id,
+        poll_path=f"/performance/executions/{calculation_id}",
+        result_path=f"/performance/attribution/results/{calculation_id}",
+    )
+
+
+@router.get(
+    "/attribution/results/{calculation_id}",
+    response_model=AttributionResponse | AttributionAcceptedResponse,
+    summary="Retrieve async attribution result",
+)
+async def get_attribution_result(calculation_id: UUID) -> AttributionResponse | JSONResponse:
+    job = compute_job_store.get_job(calculation_id)
+    if job is None:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"An unexpected server error occurred: {str(e)}",
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Async attribution result not found for the given calculation_id.",
         )
+    if job.job_status in {ComputeJobStatus.PENDING, ComputeJobStatus.RUNNING}:
+        accepted = _accepted_attribution_response(calculation_id)
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=accepted.model_dump(mode="json"))
+    if job.job_status == ComputeJobStatus.FAILED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=job.error_message or "Async attribution execution failed.",
+        )
+    return AttributionResponse.model_validate(job.response_payload)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     COMPUTE_EXECUTOR_BATCH_SIZE: int = 10
     RETURNS_SERIES_EXECUTOR_WINDOW_DAYS: int = 180
     CONTRIBUTION_EXECUTOR_POSITION_COUNT: int = 250
+    ATTRIBUTION_EXECUTOR_INPUT_COUNT: int = 250
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/app/models/attribution_responses.py
+++ b/app/models/attribution_responses.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from common.enums import AttributionModel, LinkingMethod
 from core.envelope import Audit, Diagnostics, Meta
@@ -94,3 +94,11 @@ class AttributionResponse(BaseModel):
     meta: Meta
     diagnostics: Optional[Diagnostics] = None  # To be populated
     audit: Optional[Audit] = None  # To be populated
+
+
+class AttributionAcceptedResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    calculation_id: UUID
+    poll_path: str
+    result_path: str

--- a/app/services/attribution_service.py
+++ b/app/services/attribution_service.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pandas as pd
+from fastapi import HTTPException, status
+
+from app.core.config import get_settings
+from app.models.attribution_requests import AttributionRequest
+from app.models.attribution_responses import AttributionResponse
+from app.services.execution_registry import execution_registry
+from app.services.lineage_service import lineage_service
+from core.envelope import Meta
+from core.periods import resolve_periods
+from engine.attribution import aggregate_attribution_results, run_attribution_calculations
+from engine.exceptions import EngineCalculationError, InvalidEngineInputError
+
+settings = get_settings()
+
+
+def _record_execution_failure(
+    *,
+    calculation_id,
+    message: str,
+    execution_stage_started: bool = False,
+    lineage_stage_started: bool = False,
+) -> None:
+    if lineage_stage_started:
+        execution_registry.fail_stage(calculation_id, "lineage_materialization", message)
+    elif execution_stage_started:
+        execution_registry.fail_stage(calculation_id, "execution", message)
+    execution_registry.mark_failed(calculation_id, message)
+
+
+def calculate_attribution(
+    request: AttributionRequest,
+    *,
+    input_fingerprint: str,
+    calculation_hash: str,
+) -> AttributionResponse:
+    execution_registry.mark_running(request.calculation_id)
+    execution_stage_started = False
+    lineage_stage_started = False
+
+    try:
+        execution_registry.start_stage(request.calculation_id, "execution")
+        execution_stage_started = True
+        periods_to_resolve = [analysis.period for analysis in request.analyses]
+        resolved_periods = resolve_periods(periods_to_resolve, request.report_end_date, request.report_start_date)
+
+        if not resolved_periods:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid periods could be resolved.")
+
+        master_start_date = min(p.start_date for p in resolved_periods)
+        master_end_date = max(p.end_date for p in resolved_periods)
+
+        master_request = request.model_copy(deep=True)
+        master_request.report_start_date = master_start_date
+        master_request.report_end_date = master_end_date
+
+        effects_df, lineage_data = run_attribution_calculations(master_request)
+
+        results_by_period = {}
+        for period in resolved_periods:
+            period_slice_df = effects_df[
+                (effects_df.index.get_level_values("date") >= pd.to_datetime(period.start_date))
+                & (effects_df.index.get_level_values("date") <= pd.to_datetime(period.end_date))
+            ].copy()
+
+            if period_slice_df.empty:
+                continue
+
+            period_result, aggregation_lineage = aggregate_attribution_results(period_slice_df, request)
+            if aggregation_lineage:
+                lineage_data.update({f"{period.name}_{key}": value for key, value in aggregation_lineage.items()})
+            results_by_period[period.name] = period_result
+
+        meta = Meta(
+            calculation_id=request.calculation_id,
+            engine_version=settings.APP_VERSION,
+            precision_mode=request.precision_mode,
+            annualization=request.annualization,
+            calendar=request.calendar,
+            periods={
+                "requested": [p.value for p in periods_to_resolve],
+                "master_start": str(master_start_date),
+                "master_end": str(master_end_date),
+            },
+            input_fingerprint=input_fingerprint,
+            calculation_hash=calculation_hash,
+        )
+
+        response_model = AttributionResponse(
+            calculation_id=request.calculation_id,
+            portfolio_id=request.portfolio_id,
+            model=request.model,
+            linking=request.linking,
+            results_by_period=results_by_period,
+            meta=meta,
+        )
+
+        execution_registry.complete_stage(
+            request.calculation_id,
+            "execution",
+            details={"period_count": len(results_by_period)},
+        )
+        execution_stage_started = False
+        execution_registry.start_stage(request.calculation_id, "lineage_materialization")
+        lineage_stage_started = True
+        lineage_service.enqueue_capture(
+            calculation_id=request.calculation_id,
+            calculation_type="Attribution",
+            request_model=request,
+            response_model=response_model,
+            calculation_details=lineage_data,
+        )
+        execution_registry.mark_complete(request.calculation_id)
+        return response_model
+    except (InvalidEngineInputError, ValueError, NotImplementedError) as exc:
+        _record_execution_failure(
+            calculation_id=request.calculation_id,
+            message=str(exc),
+            execution_stage_started=execution_stage_started,
+            lineage_stage_started=lineage_stage_started,
+        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except EngineCalculationError as exc:
+        _record_execution_failure(
+            calculation_id=request.calculation_id,
+            message=f"Calculation Error: {exc.message}",
+            execution_stage_started=execution_stage_started,
+            lineage_stage_started=lineage_stage_started,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Calculation Error: {exc.message}",
+        ) from exc
+    except HTTPException as exc:
+        _record_execution_failure(
+            calculation_id=request.calculation_id,
+            message=str(exc.detail),
+            execution_stage_started=execution_stage_started,
+            lineage_stage_started=lineage_stage_started,
+        )
+        raise
+    except Exception as exc:
+        _record_execution_failure(
+            calculation_id=request.calculation_id,
+            message=f"An unexpected server error occurred: {str(exc)}",
+            execution_stage_started=execution_stage_started,
+            lineage_stage_started=lineage_stage_started,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An unexpected server error occurred: {str(exc)}",
+        ) from exc

--- a/app/workers/compute_executor_worker.py
+++ b/app/workers/compute_executor_worker.py
@@ -5,8 +5,10 @@ import logging
 import time
 
 from app.core.config import get_settings
+from app.models.attribution_requests import AttributionRequest
 from app.models.contribution_requests import ContributionRequest
 from app.models.returns_series import ReturnsSeriesRequest
+from app.services.attribution_service import calculate_attribution
 from app.services.compute_job_store import compute_job_store
 from app.services.contribution_service import calculate_contribution
 from app.services.execution_registry import execution_registry
@@ -27,6 +29,14 @@ def process_pending_jobs(*, limit: int | None = None) -> int:
             if job.analytics_type == "ReturnsSeries":
                 request = ReturnsSeriesRequest.model_validate(job.request_payload)
                 response = asyncio.run(calculate_returns_series(request))
+            elif job.analytics_type == "Attribution":
+                request = AttributionRequest.model_validate(job.request_payload)
+                input_fingerprint, calculation_hash = generate_canonical_hash(request, settings.APP_VERSION)
+                response = calculate_attribution(
+                    request,
+                    input_fingerprint=input_fingerprint,
+                    calculation_hash=calculation_hash,
+                )
             elif job.analytics_type == "Contribution":
                 request = ContributionRequest.model_validate(job.request_payload)
                 input_fingerprint, calculation_hash = generate_canonical_hash(request, settings.APP_VERSION)

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-03-08T05:51:11.334391+00:00",
+  "generatedAt": "2026-03-08T06:13:20.228273+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.amount",
@@ -127,8 +127,7 @@
         "body"
       ],
       "observedTypes": [
-        "Audit",
-        "object"
+        "Audit"
       ]
     },
     {
@@ -561,8 +560,7 @@
         "body"
       ],
       "observedTypes": [
-        "Diagnostics",
-        "object"
+        "Diagnostics"
       ]
     },
     {
@@ -2308,6 +2306,18 @@
       "attributeRef": "#/attributeCatalog/lotus.calculation_id"
     },
     {
+      "name": "calculation_id",
+      "kind": "request_option",
+      "location": "path",
+      "required": true,
+      "type": "string",
+      "description": "Canonical calculation id used by lotus-performance APIs.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.calculation_id",
+      "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+    },
+    {
       "name": "consumer_system",
       "kind": "request_option",
       "location": "query",
@@ -3885,184 +3895,29 @@
         ]
       },
       "response": {
+        "fields": []
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "GET",
+      "path": "/performance/attribution/results/{calculation_id}",
+      "operationId": "get_attribution_result_performance_attribution_results__calculation_id__get",
+      "summary": "Retrieve async attribution result",
+      "request": {
         "fields": [
           {
             "name": "calculation_id",
-            "location": "body",
+            "location": "path",
             "required": true,
             "type": "string",
             "semanticId": "lotus.calculation_id",
             "attributeRef": "#/attributeCatalog/lotus.calculation_id"
-          },
-          {
-            "name": "portfolio_id",
-            "location": "body",
-            "required": true,
-            "type": "string",
-            "semanticId": "lotus.portfolio_id",
-            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
-          },
-          {
-            "name": "model",
-            "location": "body",
-            "required": true,
-            "type": "AttributionModel",
-            "semanticId": "lotus.model",
-            "attributeRef": "#/attributeCatalog/lotus.model"
-          },
-          {
-            "name": "linking",
-            "location": "body",
-            "required": true,
-            "type": "LinkingMethod",
-            "semanticId": "lotus.linking",
-            "attributeRef": "#/attributeCatalog/lotus.linking"
-          },
-          {
-            "name": "results_by_period",
-            "location": "body",
-            "required": true,
-            "type": "object",
-            "semanticId": "lotus.results_by_period",
-            "attributeRef": "#/attributeCatalog/lotus.results_by_period"
-          },
-          {
-            "name": "meta",
-            "location": "body",
-            "required": true,
-            "type": "Meta",
-            "semanticId": "lotus.meta",
-            "attributeRef": "#/attributeCatalog/lotus.meta"
-          },
-          {
-            "name": "meta.calculation_id",
-            "location": "body",
-            "required": true,
-            "type": "string",
-            "semanticId": "lotus.calculation_id",
-            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
-          },
-          {
-            "name": "meta.engine_version",
-            "location": "body",
-            "required": true,
-            "type": "string",
-            "semanticId": "lotus.engine_version",
-            "attributeRef": "#/attributeCatalog/lotus.engine_version"
-          },
-          {
-            "name": "meta.precision_mode",
-            "location": "body",
-            "required": true,
-            "type": "string",
-            "semanticId": "lotus.precision_mode",
-            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
-          },
-          {
-            "name": "meta.annualization",
-            "location": "body",
-            "required": true,
-            "type": "Annualization",
-            "semanticId": "lotus.annualization",
-            "attributeRef": "#/attributeCatalog/lotus.annualization"
-          },
-          {
-            "name": "meta.annualization.enabled",
-            "location": "body",
-            "required": false,
-            "type": "boolean",
-            "semanticId": "lotus.enabled",
-            "attributeRef": "#/attributeCatalog/lotus.enabled"
-          },
-          {
-            "name": "meta.annualization.basis",
-            "location": "body",
-            "required": false,
-            "type": "string",
-            "semanticId": "lotus.basis",
-            "attributeRef": "#/attributeCatalog/lotus.basis"
-          },
-          {
-            "name": "meta.annualization.periods_per_year",
-            "location": "body",
-            "required": false,
-            "type": "object",
-            "semanticId": "lotus.periods_per_year",
-            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
-          },
-          {
-            "name": "meta.calendar",
-            "location": "body",
-            "required": true,
-            "type": "Calendar",
-            "semanticId": "lotus.calendar",
-            "attributeRef": "#/attributeCatalog/lotus.calendar"
-          },
-          {
-            "name": "meta.calendar.type",
-            "location": "body",
-            "required": false,
-            "type": "string",
-            "semanticId": "lotus.type",
-            "attributeRef": "#/attributeCatalog/lotus.type"
-          },
-          {
-            "name": "meta.calendar.trading_calendar",
-            "location": "body",
-            "required": false,
-            "type": "object",
-            "semanticId": "lotus.trading_calendar",
-            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
-          },
-          {
-            "name": "meta.periods",
-            "location": "body",
-            "required": true,
-            "type": "object",
-            "semanticId": "lotus.periods",
-            "attributeRef": "#/attributeCatalog/lotus.periods"
-          },
-          {
-            "name": "meta.input_fingerprint",
-            "location": "body",
-            "required": false,
-            "type": "object",
-            "semanticId": "lotus.input_fingerprint",
-            "attributeRef": "#/attributeCatalog/lotus.input_fingerprint"
-          },
-          {
-            "name": "meta.calculation_hash",
-            "location": "body",
-            "required": false,
-            "type": "object",
-            "semanticId": "lotus.calculation_hash",
-            "attributeRef": "#/attributeCatalog/lotus.calculation_hash"
-          },
-          {
-            "name": "meta.report_ccy",
-            "location": "body",
-            "required": false,
-            "type": "object",
-            "semanticId": "lotus.report_ccy",
-            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
-          },
-          {
-            "name": "diagnostics",
-            "location": "body",
-            "required": false,
-            "type": "object",
-            "semanticId": "lotus.diagnostics",
-            "attributeRef": "#/attributeCatalog/lotus.diagnostics"
-          },
-          {
-            "name": "audit",
-            "location": "body",
-            "required": false,
-            "type": "object",
-            "semanticId": "lotus.audit",
-            "attributeRef": "#/attributeCatalog/lotus.audit"
           }
         ]
+      },
+      "response": {
+        "fields": []
       }
     },
     {

--- a/tests/integration/test_attribution_api.py
+++ b/tests/integration/test_attribution_api.py
@@ -1,17 +1,41 @@
-# tests/integration/test_attribution_api.py
+import os
+import shutil
+
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core.config import get_settings
+from app.services.compute_job_store import compute_job_store
+from app.services.execution_registry import execution_registry
+from app.services.lineage_metadata_store import lineage_metadata_store
 from core.periods import ResolvedPeriod
 from engine.exceptions import EngineCalculationError, InvalidEngineInputError
 from main import app
-from tests.conftest import drain_lineage_queue
+from tests.conftest import drain_compute_queue, drain_lineage_queue
+
+settings = get_settings()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def client():
+    if os.path.exists(settings.LINEAGE_STORAGE_PATH):
+        shutil.rmtree(settings.LINEAGE_STORAGE_PATH)
+    os.makedirs(settings.LINEAGE_STORAGE_PATH, exist_ok=True)
+    execution_registry.create_schema()
+    execution_registry.clear_all_records()
+    compute_job_store.create_schema()
+    compute_job_store.clear_all_records()
+    lineage_metadata_store.create_schema()
+    lineage_metadata_store.clear_all_records()
+
     with TestClient(app) as c:
         yield c
+
+    if os.path.exists(settings.LINEAGE_STORAGE_PATH):
+        shutil.rmtree(settings.LINEAGE_STORAGE_PATH)
+    compute_job_store.clear_all_records()
+    execution_registry.clear_all_records()
+    lineage_metadata_store.clear_all_records()
 
 
 def test_attribution_endpoint_by_instrument_happy_path(client):
@@ -247,7 +271,7 @@ def test_attribution_endpoint_currency_attribution(client):
 )
 def test_attribution_endpoint_error_handling(client, mocker, error_class, expected_status):
     """Tests that the attribution endpoint correctly handles engine exceptions."""
-    mocker.patch("app.api.endpoints.performance.run_attribution_calculations", side_effect=error_class("Test Error"))
+    mocker.patch("app.services.attribution_service.run_attribution_calculations", side_effect=error_class("Test Error"))
     payload = {
         "portfolio_id": "ERROR",
         "mode": "by_group",
@@ -266,7 +290,7 @@ def test_attribution_endpoint_error_handling(client, mocker, error_class, expect
 
 def test_attribution_endpoint_returns_400_when_no_resolved_periods(client, mocker):
     """Tests explicit 400 path when period resolution yields no valid periods."""
-    mocker.patch("app.api.endpoints.performance.resolve_periods", return_value=[])
+    mocker.patch("app.services.attribution_service.resolve_periods", return_value=[])
     payload = {
         "portfolio_id": "ATTRIB_NO_PERIODS",
         "mode": "by_group",
@@ -286,7 +310,7 @@ def test_attribution_endpoint_returns_400_when_no_resolved_periods(client, mocke
 def test_attribution_endpoint_skips_empty_period_slice(client, mocker):
     """Tests empty-slice branch where a resolved period has no matching effect rows."""
     mocker.patch(
-        "app.api.endpoints.performance.resolve_periods",
+        "app.services.attribution_service.resolve_periods",
         return_value=[
             ResolvedPeriod(name="ITD", start_date="2025-01-01", end_date="2025-01-31"),
             ResolvedPeriod(name="MTD", start_date="2025-02-01", end_date="2025-02-28"),
@@ -322,3 +346,90 @@ def test_attribution_endpoint_skips_empty_period_slice(client, mocker):
     results = response.json()["results_by_period"]
     assert "ITD" in results
     assert "MTD" not in results
+
+
+def test_attribution_async_result_retrieval(client):
+    original_threshold = settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT
+    settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT = 0
+    payload = {
+        "portfolio_id": "ATTRIB_ASYNC_01",
+        "mode": "by_group",
+        "group_by": ["sector"],
+        "linking": "none",
+        "frequency": "daily",
+        "report_start_date": "2025-01-01",
+        "report_end_date": "2025-01-01",
+        "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
+        "portfolio_groups_data": [
+            {
+                "key": {"sector": "Tech"},
+                "observations": [{"date": "2025-01-01", "return_base": 0.015, "weight_bop": 1.0}],
+            }
+        ],
+        "benchmark_groups_data": [
+            {
+                "key": {"sector": "Tech"},
+                "observations": [{"date": "2025-01-01", "return_base": 0.01, "weight_bop": 1.0}],
+            }
+        ],
+    }
+
+    try:
+        accepted = client.post("/performance/attribution", json=payload)
+        assert accepted.status_code == 202
+        calculation_id = accepted.json()["calculation_id"]
+
+        pending = client.get(f"/performance/attribution/results/{calculation_id}")
+        assert pending.status_code == 202
+
+        assert drain_compute_queue() == 1
+
+        complete = client.get(f"/performance/attribution/results/{calculation_id}")
+        assert complete.status_code == 200
+        assert complete.json()["calculation_id"] == calculation_id
+    finally:
+        settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT = original_threshold
+
+
+def test_attribution_async_result_not_found_and_failed(client, mocker):
+    original_threshold = settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT
+    settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT = 0
+    payload = {
+        "portfolio_id": "ATTRIB_ASYNC_FAIL_01",
+        "mode": "by_group",
+        "group_by": ["sector"],
+        "linking": "none",
+        "frequency": "daily",
+        "report_start_date": "2025-01-01",
+        "report_end_date": "2025-01-01",
+        "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
+        "portfolio_groups_data": [
+            {
+                "key": {"sector": "Tech"},
+                "observations": [{"date": "2025-01-01", "return_base": 0.015, "weight_bop": 1.0}],
+            }
+        ],
+        "benchmark_groups_data": [
+            {
+                "key": {"sector": "Tech"},
+                "observations": [{"date": "2025-01-01", "return_base": 0.01, "weight_bop": 1.0}],
+            }
+        ],
+    }
+    mocker.patch("app.workers.compute_executor_worker.calculate_attribution", side_effect=RuntimeError("explode"))
+
+    try:
+        missing = client.get("/performance/attribution/results/00000000-0000-0000-0000-000000000000")
+        assert missing.status_code == 404
+
+        accepted = client.post("/performance/attribution", json=payload)
+        assert accepted.status_code == 202
+        calculation_id = accepted.json()["calculation_id"]
+
+        assert drain_compute_queue() == 1
+
+        failed = client.get(f"/performance/attribution/results/{calculation_id}")
+        assert failed.status_code == 409
+        assert failed.json()["detail"] == "explode"
+    finally:
+        settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT = original_threshold

--- a/tests/integration/test_execution_api.py
+++ b/tests/integration/test_execution_api.py
@@ -244,3 +244,55 @@ def test_execution_api_tracks_async_contribution_job_state(client, happy_path_pa
         assert execution_body_after_worker["compute_job"]["job_status"] == "complete"
     finally:
         settings.CONTRIBUTION_EXECUTOR_POSITION_COUNT = original_threshold
+
+
+def test_execution_api_tracks_async_attribution_job_state(client):
+    original_threshold = settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT
+    settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT = 0
+    payload = {
+        "portfolio_id": "ATTRIB_EXEC_01",
+        "mode": "by_group",
+        "group_by": ["sector"],
+        "linking": "none",
+        "frequency": "daily",
+        "report_start_date": "2025-01-01",
+        "report_end_date": "2025-01-01",
+        "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
+        "portfolio_groups_data": [
+            {
+                "key": {"sector": "Tech"},
+                "observations": [{"date": "2025-01-01", "return_base": 0.015, "weight_bop": 1.0}],
+            }
+        ],
+        "benchmark_groups_data": [
+            {
+                "key": {"sector": "Tech"},
+                "observations": [{"date": "2025-01-01", "return_base": 0.01, "weight_bop": 1.0}],
+            }
+        ],
+    }
+
+    try:
+        response = client.post("/performance/attribution", json=payload)
+        assert response.status_code == 202
+        calculation_id = response.json()["calculation_id"]
+
+        execution_response = client.get(f"/performance/executions/{calculation_id}")
+        assert execution_response.status_code == 200
+        execution_body = execution_response.json()
+        assert execution_body["analytics_type"] == "Attribution"
+        assert execution_body["execution_mode"] == "async"
+        assert execution_body["status"] == "pending"
+        assert execution_body["compute_job"]["job_status"] == "pending"
+        submission_stage = {stage["stage_name"]: stage for stage in execution_body["stages"]}["submission"]
+        assert submission_stage["status"] == "complete"
+
+        assert drain_compute_queue() == 1
+
+        execution_after_worker = client.get(f"/performance/executions/{calculation_id}")
+        assert execution_after_worker.status_code == 200
+        execution_body_after_worker = execution_after_worker.json()
+        assert execution_body_after_worker["status"] == "complete"
+        assert execution_body_after_worker["compute_job"]["job_status"] == "complete"
+    finally:
+        settings.ATTRIBUTION_EXECUTOR_INPUT_COUNT = original_threshold

--- a/tests/unit/services/test_compute_executor_worker.py
+++ b/tests/unit/services/test_compute_executor_worker.py
@@ -2,9 +2,10 @@ from uuid import uuid4
 
 import pytest
 
+from app.models.attribution_requests import AttributionRequest
 from app.models.contribution_requests import ContributionRequest
 from app.models.returns_series import ReturnsSeriesRequest
-from app.services import contribution_service, returns_series_service
+from app.services import attribution_service, contribution_service, returns_series_service
 from app.services.compute_job_store import ComputeJobStatus, ComputeJobStore
 from app.services.execution_registry import ExecutionRegistry
 from app.services.lineage_metadata_store import LineageMetadataStore
@@ -121,6 +122,75 @@ def test_compute_executor_worker_processes_pending_contribution_job(tmp_path, mo
     job_store.enqueue_job(
         calculation_id=calculation_id,
         analytics_type="Contribution",
+        request_payload=request.model_dump(mode="json"),
+    )
+
+    assert compute_executor_worker.process_pending_jobs(limit=10) == 1
+
+    job = job_store.get_job(calculation_id)
+    assert job is not None
+    assert job.job_status == ComputeJobStatus.COMPLETE
+    assert job.response_payload is not None
+
+    execution = execution_store.get_execution(calculation_id)
+    assert execution is not None
+    assert execution.status.value == "complete"
+
+
+def test_compute_executor_worker_processes_pending_attribution_job(tmp_path, monkeypatch):
+    execution_store = ExecutionRegistry(f"sqlite:///{tmp_path / 'execution.db'}")
+    execution_store.create_schema()
+    monkeypatch.setattr(compute_executor_worker, "execution_registry", execution_store)
+    monkeypatch.setattr(attribution_service, "execution_registry", execution_store)
+    lineage_store = LineageMetadataStore(f"sqlite:///{tmp_path / 'lineage.db'}")
+    lineage_store.create_schema()
+    monkeypatch.setattr(
+        attribution_service,
+        "lineage_service",
+        LineageService(storage_path=str(tmp_path / "lineage"), metadata_store=lineage_store),
+    )
+
+    job_store = ComputeJobStore(f"sqlite:///{tmp_path / 'jobs.db'}")
+    job_store.create_schema()
+    monkeypatch.setattr(compute_executor_worker, "compute_job_store", job_store)
+
+    calculation_id = uuid4()
+    request = AttributionRequest.model_validate(
+        {
+            "calculation_id": str(calculation_id),
+            "portfolio_id": "P1",
+            "mode": "by_group",
+            "group_by": ["sector"],
+            "linking": "none",
+            "frequency": "daily",
+            "report_start_date": "2025-01-01",
+            "report_end_date": "2025-01-01",
+            "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
+            "portfolio_groups_data": [
+                {
+                    "key": {"sector": "Tech"},
+                    "observations": [{"date": "2025-01-01", "return_base": 0.015, "weight_bop": 1.0}],
+                }
+            ],
+            "benchmark_groups_data": [
+                {
+                    "key": {"sector": "Tech"},
+                    "observations": [{"date": "2025-01-01", "return_base": 0.01, "weight_bop": 1.0}],
+                }
+            ],
+        }
+    )
+
+    execution_store.create_execution(
+        calculation_id=calculation_id,
+        analytics_type="Attribution",
+        portfolio_id="P1",
+        execution_mode="async",
+        requested_window={},
+    )
+    job_store.enqueue_job(
+        calculation_id=calculation_id,
+        analytics_type="Attribution",
         request_payload=request.model_dump(mode="json"),
     )
 


### PR DESCRIPTION
## Summary
- add RFC-041 async/offloaded execution support for `/performance/attribution`
- extract shared attribution calculation flow for API and compute worker reuse
- add async result retrieval, execution tracking coverage, and updated API vocabulary inventory

## Verification
1. `make lint`
2. `python -m mypy --config-file mypy.ini`
3. `python -m pytest tests/integration/test_attribution_api.py tests/integration/test_execution_api.py tests/unit/services/test_compute_executor_worker.py tests/e2e/test_workflow_journeys.py -q`
4. `python scripts/openapi_quality_gate.py`
5. `python scripts/no_alias_contract_guard.py`
6. `python scripts/api_vocabulary_inventory.py --validate-only`

## Tiering
- Heavy-tier performance/replay checks remain scheduled/manual; not PR-blocking for this slice.