### PR TITLE
Refactor async result resolution and cleanup snapshots

### DIFF
--- a/app/api/endpoints/contribution.py
+++ b/app/api/endpoints/contribution.py
@@ -2,7 +2,7 @@
 from uuid import UUID
 
 import pandas as pd
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, status
 from fastapi.responses import JSONResponse
 
 from app.core.config import get_settings
@@ -11,8 +11,9 @@ from app.models.contribution_responses import (
     ContributionAcceptedResponse,
     ContributionResponse,
 )
-from app.services.async_result_store import AsyncResultStatus, async_result_store
-from app.services.compute_job_store import ComputeJobStatus, compute_job_store
+from app.services.async_result_service import resolve_async_result
+from app.services.async_result_store import async_result_store
+from app.services.compute_job_store import compute_job_store
 from app.services.contribution_service import calculate_contribution
 from app.services.execution_registry import execution_registry
 from core.repro import generate_canonical_hash
@@ -98,26 +99,10 @@ async def calculate_contribution_endpoint(request: ContributionRequest) -> Contr
     summary="Retrieve async contribution result",
 )
 async def get_contribution_result(calculation_id: UUID) -> ContributionResponse | JSONResponse:
-    async_result = async_result_store.get_result(calculation_id)
-    if async_result is not None:
-        if async_result.result_status == AsyncResultStatus.FAILED:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=async_result.error_message or "Async contribution execution failed.",
-            )
-        return ContributionResponse.model_validate(async_result.response_payload)
-    job = compute_job_store.get_job(calculation_id)
-    if job is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Async contribution result not found for the given calculation_id.",
-        )
-    if job.job_status in {ComputeJobStatus.PENDING, ComputeJobStatus.LEASED, ComputeJobStatus.RUNNING}:
-        accepted = _accepted_response(calculation_id)
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=accepted.model_dump(mode="json"))
-    if job.job_status == ComputeJobStatus.FAILED:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=job.error_message or "Async contribution execution failed.",
-        )
-    return ContributionResponse.model_validate(job.response_payload)
+    return resolve_async_result(
+        calculation_id=calculation_id,
+        response_model=ContributionResponse,
+        accepted_response_factory=_accepted_response,
+        not_found_detail="Async contribution result not found for the given calculation_id.",
+        failed_detail="Async contribution execution failed.",
+    )

--- a/app/api/endpoints/performance.py
+++ b/app/api/endpoints/performance.py
@@ -22,9 +22,10 @@ from app.models.responses import (
     ResetEvent,
     SinglePeriodPerformanceResult,
 )
-from app.services.async_result_store import AsyncResultStatus, async_result_store
+from app.services.async_result_service import resolve_async_result
+from app.services.async_result_store import async_result_store
 from app.services.attribution_service import calculate_attribution
-from app.services.compute_job_store import ComputeJobStatus, compute_job_store
+from app.services.compute_job_store import compute_job_store
 from app.services.execution_registry import execution_registry
 from app.services.lineage_service import lineage_service
 from core.envelope import Audit, Diagnostics, Meta
@@ -500,26 +501,10 @@ def _accepted_attribution_response(calculation_id) -> AttributionAcceptedRespons
     summary="Retrieve async attribution result",
 )
 async def get_attribution_result(calculation_id: UUID) -> AttributionResponse | JSONResponse:
-    async_result = async_result_store.get_result(calculation_id)
-    if async_result is not None:
-        if async_result.result_status == AsyncResultStatus.FAILED:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=async_result.error_message or "Async attribution execution failed.",
-            )
-        return AttributionResponse.model_validate(async_result.response_payload)
-    job = compute_job_store.get_job(calculation_id)
-    if job is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Async attribution result not found for the given calculation_id.",
-        )
-    if job.job_status in {ComputeJobStatus.PENDING, ComputeJobStatus.LEASED, ComputeJobStatus.RUNNING}:
-        accepted = _accepted_attribution_response(calculation_id)
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=accepted.model_dump(mode="json"))
-    if job.job_status == ComputeJobStatus.FAILED:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=job.error_message or "Async attribution execution failed.",
-        )
-    return AttributionResponse.model_validate(job.response_payload)
+    return resolve_async_result(
+        calculation_id=calculation_id,
+        response_model=AttributionResponse,
+        accepted_response_factory=_accepted_attribution_response,
+        not_found_detail="Async attribution result not found for the given calculation_id.",
+        failed_detail="Async attribution execution failed.",
+    )

--- a/app/api/endpoints/returns_series.py
+++ b/app/api/endpoints/returns_series.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, status
 from fastapi.responses import JSONResponse
 
 from app.core.config import get_settings
@@ -11,8 +11,9 @@ from app.models.returns_series import (
     ReturnsSeriesRequest,
     ReturnsSeriesResponse,
 )
-from app.services.async_result_store import AsyncResultStatus, async_result_store
-from app.services.compute_job_store import ComputeJobStatus, compute_job_store
+from app.services.async_result_service import resolve_async_result
+from app.services.async_result_store import async_result_store
+from app.services.compute_job_store import compute_job_store
 from app.services.core_integration_service import CoreIntegrationService  # noqa: F401
 from app.services.execution_registry import execution_registry
 from app.services.returns_series_service import (
@@ -121,26 +122,10 @@ async def get_returns_series(request: ReturnsSeriesRequest) -> ReturnsSeriesResp
     description="Returns the final returns-series payload for an async executor job, or a pending handle while execution is in progress.",
 )
 async def get_returns_series_result(calculation_id: UUID) -> ReturnsSeriesResponse | JSONResponse:
-    async_result = async_result_store.get_result(calculation_id)
-    if async_result is not None:
-        if async_result.result_status == AsyncResultStatus.FAILED:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=async_result.error_message or "Async returns-series execution failed.",
-            )
-        return ReturnsSeriesResponse.model_validate(async_result.response_payload)
-    job = compute_job_store.get_job(calculation_id)
-    if job is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Async returns-series result not found for the given calculation_id.",
-        )
-    if job.job_status in {ComputeJobStatus.PENDING, ComputeJobStatus.LEASED, ComputeJobStatus.RUNNING}:
-        accepted = _accepted_response(calculation_id)
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=accepted.model_dump(mode="json"))
-    if job.job_status == ComputeJobStatus.FAILED:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=job.error_message or "Async returns-series execution failed.",
-        )
-    return ReturnsSeriesResponse.model_validate(job.response_payload)
+    return resolve_async_result(
+        calculation_id=calculation_id,
+        response_model=ReturnsSeriesResponse,
+        accepted_response_factory=_accepted_response,
+        not_found_detail="Async returns-series result not found for the given calculation_id.",
+        failed_detail="Async returns-series execution failed.",
+    )

--- a/app/services/async_result_service.py
+++ b/app/services/async_result_service.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from app.services.async_result_store import AsyncResultStatus, async_result_store
+from app.services.compute_job_store import ComputeJobStatus, compute_job_store
+
+ResponseModelT = TypeVar("ResponseModelT", bound=BaseModel)
+AcceptedModelT = TypeVar("AcceptedModelT", bound=BaseModel)
+
+
+def resolve_async_result(
+    *,
+    calculation_id: UUID,
+    response_model: type[ResponseModelT],
+    accepted_response_factory: Callable[[UUID], AcceptedModelT],
+    not_found_detail: str,
+    failed_detail: str,
+) -> ResponseModelT | JSONResponse:
+    async_result = async_result_store.get_result(calculation_id)
+    if async_result is not None:
+        if async_result.result_status == AsyncResultStatus.FAILED:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=async_result.error_message or failed_detail,
+            )
+        return response_model.model_validate(async_result.response_payload)
+
+    job = compute_job_store.get_job(calculation_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=not_found_detail,
+        )
+    if job.job_status in {ComputeJobStatus.PENDING, ComputeJobStatus.LEASED, ComputeJobStatus.RUNNING}:
+        accepted = accepted_response_factory(calculation_id)
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=accepted.model_dump(mode="json"))
+    if job.job_status == ComputeJobStatus.FAILED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=job.error_message or failed_detail,
+        )
+    return response_model.model_validate(job.response_payload)

--- a/app/services/execution_registry.py
+++ b/app/services/execution_registry.py
@@ -160,6 +160,7 @@ class ExecutionRegistry:
 
     def clear_all_records(self) -> None:
         with self._session() as session:
+            session.query(AnalyticsUpstreamSnapshotModel).delete()
             session.query(AnalyticsExecutionStageModel).delete()
             session.query(AnalyticsExecutionModel).delete()
 

--- a/tests/unit/services/test_execution_registry.py
+++ b/tests/unit/services/test_execution_registry.py
@@ -109,3 +109,28 @@ def test_execution_registry_records_upstream_snapshots(tmp_path):
     assert snapshot.snapshot_id == "snap-1"
     assert snapshot.upstream_endpoint == "portfolio_timeseries"
     assert snapshot.paging_metadata == {"page_token": "n1"}
+
+
+def test_execution_registry_clear_all_records_removes_upstream_snapshots(tmp_path):
+    registry = ExecutionRegistry(f"sqlite:///{tmp_path / 'execution.db'}")
+    registry.create_schema()
+    calculation_id = uuid4()
+    registry.create_execution(
+        calculation_id=calculation_id,
+        analytics_type="ReturnsSeries",
+        portfolio_id="PORT-5",
+    )
+    registry.record_upstream_snapshot(
+        calculation_id=calculation_id,
+        snapshot_id="snap-clear",
+        upstream_endpoint="portfolio_timeseries",
+        source_identifier="PORT-5",
+        as_of_date="2026-02-27",
+        request_fingerprint="req-clear",
+        response_fingerprint="resp-clear",
+        retrieval_status="200",
+    )
+
+    registry.clear_all_records()
+
+    assert registry.get_execution(calculation_id) is None


### PR DESCRIPTION
## Summary
- extract shared async result resolution to remove endpoint duplication across executor-backed APIs
- fix execution registry cleanup so upstream snapshot rows are deleted during full reset flows
- add regression coverage for execution reset behavior and keep RFC-041 executor/result lifecycle cleanly extensible

## Verification
1. `python -m ruff check .`
2. `python -m mypy --config-file mypy.ini`
3. `python scripts/openapi_quality_gate.py`
4. `python scripts/no_alias_contract_guard.py`
5. `python scripts/api_vocabulary_inventory.py --validate-only`
6. `python -m pytest tests/unit/services/test_async_result_store.py tests/unit/services/test_compute_job_store.py tests/unit/services/test_compute_executor_worker.py tests/unit/services/test_execution_registry.py tests/integration/test_execution_api.py tests/integration/test_returns_series_api.py tests/integration/test_contribution_api.py tests/integration/test_attribution_api.py tests/e2e/test_workflow_journeys.py -q`

## Tiering
- Heavy-tier checks remain non-blocking and are not required for this PR.