### PR TITLE
Drop compute worker helper-only test

### DIFF
--- a/tests/unit/services/test_compute_executor_worker.py
+++ b/tests/unit/services/test_compute_executor_worker.py
@@ -759,13 +759,3 @@ def test_compute_executor_worker_rejects_unsupported_analytics_type(tmp_path, mo
     assert "Unsupported compute job analytics_type" in (job.error_message or "")
 
 
-def test_compute_executor_worker_poll_helpers_cover_direct_paths(monkeypatch):
-    slept: list[float] = []
-    monkeypatch.setattr(compute_executor_worker.time, "sleep", lambda seconds: slept.append(seconds))
-
-    assert compute_executor_worker._stop_requested(None) is False
-    stop_event = Event()
-    stop_event.set()
-    assert compute_executor_worker._stop_requested(stop_event) is True
-    assert compute_executor_worker._wait_for_next_poll(None, 2.5) is False
-    assert slept == [2.5]


### PR DESCRIPTION
## Summary
- remove the direct helper-level compute worker polling test
- keep the stronger run loop behavior coverage that already protects the same contract
- preserve the combined coverage gate without carrying low-value padding

## Validation
- python -m pytest tests/unit/services/test_compute_executor_worker.py -q
- exact combined unit + integration + e2e coverage flow at 99%