### PR TITLE
Format stateful integration test suite

### DIFF
--- a/tests/unit/services/test_attribution_mode_service.py
+++ b/tests/unit/services/test_attribution_mode_service.py
@@ -49,8 +49,12 @@ async def test_resolve_attribution_request_fails_retrieval_stage(monkeypatch):
 
     monkeypatch.setattr("app.services.attribution_mode_service.build_stateful_input_service", lambda settings: object())
     monkeypatch.setattr("app.services.attribution_mode_service.retrieve_stateful_attribution_source_input", _boom)
-    monkeypatch.setattr("app.services.attribution_mode_service.execution_registry.start_stage", lambda *args, **kwargs: None)
-    monkeypatch.setattr("app.services.attribution_mode_service.execution_registry.complete_stage", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "app.services.attribution_mode_service.execution_registry.start_stage", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "app.services.attribution_mode_service.execution_registry.complete_stage", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(
         "app.services.attribution_mode_service.execution_registry.fail_stage",
         lambda *args, **kwargs: failed.append(args),
@@ -106,13 +110,19 @@ async def test_resolve_attribution_request_fails_normalization_stage(monkeypatch
     async def _mock_retrieve(**kwargs):  # noqa: ARG001
         return source_input
 
-    monkeypatch.setattr("app.services.attribution_mode_service.retrieve_stateful_attribution_source_input", _mock_retrieve)
+    monkeypatch.setattr(
+        "app.services.attribution_mode_service.retrieve_stateful_attribution_source_input", _mock_retrieve
+    )
     monkeypatch.setattr(
         "app.services.attribution_mode_service.build_stateful_attribution_input",
         lambda **kwargs: (_ for _ in ()).throw(ValueError("bad normalization")),
     )
-    monkeypatch.setattr("app.services.attribution_mode_service.execution_registry.start_stage", lambda *args, **kwargs: None)
-    monkeypatch.setattr("app.services.attribution_mode_service.execution_registry.complete_stage", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "app.services.attribution_mode_service.execution_registry.start_stage", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "app.services.attribution_mode_service.execution_registry.complete_stage", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(
         "app.services.attribution_mode_service.execution_registry.fail_stage",
         lambda *args, **kwargs: failed.append(args),

--- a/tests/unit/services/test_compute_executor_worker.py
+++ b/tests/unit/services/test_compute_executor_worker.py
@@ -757,5 +757,3 @@ def test_compute_executor_worker_rejects_unsupported_analytics_type(tmp_path, mo
     assert job is not None
     assert job.job_status == ComputeJobStatus.FAILED
     assert "Unsupported compute job analytics_type" in (job.error_message or "")
-
-


### PR DESCRIPTION
## Summary
- apply the repo formatter to the remaining stateful integration test files touched in the cleanup pass
- align local lint output with GitHub Actions formatting checks

## Validation
- make lint
- python -m pytest tests/unit/services/test_attribution_mode_service.py tests/unit/services/test_compute_executor_worker.py tests/unit/services/test_stateful_attribution_input_service.py tests/unit/services/test_stateful_contribution_input_service.py tests/unit/services/test_stateful_input_service.py -q
- python -m pytest -q