### PR TITLE
Stabilize postgres lineage concurrency proofs

### DIFF
--- a/app/services/lineage_metadata_store.py
+++ b/app/services/lineage_metadata_store.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from typing import Iterator
 from uuid import UUID
 
-from sqlalchemy import DateTime, Index, Integer, String, Text, case, create_engine, func, inspect, select, text
+from sqlalchemy import DateTime, Index, Integer, String, Text, case, create_engine, exists, func, inspect, select, text
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
 from app.services.durable_store_runtime import RuntimeStoreProxy, resolve_runtime_store
@@ -354,10 +354,19 @@ class LineageMetadataStore:
         now = datetime.now(timezone.utc)
         lease_expiry = now + timedelta(seconds=lease_seconds)
         with self._session() as session:
+            dialect_name = session.bind.dialect.name if session.bind is not None else ""
+            if dialect_name == "postgresql":
+                return self._lease_pending_payloads_postgresql(
+                    session=session,
+                    now=now,
+                    lease_expiry=lease_expiry,
+                    worker_id=worker_id,
+                    limit=limit,
+                )
             statement = self._build_lease_pending_payloads_statement(
                 now=now,
                 limit=limit,
-                dialect_name=session.bind.dialect.name if session.bind is not None else "",
+                dialect_name=dialect_name,
             )
             rows = session.execute(statement).scalars().all()
             leased: list[LineagePayload] = []
@@ -1005,22 +1014,98 @@ class LineageMetadataStore:
         )
 
     def _build_lease_pending_payloads_statement(self, *, now: datetime, limit: int, dialect_name: str):
+        pending_record_exists = exists(
+            select(1).where(
+                (LineageRecordModel.calculation_id == LineagePayloadModel.calculation_id)
+                & (LineageRecordModel.status == LineageStatus.PENDING.value)
+            )
+        )
         statement = (
             select(LineagePayloadModel)
-            .join(LineageRecordModel, LineagePayloadModel.calculation_id == LineageRecordModel.calculation_id)
             .where(
-                (LineageRecordModel.status == LineageStatus.PENDING.value)
+                pending_record_exists
                 & (
                     LineagePayloadModel.lease_expires_at_utc.is_(None)
                     | (LineagePayloadModel.lease_expires_at_utc < now)
                 )
             )
-            .order_by(LineagePayloadModel.created_at_utc.asc())
+            .order_by(LineagePayloadModel.created_at_utc.asc(), LineagePayloadModel.calculation_id.asc())
             .limit(limit)
         )
         if dialect_name == "postgresql":
-            statement = statement.with_for_update(skip_locked=True)
+            statement = statement.with_for_update(of=LineagePayloadModel, skip_locked=True)
         return statement
+
+    def _lease_pending_payloads_postgresql(
+        self,
+        *,
+        session: Session,
+        now: datetime,
+        lease_expiry: datetime,
+        worker_id: str,
+        limit: int,
+    ) -> list[LineagePayload]:
+        statement = text(
+            """
+            UPDATE lineage_payloads AS payload
+            SET worker_id = :worker_id,
+                leased_at_utc = :leased_at_utc,
+                lease_expires_at_utc = :lease_expires_at_utc,
+                attempt_count = payload.attempt_count + 1
+            FROM (
+                SELECT payload.calculation_id
+                FROM lineage_payloads AS payload
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM lineage_records AS record
+                    WHERE record.calculation_id = payload.calculation_id
+                      AND record.status = :pending_status
+                )
+                  AND (
+                    payload.lease_expires_at_utc IS NULL
+                    OR payload.lease_expires_at_utc < :leased_at_utc
+                  )
+                ORDER BY payload.created_at_utc ASC, payload.calculation_id ASC
+                FOR UPDATE OF payload SKIP LOCKED
+                LIMIT :limit
+            ) AS claimable
+            WHERE payload.calculation_id = claimable.calculation_id
+            RETURNING
+                payload.calculation_id,
+                payload.calculation_type,
+                payload.request_json,
+                payload.response_json,
+                payload.details_json,
+                payload.attempt_count,
+                payload.worker_id,
+                payload.leased_at_utc,
+                payload.lease_expires_at_utc
+            """
+        )
+        rows = session.execute(
+            statement,
+            {
+                "worker_id": worker_id,
+                "leased_at_utc": now,
+                "lease_expires_at_utc": lease_expiry,
+                "pending_status": LineageStatus.PENDING.value,
+                "limit": limit,
+            },
+        ).mappings()
+        return [
+            LineagePayload(
+                calculation_id=UUID(str(row["calculation_id"])),
+                calculation_type=str(row["calculation_type"]),
+                request_json=str(row["request_json"]),
+                response_json=str(row["response_json"]),
+                details=json.loads(str(row["details_json"])),
+                attempt_count=int(row["attempt_count"]),
+                worker_id=None if row["worker_id"] is None else str(row["worker_id"]),
+                leased_at_utc=_format_timestamp(row["leased_at_utc"]),
+                lease_expires_at_utc=_format_timestamp(row["lease_expires_at_utc"]),
+            )
+            for row in rows
+        ]
 
     def _to_payload(self, payload: LineagePayloadModel) -> LineagePayload:
         return LineagePayload(

--- a/tests/benchmarks/postgres_runtime_helpers.py
+++ b/tests/benchmarks/postgres_runtime_helpers.py
@@ -1,7 +1,9 @@
 import os
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import OperationalError
 
 POSTGRES_RUNTIME_DATABASE_URL = os.getenv(
@@ -12,16 +14,24 @@ POSTGRES_RUNTIME_CONNECT_TIMEOUT_SECONDS = 3
 
 
 def get_postgres_database_url() -> str:
+    isolated_schema_name = f"lotus_perf_bench_{uuid4().hex}"
     engine = create_engine(
         POSTGRES_RUNTIME_DATABASE_URL,
         future=True,
         connect_args={"connect_timeout": POSTGRES_RUNTIME_CONNECT_TIMEOUT_SECONDS},
     )
     try:
-        with engine.connect() as connection:
+        with engine.begin() as connection:
             connection.execute(text("SELECT 1"))
+            connection.exec_driver_sql(f'CREATE SCHEMA IF NOT EXISTS "{isolated_schema_name}"')
     except OperationalError:
         pytest.skip(f"PostgreSQL runtime proof database unavailable at {POSTGRES_RUNTIME_DATABASE_URL}")
     finally:
         engine.dispose()
-    return POSTGRES_RUNTIME_DATABASE_URL
+    database_url = make_url(POSTGRES_RUNTIME_DATABASE_URL)
+    existing_options = database_url.query.get("options")
+    search_path_option = f"-csearch_path={isolated_schema_name}"
+    combined_options = (
+        f"{existing_options} {search_path_option}".strip() if existing_options else search_path_option
+    )
+    return database_url.update_query_dict({"options": combined_options}).render_as_string(hide_password=False)

--- a/tests/unit/benchmarks/test_postgres_runtime_helpers.py
+++ b/tests/unit/benchmarks/test_postgres_runtime_helpers.py
@@ -4,19 +4,25 @@ from tests.benchmarks import postgres_runtime_helpers
 def test_get_postgres_database_url_uses_short_connect_timeout(mocker):
     engine = mocker.MagicMock()
     connection = mocker.MagicMock()
-    engine.connect.return_value.__enter__.return_value = connection
+    engine.begin.return_value.__enter__.return_value = connection
     mocked_create_engine = mocker.patch(
         "tests.benchmarks.postgres_runtime_helpers.create_engine",
         return_value=engine,
     )
+    mocked_uuid4 = mocker.patch("tests.benchmarks.postgres_runtime_helpers.uuid4")
+    mocked_uuid4.return_value.hex = "abc123"
 
     database_url = postgres_runtime_helpers.get_postgres_database_url()
 
-    assert database_url == postgres_runtime_helpers.POSTGRES_RUNTIME_DATABASE_URL
+    assert database_url == (
+        f"{postgres_runtime_helpers.POSTGRES_RUNTIME_DATABASE_URL}"
+        "?options=-csearch_path%3Dlotus_perf_bench_abc123"
+    )
     mocked_create_engine.assert_called_once_with(
         postgres_runtime_helpers.POSTGRES_RUNTIME_DATABASE_URL,
         future=True,
         connect_args={"connect_timeout": postgres_runtime_helpers.POSTGRES_RUNTIME_CONNECT_TIMEOUT_SECONDS},
     )
     connection.execute.assert_called_once()
+    connection.exec_driver_sql.assert_called_once_with('CREATE SCHEMA IF NOT EXISTS "lotus_perf_bench_abc123"')
     engine.dispose.assert_called_once()


### PR DESCRIPTION
## Summary
- isolate Postgres benchmark runs into a unique schema per invocation so concurrency proofs do not share the live runtime schema
- harden Postgres lineage payload leasing with a deterministic payload-first claim path
- keep benchmark helper coverage aligned with the new isolated-schema contract

## Evidence
- Static: `python -m ruff check app/services/lineage_metadata_store.py tests/benchmarks/postgres_runtime_helpers.py tests/unit/benchmarks/test_postgres_runtime_helpers.py`
- Types: `python -m mypy --config-file mypy.ini app/services/lineage_metadata_store.py tests/benchmarks/postgres_runtime_helpers.py tests/unit/benchmarks/test_postgres_runtime_helpers.py`
- Targeted: `python -m pytest tests/unit/benchmarks/test_postgres_runtime_helpers.py tests/benchmarks/test_postgres_concurrency_contracts.py -q`
- Full: `python -m pytest -q`

## Why
The previously failing Postgres lineage concurrency benchmark was sharing a live runtime database and was vulnerable to ambient lineage workers mutating the same schema. This PR makes the benchmark proof isolated and keeps the Postgres lineage claim path deterministic under concurrency.