### PR TITLE
Restore postgres lineage coverage gate

### DIFF
--- a/tests/benchmarks/postgres_runtime_helpers.py
+++ b/tests/benchmarks/postgres_runtime_helpers.py
@@ -31,7 +31,5 @@ def get_postgres_database_url() -> str:
     database_url = make_url(POSTGRES_RUNTIME_DATABASE_URL)
     existing_options = database_url.query.get("options")
     search_path_option = f"-csearch_path={isolated_schema_name}"
-    combined_options = (
-        f"{existing_options} {search_path_option}".strip() if existing_options else search_path_option
-    )
+    combined_options = f"{existing_options} {search_path_option}".strip() if existing_options else search_path_option
     return database_url.update_query_dict({"options": combined_options}).render_as_string(hide_password=False)

--- a/tests/unit/benchmarks/test_postgres_runtime_helpers.py
+++ b/tests/unit/benchmarks/test_postgres_runtime_helpers.py
@@ -15,8 +15,7 @@ def test_get_postgres_database_url_uses_short_connect_timeout(mocker):
     database_url = postgres_runtime_helpers.get_postgres_database_url()
 
     assert database_url == (
-        f"{postgres_runtime_helpers.POSTGRES_RUNTIME_DATABASE_URL}"
-        "?options=-csearch_path%3Dlotus_perf_bench_abc123"
+        f"{postgres_runtime_helpers.POSTGRES_RUNTIME_DATABASE_URL}" "?options=-csearch_path%3Dlotus_perf_bench_abc123"
     )
     mocked_create_engine.assert_called_once_with(
         postgres_runtime_helpers.POSTGRES_RUNTIME_DATABASE_URL,


### PR DESCRIPTION
## Summary
- restore the 99% combined coverage gate after `#91` merged the Postgres lineage concurrency fix
- add unit coverage for the Postgres lineage payload claim path, including SQL shape, dispatch, and returned-row normalization
- add benchmark helper coverage for isolated-schema URL construction, existing option merging, and unavailable-database skip behavior
- keep the helper files formatted to satisfy the repo lint gate

## Evidence
- `make lint`
- `python -m pytest tests/unit/services/test_lineage_metadata_store.py tests/unit/benchmarks/test_postgres_runtime_helpers.py -q`
- `python -m pytest tests/unit/benchmarks/test_postgres_runtime_helpers.py tests/benchmarks/test_postgres_concurrency_contracts.py -q`
- combined coverage flow:
  - `COVERAGE_FILE=.coverage.unit python -m pytest tests/unit --cov=app --cov=engine --cov=core --cov=adapters --cov-report=`
  - `COVERAGE_FILE=.coverage.integration python -m pytest tests/integration --cov=app --cov=engine --cov=core --cov=adapters --cov-report=`
  - `COVERAGE_FILE=.coverage.e2e python -m pytest tests/e2e --cov=app --cov=engine --cov=core --cov=adapters --cov-report=`
  - `python -m coverage combine .coverage.unit .coverage.integration .coverage.e2e`
  - `python -m coverage report --fail-under=99`

## Result
- combined coverage restored to `99%`