### PR TITLE
Fix post-merge typecheck regressions

### DIFF
--- a/app/api/endpoints/benchmark.py
+++ b/app/api/endpoints/benchmark.py
@@ -243,7 +243,7 @@ def _build_execution_window(
     source_request_fingerprint: str | None = None,
     input_count: int | None = None,
 ) -> dict[str, object]:
-    requested_window = {
+    requested_window: dict[str, object] = {
         "benchmark_start_date": str(request.benchmark_start_date),
         "report_end_date": str(request.report_end_date),
         "requested_periods": [analysis.period.value for analysis in request.analyses],

--- a/app/models/requests.py
+++ b/app/models/requests.py
@@ -77,9 +77,12 @@ class PerformanceRequestBase(BaseModel):
         description="A unique identifier for the calculation request. If not provided, one will be generated.",
     )
     portfolio_id: str = Field(..., description="A unique identifier for the portfolio being analyzed.")
-    performance_start_date: date = Field(
-        ...,
-        description="The inception date of the portfolio or the earliest date for which performance data is available.",
+    performance_start_date: Optional[date] = Field(
+        None,
+        description=(
+            "The inception date of the portfolio or the earliest date for which performance data is available. "
+            "Some stateful request flows allow lotus-performance to derive this value upstream."
+        ),
     )
     metric_basis: Literal["NET", "GROSS"] = Field(
         ..., description="Specifies whether to calculate returns 'NET' (after fees) or 'GROSS' (before fees)."
@@ -125,4 +128,8 @@ class PerformanceRequestBase(BaseModel):
 
 
 class PerformanceRequest(PerformanceRequestBase):
+    performance_start_date: date = Field(
+        ...,
+        description="The inception date of the portfolio or the earliest date for which performance data is available.",
+    )
     valuation_points: List[DailyInputData]

--- a/app/services/contribution_service.py
+++ b/app/services/contribution_service.py
@@ -24,7 +24,7 @@ from app.services.execution_lifecycle_service import (
 from app.services.execution_registry import execution_registry
 from core.envelope import Audit, Diagnostics, Meta
 from core.periods import resolve_periods
-from engine.config import EngineConfig
+from engine.config import EngineConfig, PrecisionMode
 from engine.contribution import (
     _calculate_daily_instrument_contributions,
     _prepare_hierarchical_data,
@@ -137,7 +137,7 @@ def _calculate_reset_aware_period_portfolio_return(
         report_end_date=period_end_date,
         metric_basis=request.portfolio_data.metric_basis,
         period_type=period_type,
-        precision_mode=request.precision_mode,
+        precision_mode=PrecisionMode(request.precision_mode),
         rounding_precision=request.rounding_precision,
         currency_mode=request.currency_mode,
         report_ccy=request.report_ccy,

--- a/app/services/returns_series_service.py
+++ b/app/services/returns_series_service.py
@@ -478,11 +478,10 @@ async def _calculate_returns_series(
             resolved_stateful_request = await resolve_stateful_returns_series_request(request)
             request = resolved_stateful_request.request
             resolved_benchmark_id = resolved_stateful_request.resolved_benchmark_id
-            resolved_benchmark_return_source = (
-                BenchmarkReturnSource(resolved_stateful_request.resolved_benchmark_return_source)
-                if resolved_stateful_request.resolved_benchmark_return_source is not None
-                else None
-            )
+            if resolved_stateful_request.resolved_benchmark_return_source is not None:
+                resolved_benchmark_return_source = BenchmarkReturnSource(
+                    resolved_stateful_request.resolved_benchmark_return_source
+                )
             input_fingerprint, calculation_hash = generate_canonical_hash(
                 resolved_stateful_request.identity_payload,
                 "returns-series-v1",

--- a/app/services/twr_mode_service.py
+++ b/app/services/twr_mode_service.py
@@ -79,13 +79,19 @@ async def resolve_twr_request(
                     request=request,
                     stateful_input_service=stateful_input_service,
                 )
+            resolved_start_date = derived_start_date or request.performance_start_date
+            if resolved_start_date is None:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Unable to derive a performance_start_date for the stateful TWR request.",
+                )
             portfolio_input = await retrieve_stateful_portfolio_input(
                 settings=settings,
                 stateful_input_service=(stateful_input_service if derived_start_date is not None else None),
                 calculation_id=request.calculation_id,
                 portfolio_id=request.portfolio_id,
                 as_of_date=request.report_end_date,
-                start_date=derived_start_date or request.performance_start_date,
+                start_date=resolved_start_date,
                 end_date=request.report_end_date,
                 reporting_currency=request.report_ccy,
                 consumer_system=DEFAULT_STATEFUL_CONSUMER_SYSTEM,

--- a/app/workers/compute_executor_worker.py
+++ b/app/workers/compute_executor_worker.py
@@ -195,7 +195,7 @@ def _process_pending_jobs(
                     request_artifact_model,
                     portfolio_id,
                     resolved_benchmark_id,
-                    benchmark_input_mode,
+                    twr_benchmark_input_mode,
                     benchmark_return_source,
                     should_update_identity,
                 ) = _resolve_async_twr_job_request(job.request_payload, settings=active_settings)
@@ -223,7 +223,7 @@ def _process_pending_jobs(
                     engine_version=active_settings.APP_VERSION,
                     request_artifact_model=request_artifact_model,
                     benchmark_request=twr_request.benchmark,
-                    benchmark_input_mode=benchmark_input_mode,
+                    benchmark_input_mode=twr_benchmark_input_mode,
                     resolved_benchmark_id=resolved_benchmark_id,
                     benchmark_return_source=benchmark_return_source,
                 )


### PR DESCRIPTION
## Summary
- fix the post-merge mypy failures on main by tightening optional date handling for TWR/stateful flows
- preserve benchmark return-source typing across stateful returns-series resolution and make the benchmark endpoint request-window payload explicitly object-typed
- convert contribution engine precision mode to the engine enum and avoid variable-type widening in the compute executor

## Verification
- make typecheck
  - Success: no issues found in 128 source files
- python -m pytest tests/unit/services/test_twr_mode_service.py tests/unit/services/test_returns_series_service.py tests/unit/services/test_compute_executor_worker.py tests/integration/test_benchmark_api.py tests/integration/test_returns_series_api.py tests/unit/app/test_contribution_endpoint_helpers.py -q
  - 77 passed
- python -m ruff check app/api/endpoints/benchmark.py app/models/requests.py app/services/contribution_service.py app/services/returns_series_service.py app/services/twr_mode_service.py app/workers/compute_executor_worker.py
  - passed

## Note
This is a follow-up cleanup PR to restore green CI after the RFC-043 merge sequence.