### PR TITLE
fix: stabilize benchmark exposure context execution lifecycle

### DIFF
--- a/app/api/endpoints/benchmark_exposure_context.py
+++ b/app/api/endpoints/benchmark_exposure_context.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 
 from app.core.config import get_settings
 from app.models.benchmark_exposure_context import BenchmarkExposureContextRequest, BenchmarkExposureContextResponse
 from app.services.benchmark_exposure_context_service import build_benchmark_exposure_context
+from app.services.execution_lifecycle_service import record_execution_failure
+from app.services.execution_registry import execution_registry
 from app.services.portfolio_source_service import build_stateful_input_service
+from app.services.submission_fencing_service import register_sync_execution_or_raise
 
 router = APIRouter(tags=["Integration"])
 
@@ -24,7 +27,52 @@ async def get_benchmark_exposure_context(
     request: BenchmarkExposureContextRequest,
 ) -> BenchmarkExposureContextResponse:
     stateful_input_service = build_stateful_input_service(settings=get_settings())
-    return await build_benchmark_exposure_context(
-        request=request,
-        stateful_input_service=stateful_input_service,
+    register_sync_execution_or_raise(
+        calculation_id=request.calculation_id,
+        analytics_type="BENCHMARK_EXPOSURE_CONTEXT",
+        portfolio_id=request.portfolio_id,
+        requested_window={
+            "as_of_date": str(request.as_of_date),
+            "window_start_date": str(request.window.start_date),
+            "window_end_date": str(request.window.end_date),
+            "frequency": request.frequency.value,
+            "grouping_dimensions": [dimension.value for dimension in request.grouping_dimensions],
+            "benchmark_id": request.benchmark_id,
+            "reporting_currency": request.reporting_currency,
+        },
+        input_fingerprint=None,
+        calculation_hash=None,
     )
+    execution_registry.mark_running(request.calculation_id)
+    execution_stage_started = False
+    try:
+        execution_registry.start_stage(request.calculation_id, "execution")
+        execution_stage_started = True
+        response = await build_benchmark_exposure_context(
+            request=request,
+            stateful_input_service=stateful_input_service,
+        )
+        execution_registry.complete_stage(
+            request.calculation_id,
+            "execution",
+            details={"row_count": len(response.rows)},
+        )
+        execution_registry.mark_complete(request.calculation_id)
+        return response
+    except HTTPException as exc:
+        record_execution_failure(
+            calculation_id=request.calculation_id,
+            message=str(exc.detail),
+            execution_stage_started=execution_stage_started,
+        )
+        raise
+    except Exception as exc:
+        record_execution_failure(
+            calculation_id=request.calculation_id,
+            message=f"An unexpected server error occurred while building benchmark exposure context: {exc}",
+            execution_stage_started=execution_stage_started,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An unexpected server error occurred while building benchmark exposure context: {exc}",
+        ) from exc

--- a/app/api/endpoints/benchmark_exposure_context.py
+++ b/app/api/endpoints/benchmark_exposure_context.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.config import get_settings
+from app.models.benchmark_exposure_context import BenchmarkExposureContextRequest, BenchmarkExposureContextResponse
+from app.services.benchmark_exposure_context_service import build_benchmark_exposure_context
+from app.services.portfolio_source_service import build_stateful_input_service
+
+router = APIRouter(tags=["Integration"])
+
+
+@router.post(
+    "/benchmarks/exposure-context",
+    response_model=BenchmarkExposureContextResponse,
+    summary="Get benchmark exposure context for downstream risk attribution",
+    description=(
+        "Returns benchmark exposure history aligned to the benchmark performance context. "
+        "lotus-performance exposes this as a derived view backed by lotus-core benchmark composition lineage; "
+        "lotus-core remains the authoritative system of record."
+    ),
+)
+async def get_benchmark_exposure_context(
+    request: BenchmarkExposureContextRequest,
+) -> BenchmarkExposureContextResponse:
+    stateful_input_service = build_stateful_input_service(settings=get_settings())
+    return await build_benchmark_exposure_context(
+        request=request,
+        stateful_input_service=stateful_input_service,
+    )

--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -236,6 +236,12 @@ async def get_integration_capabilities(
             description="Benchmark performance analytics APIs.",
         ),
         FeatureCapability(
+            key="pa.integration.benchmark_exposure_context",
+            enabled=benchmark_enabled and stateful_mode_enabled,
+            owner_service="lotus-performance",
+            description="Performance-aligned benchmark exposure context derived from lotus-core benchmark lineage.",
+        ),
+        FeatureCapability(
             key="pa.analytics.workspace_summary",
             enabled=workspace_summary_enabled,
             owner_service="lotus-performance",
@@ -410,6 +416,30 @@ async def get_integration_capabilities(
             supports_async=True,
             poll_path_template="/performance/executions/{calculation_id}",
             result_path_template="/integration/returns/series/results/{calculation_id}",
+        ),
+        AnalyticsSurfaceCapability(
+            key="benchmark_exposure_context",
+            path="/integration/benchmarks/exposure-context",
+            enabled=benchmark_enabled and stateful_mode_enabled,
+            supported_input_modes=["stateful"] if stateful_mode_enabled else [],
+            supports_async=False,
+            stateful_restrictions=(
+                [
+                    "lotus-core remains the benchmark composition system of record",
+                    "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported",
+                    "ISSUER remains gated until benchmark issuer exposure semantics are approved",
+                ]
+                if benchmark_enabled and stateful_mode_enabled
+                else []
+            ),
+            contract_notes=(
+                [
+                    "returns a lineage-backed benchmark exposure view aligned to benchmark performance context",
+                    "intended for lotus-risk stateful ACTIVE_RISK attribution integration",
+                ]
+                if benchmark_enabled and stateful_mode_enabled
+                else []
+            ),
         ),
     ]
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     LINEAGE_WORKER_MAX_ATTEMPTS: int = 3
     LINEAGE_WORKER_LEASE_SECONDS: int = 60
     LINEAGE_WORKER_ID: str = "lineage-worker-1"
-    CORE_QUERY_BASE_URL: str = "http://localhost:8202"
+    CORE_QUERY_BASE_URL: str = "http://core-query.dev.lotus"
     CORE_TIMEOUT_SECONDS: float = 10.0
     CORE_MAX_RETRIES: int = 2
     CORE_RETRY_BACKOFF_SECONDS: float = 0.2

--- a/app/models/benchmark_exposure_context.py
+++ b/app/models/benchmark_exposure_context.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import date as dt_date
+from datetime import datetime as dt_datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.returns_series import ReturnsFrequency
+
+
+class BenchmarkExposureGroupingDimension(str, Enum):
+    POSITION = "POSITION"
+    SECTOR = "SECTOR"
+    ASSET_CLASS = "ASSET_CLASS"
+    ISSUER = "ISSUER"
+
+
+class BenchmarkExposureWindow(BaseModel):
+    start_date: dt_date = Field(description="Inclusive start date for benchmark exposure history.", examples=["2026-01-02"])
+    end_date: dt_date = Field(description="Inclusive end date for benchmark exposure history.", examples=["2026-02-28"])
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "BenchmarkExposureWindow":
+        if self.start_date > self.end_date:
+            raise ValueError("window.start_date cannot be after window.end_date")
+        return self
+
+
+class BenchmarkExposurePageRequest(BaseModel):
+    page_size: int = Field(
+        default=1000,
+        ge=1,
+        le=1000,
+        description="Maximum number of exposure rows to return. Capped at 1000 to match lotus-core benchmark market-series contract.",
+        examples=[1000],
+    )
+    page_token: str | None = Field(
+        default=None,
+        description="Opaque pagination token from a previous benchmark exposure context response.",
+        examples=["1000"],
+    )
+
+
+class BenchmarkExposureContextRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    calculation_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this benchmark exposure context request.",
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier used to resolve benchmark assignment when benchmark_id is omitted.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    benchmark_id: str | None = Field(
+        default=None,
+        description="Optional explicit benchmark identifier. If omitted, lotus-performance resolves the benchmark assignment through lotus-core.",
+        examples=["BMK_PB_GLOBAL_BALANCED_60_40"],
+    )
+    as_of_date: dt_date = Field(
+        description="As-of date used for benchmark assignment and exposure context resolution.",
+        examples=["2026-02-28"],
+    )
+    window: BenchmarkExposureWindow = Field(description="Date window for exposure history.")
+    frequency: ReturnsFrequency = Field(
+        default=ReturnsFrequency.DAILY,
+        description="Output frequency for benchmark exposure context. v1 supports DAILY.",
+    )
+    reporting_currency: str | None = Field(
+        default=None,
+        description="Optional reporting currency used to request currency-aligned benchmark market-series context.",
+        examples=["USD"],
+    )
+    grouping_dimensions: list[BenchmarkExposureGroupingDimension] = Field(
+        default_factory=lambda: [BenchmarkExposureGroupingDimension.POSITION],
+        description="Benchmark exposure grouping dimensions to return. v1 supports POSITION, SECTOR, and ASSET_CLASS. ISSUER remains gated until issuer benchmark semantics are approved.",
+        examples=[["POSITION", "SECTOR", "ASSET_CLASS"]],
+        json_schema_extra={"example": ["POSITION", "SECTOR", "ASSET_CLASS"]},
+    )
+    page: BenchmarkExposurePageRequest = Field(default_factory=BenchmarkExposurePageRequest)
+
+    @model_validator(mode="after")
+    def validate_dimensions(self) -> "BenchmarkExposureContextRequest":
+        if not self.grouping_dimensions:
+            raise ValueError("grouping_dimensions must contain at least one value")
+        unsupported = sorted({dimension.value for dimension in self.grouping_dimensions if dimension == BenchmarkExposureGroupingDimension.ISSUER})
+        if unsupported:
+            raise ValueError("benchmark exposure context does not yet support grouping_dimensions=" + ", ".join(unsupported))
+        return self
+
+
+class BenchmarkExposureRow(BaseModel):
+    valuation_date: dt_date = Field(description="Observation date for the benchmark exposure row.", examples=["2026-01-02"])
+    component_id: str | None = Field(
+        default=None,
+        description="Benchmark component identifier when the row represents POSITION-level exposure; null for aggregated groups.",
+        examples=["IDX_GLOBAL_EQUITY"],
+    )
+    grouping_dimension: BenchmarkExposureGroupingDimension = Field(description="Grouping dimension represented by this exposure row.")
+    group_key: str = Field(description="Stable canonical group key for this benchmark exposure row.", examples=["ASSET_CLASS_EQUITY"])
+    group_label: str = Field(description="Human-readable group label for this benchmark exposure row.", examples=["Equity"])
+    weight: Decimal = Field(
+        description="Benchmark exposure weight as a decimal fraction. Example: 0.60 means 60%.",
+        examples=["0.600000"],
+    )
+
+
+class BenchmarkExposurePageResponse(BaseModel):
+    next_page_token: str | None = Field(
+        default=None,
+        description="Token for the next page, or null when all exposure rows have been returned.",
+    )
+
+
+class BenchmarkExposureMetadata(BaseModel):
+    source_system: Literal["lotus-core"] = Field(
+        default="lotus-core",
+        description="Authoritative source system for benchmark composition and classifications.",
+    )
+    served_by: Literal["lotus-performance"] = Field(
+        default="lotus-performance",
+        description="Service exposing the performance-aligned benchmark exposure context view.",
+    )
+    calculation_run_id: UUID = Field(description="lotus-performance request/calc identifier for this exposure context response.")
+    contract_version: Literal["v1"] = Field(default="v1", description="Contract version for this response payload.")
+    generated_at: dt_datetime = Field(description="UTC timestamp at which the response was generated.")
+    retrieval_metadata: dict[str, int] = Field(
+        default_factory=dict,
+        description="Upstream retrieval counters such as chunk and page counts.",
+        examples=[{"benchmark_market_series_chunk_count": 1, "index_catalog_page_count": 1}],
+    )
+
+
+class BenchmarkExposureContextResponse(BaseModel):
+    calculation_id: UUID = Field(description="Stable calculation handle for this benchmark exposure context request.")
+    source_service: Literal["lotus-performance"] = Field(default="lotus-performance")
+    contract_version: Literal["v1"] = Field(default="v1")
+    portfolio_id: str = Field(description="Portfolio identifier used for request context.", examples=["PB_SG_GLOBAL_BAL_001"])
+    benchmark_id: str = Field(description="Resolved benchmark identifier.", examples=["BMK_PB_GLOBAL_BALANCED_60_40"])
+    benchmark_version: str = Field(description="Benchmark version/effective as-of marker used for the exposure context.", examples=["2026-02-28"])
+    as_of_date: dt_date = Field(description="As-of date used for context resolution.", examples=["2026-02-28"])
+    window: BenchmarkExposureWindow = Field(description="Resolved benchmark exposure context window.")
+    frequency: ReturnsFrequency = Field(description="Frequency of the exposure context rows.")
+    reporting_currency: str | None = Field(default=None, description="Reporting currency used for the exposure context.")
+    rows: list[BenchmarkExposureRow] = Field(description="Benchmark exposure rows aligned to benchmark return context.")
+    page: BenchmarkExposurePageResponse = Field(description="Pagination metadata for exposure rows.")
+    metadata: BenchmarkExposureMetadata = Field(description="Lineage and operational metadata for the response.")

--- a/app/models/benchmark_exposure_context.py
+++ b/app/models/benchmark_exposure_context.py
@@ -20,7 +20,9 @@ class BenchmarkExposureGroupingDimension(str, Enum):
 
 
 class BenchmarkExposureWindow(BaseModel):
-    start_date: dt_date = Field(description="Inclusive start date for benchmark exposure history.", examples=["2026-01-02"])
+    start_date: dt_date = Field(
+        description="Inclusive start date for benchmark exposure history.", examples=["2026-01-02"]
+    )
     end_date: dt_date = Field(description="Inclusive end date for benchmark exposure history.", examples=["2026-02-28"])
 
     @model_validator(mode="after")
@@ -87,22 +89,38 @@ class BenchmarkExposureContextRequest(BaseModel):
     def validate_dimensions(self) -> "BenchmarkExposureContextRequest":
         if not self.grouping_dimensions:
             raise ValueError("grouping_dimensions must contain at least one value")
-        unsupported = sorted({dimension.value for dimension in self.grouping_dimensions if dimension == BenchmarkExposureGroupingDimension.ISSUER})
+        unsupported = sorted(
+            {
+                dimension.value
+                for dimension in self.grouping_dimensions
+                if dimension == BenchmarkExposureGroupingDimension.ISSUER
+            }
+        )
         if unsupported:
-            raise ValueError("benchmark exposure context does not yet support grouping_dimensions=" + ", ".join(unsupported))
+            raise ValueError(
+                "benchmark exposure context does not yet support grouping_dimensions=" + ", ".join(unsupported)
+            )
         return self
 
 
 class BenchmarkExposureRow(BaseModel):
-    valuation_date: dt_date = Field(description="Observation date for the benchmark exposure row.", examples=["2026-01-02"])
+    valuation_date: dt_date = Field(
+        description="Observation date for the benchmark exposure row.", examples=["2026-01-02"]
+    )
     component_id: str | None = Field(
         default=None,
         description="Benchmark component identifier when the row represents POSITION-level exposure; null for aggregated groups.",
         examples=["IDX_GLOBAL_EQUITY"],
     )
-    grouping_dimension: BenchmarkExposureGroupingDimension = Field(description="Grouping dimension represented by this exposure row.")
-    group_key: str = Field(description="Stable canonical group key for this benchmark exposure row.", examples=["ASSET_CLASS_EQUITY"])
-    group_label: str = Field(description="Human-readable group label for this benchmark exposure row.", examples=["Equity"])
+    grouping_dimension: BenchmarkExposureGroupingDimension = Field(
+        description="Grouping dimension represented by this exposure row."
+    )
+    group_key: str = Field(
+        description="Stable canonical group key for this benchmark exposure row.", examples=["ASSET_CLASS_EQUITY"]
+    )
+    group_label: str = Field(
+        description="Human-readable group label for this benchmark exposure row.", examples=["Equity"]
+    )
     weight: Decimal = Field(
         description="Benchmark exposure weight as a decimal fraction. Example: 0.60 means 60%.",
         examples=["0.600000"],
@@ -125,7 +143,9 @@ class BenchmarkExposureMetadata(BaseModel):
         default="lotus-performance",
         description="Service exposing the performance-aligned benchmark exposure context view.",
     )
-    calculation_run_id: UUID = Field(description="lotus-performance request/calc identifier for this exposure context response.")
+    calculation_run_id: UUID = Field(
+        description="lotus-performance request/calc identifier for this exposure context response."
+    )
     contract_version: Literal["v1"] = Field(default="v1", description="Contract version for this response payload.")
     generated_at: dt_datetime = Field(description="UTC timestamp at which the response was generated.")
     retrieval_metadata: dict[str, int] = Field(
@@ -139,13 +159,19 @@ class BenchmarkExposureContextResponse(BaseModel):
     calculation_id: UUID = Field(description="Stable calculation handle for this benchmark exposure context request.")
     source_service: Literal["lotus-performance"] = Field(default="lotus-performance")
     contract_version: Literal["v1"] = Field(default="v1")
-    portfolio_id: str = Field(description="Portfolio identifier used for request context.", examples=["PB_SG_GLOBAL_BAL_001"])
+    portfolio_id: str = Field(
+        description="Portfolio identifier used for request context.", examples=["PB_SG_GLOBAL_BAL_001"]
+    )
     benchmark_id: str = Field(description="Resolved benchmark identifier.", examples=["BMK_PB_GLOBAL_BALANCED_60_40"])
-    benchmark_version: str = Field(description="Benchmark version/effective as-of marker used for the exposure context.", examples=["2026-02-28"])
+    benchmark_version: str = Field(
+        description="Benchmark version/effective as-of marker used for the exposure context.", examples=["2026-02-28"]
+    )
     as_of_date: dt_date = Field(description="As-of date used for context resolution.", examples=["2026-02-28"])
     window: BenchmarkExposureWindow = Field(description="Resolved benchmark exposure context window.")
     frequency: ReturnsFrequency = Field(description="Frequency of the exposure context rows.")
-    reporting_currency: str | None = Field(default=None, description="Reporting currency used for the exposure context.")
+    reporting_currency: str | None = Field(
+        default=None, description="Reporting currency used for the exposure context."
+    )
     rows: list[BenchmarkExposureRow] = Field(description="Benchmark exposure rows aligned to benchmark return context.")
     page: BenchmarkExposurePageResponse = Field(description="Pagination metadata for exposure rows.")
     metadata: BenchmarkExposureMetadata = Field(description="Lineage and operational metadata for the response.")

--- a/app/services/benchmark_exposure_context_service.py
+++ b/app/services/benchmark_exposure_context_service.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.models.benchmark_exposure_context import (
+    BenchmarkExposureContextRequest,
+    BenchmarkExposureContextResponse,
+    BenchmarkExposureGroupingDimension,
+    BenchmarkExposureMetadata,
+    BenchmarkExposurePageResponse,
+    BenchmarkExposureRow,
+)
+from app.services.stateful_input_service import StatefulInputService
+from core.errors import HTTP_422_UNPROCESSABLE
+
+
+def _as_decimal(value: Any, *, field_name: str) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE,
+            detail=f"benchmark exposure context payload has invalid {field_name}: {value}",
+        ) from exc
+
+
+async def build_benchmark_exposure_context(
+    *,
+    request: BenchmarkExposureContextRequest,
+    stateful_input_service: StatefulInputService,
+) -> BenchmarkExposureContextResponse:
+    benchmark_id = await _resolve_benchmark_id(request=request, stateful_input_service=stateful_input_service)
+    classification_map = await _classification_map_for_request(
+        request=request,
+        stateful_input_service=stateful_input_service,
+    )
+    market_status, market_payload = await stateful_input_service.get_benchmark_market_series(
+        calculation_id=request.calculation_id,
+        benchmark_id=benchmark_id,
+        as_of_date=request.as_of_date,
+        start_date=request.window.start_date,
+        end_date=request.window.end_date,
+        frequency=request.frequency.value.lower(),
+        target_currency=request.reporting_currency,
+        series_fields=["component_weight"],
+    )
+    if market_status == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No benchmark market-series found for benchmark_id={benchmark_id}.",
+        )
+    if market_status >= status.HTTP_400_BAD_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"benchmark market-series source unavailable ({market_status}).",
+        )
+
+    rows = _build_exposure_rows(
+        component_series=_parse_component_series(market_payload),
+        grouping_dimensions=request.grouping_dimensions,
+        classification_map=classification_map,
+    )
+    if not rows:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE,
+            detail=f"No usable benchmark exposure rows returned for benchmark_id={benchmark_id}.",
+        )
+
+    paged_rows, next_page_token = _page_rows(
+        rows=rows,
+        page_size=request.page.page_size,
+        page_token=request.page.page_token,
+    )
+    market_retrieval = _parse_retrieval_metadata(market_payload)
+    index_catalog_count = 1 if classification_map else 0
+
+    return BenchmarkExposureContextResponse(
+        calculation_id=request.calculation_id,
+        portfolio_id=request.portfolio_id,
+        benchmark_id=benchmark_id,
+        benchmark_version=str(request.as_of_date),
+        as_of_date=request.as_of_date,
+        window=request.window,
+        frequency=request.frequency,
+        reporting_currency=request.reporting_currency,
+        rows=paged_rows,
+        page=BenchmarkExposurePageResponse(next_page_token=next_page_token),
+        metadata=BenchmarkExposureMetadata(
+            calculation_run_id=request.calculation_id,
+            generated_at=datetime.now(UTC),
+            retrieval_metadata={
+                "benchmark_market_series_chunk_count": market_retrieval.get("chunk_count", 0),
+                "benchmark_market_series_page_count": market_retrieval.get("page_count", 0),
+                "index_catalog_page_count": index_catalog_count,
+            },
+        ),
+    )
+
+
+async def _resolve_benchmark_id(
+    *,
+    request: BenchmarkExposureContextRequest,
+    stateful_input_service: StatefulInputService,
+) -> str:
+    if request.benchmark_id:
+        return request.benchmark_id
+    assignment_status, assignment_payload = await stateful_input_service.get_benchmark_assignment(
+        calculation_id=request.calculation_id,
+        portfolio_id=request.portfolio_id,
+        as_of_date=request.as_of_date,
+        reporting_currency=request.reporting_currency,
+    )
+    if assignment_status == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE,
+            detail="benchmark exposure context requires a benchmark assignment or explicit benchmark_id.",
+        )
+    if assignment_status >= status.HTTP_400_BAD_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"benchmark assignment source unavailable ({assignment_status}).",
+        )
+    benchmark_id = assignment_payload.get("benchmark_id")
+    if not isinstance(benchmark_id, str) or not benchmark_id:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="benchmark assignment payload missing benchmark_id.",
+        )
+    return benchmark_id
+
+
+async def _classification_map_for_request(
+    *,
+    request: BenchmarkExposureContextRequest,
+    stateful_input_service: StatefulInputService,
+) -> dict[str, dict[str, str]]:
+    if not any(
+        dimension in {BenchmarkExposureGroupingDimension.SECTOR, BenchmarkExposureGroupingDimension.ASSET_CLASS}
+        for dimension in request.grouping_dimensions
+    ):
+        return {}
+    catalog_status, catalog_payload = await stateful_input_service.get_index_catalog(
+        calculation_id=request.calculation_id,
+        as_of_date=request.as_of_date,
+    )
+    if catalog_status >= status.HTTP_400_BAD_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"index catalog source unavailable ({catalog_status}).",
+        )
+    records = catalog_payload.get("records")
+    if not isinstance(records, list):
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE,
+            detail="index catalog payload missing records list.",
+        )
+    classification_map: dict[str, dict[str, str]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        index_id = record.get("index_id")
+        labels = record.get("classification_labels")
+        if isinstance(index_id, str) and isinstance(labels, dict):
+            classification_map[index_id] = {str(key): str(value) for key, value in labels.items() if value is not None}
+    return classification_map
+
+
+def _parse_component_series(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    component_series = payload.get("component_series")
+    if not isinstance(component_series, list):
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE,
+            detail="benchmark market-series payload missing component_series list.",
+        )
+    return [component for component in component_series if isinstance(component, dict)]
+
+
+def _build_exposure_rows(
+    *,
+    component_series: list[dict[str, Any]],
+    grouping_dimensions: list[BenchmarkExposureGroupingDimension],
+    classification_map: dict[str, dict[str, str]],
+) -> list[BenchmarkExposureRow]:
+    grouped_weights: dict[tuple[str, BenchmarkExposureGroupingDimension, str], Decimal] = {}
+    labels: dict[tuple[BenchmarkExposureGroupingDimension, str], str] = {}
+    component_ids: dict[tuple[BenchmarkExposureGroupingDimension, str], str | None] = {}
+
+    for component in component_series:
+        index_id_raw = component.get("index_id")
+        if not isinstance(index_id_raw, str) or not index_id_raw:
+            continue
+        points = component.get("points")
+        if not isinstance(points, list):
+            continue
+        for point in points:
+            if not isinstance(point, dict):
+                continue
+            series_date = point.get("series_date")
+            if not isinstance(series_date, str):
+                continue
+            component_weight = point.get("component_weight")
+            if component_weight is None:
+                continue
+            weight = _as_decimal(component_weight, field_name="component_weight")
+            for dimension in grouping_dimensions:
+                group_key, group_label, component_id = _group_identity(
+                    index_id=index_id_raw,
+                    grouping_dimension=dimension,
+                    classification_map=classification_map,
+                )
+                grouped_key = (series_date, dimension, group_key)
+                grouped_weights[grouped_key] = grouped_weights.get(grouped_key, Decimal("0")) + weight
+                labels[(dimension, group_key)] = group_label
+                component_ids[(dimension, group_key)] = component_id
+
+    return [
+        BenchmarkExposureRow(
+            valuation_date=series_date,
+            component_id=component_ids.get((dimension, group_key)),
+            grouping_dimension=dimension,
+            group_key=group_key,
+            group_label=labels[(dimension, group_key)],
+            weight=weight,
+        )
+        for (series_date, dimension, group_key), weight in sorted(grouped_weights.items())
+    ]
+
+
+def _group_identity(
+    *,
+    index_id: str,
+    grouping_dimension: BenchmarkExposureGroupingDimension,
+    classification_map: dict[str, dict[str, str]],
+) -> tuple[str, str, str | None]:
+    if grouping_dimension == BenchmarkExposureGroupingDimension.POSITION:
+        return index_id, index_id, index_id
+    if grouping_dimension == BenchmarkExposureGroupingDimension.SECTOR:
+        label = classification_map.get(index_id, {}).get("sector") or "UNKNOWN"
+        return f"SECTOR_{label}", label, None
+    if grouping_dimension == BenchmarkExposureGroupingDimension.ASSET_CLASS:
+        label = classification_map.get(index_id, {}).get("asset_class") or "UNKNOWN"
+        return f"ASSET_CLASS_{label}", label, None
+    raise HTTPException(
+        status_code=HTTP_422_UNPROCESSABLE,
+        detail=f"benchmark exposure context does not yet support grouping_dimension={grouping_dimension.value}",
+    )
+
+
+def _page_rows(
+    *,
+    rows: list[BenchmarkExposureRow],
+    page_size: int,
+    page_token: str | None,
+) -> tuple[list[BenchmarkExposureRow], str | None]:
+    try:
+        start = int(page_token) if page_token else 0
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE,
+            detail="page.page_token must be a numeric offset token returned by lotus-performance.",
+        ) from exc
+    if start < 0:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE,
+            detail="page.page_token must be non-negative.",
+        )
+    end = start + page_size
+    next_page_token = str(end) if end < len(rows) else None
+    return rows[start:end], next_page_token
+
+
+def _parse_retrieval_metadata(payload: dict[str, Any]) -> dict[str, int]:
+    raw = payload.get("retrieval_metadata")
+    if not isinstance(raw, dict):
+        return {"chunk_count": 0, "page_count": 0}
+    return {
+        "chunk_count": int(raw.get("chunk_count", 0) or 0),
+        "page_count": int(raw.get("page_count", 0) or 0),
+    }

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -664,6 +664,28 @@ Return semantics for the workspace surface are now explicit rather than inferred
   - completed: `ReturnsSeriesResponse`
   - still running: `ReturnsSeriesAcceptedResponse`
 
+### `POST /integration/benchmarks/exposure-context`
+
+- purpose: return benchmark exposure history aligned to benchmark performance context for downstream active-risk attribution
+- request model: `app.models.benchmark_exposure_context.BenchmarkExposureContextRequest`
+- response model: `app.models.benchmark_exposure_context.BenchmarkExposureContextResponse`
+- execution mode:
+  - synchronous v1 integration endpoint
+- ownership:
+  - lotus-core remains the benchmark composition and classification system of record
+  - lotus-performance exposes the derived, lineage-backed view used with benchmark returns
+- supported grouping dimensions:
+  - `POSITION`
+  - `SECTOR`
+  - `ASSET_CLASS`
+- gated grouping dimensions:
+  - `ISSUER` remains unsupported until benchmark issuer exposure semantics are defined
+- contract notes:
+  - if `benchmark_id` is omitted, lotus-performance resolves benchmark assignment through lotus-core
+  - benchmark market-series is requested with `series_fields=["component_weight"]`
+  - response rows use decimal weights, not percentages
+  - lineage metadata includes `source_system="lotus-core"` and `served_by="lotus-performance"`
+
 ## Health and observability
 
 ### `GET /health`

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,8 +8,22 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-03-21T00:41:36.013032+00:00",
+  "generatedAt": "2026-04-07T09:14:52.705320+00:00",
   "attributeCatalog": [
+    {
+      "semanticId": "lotus.account_reset_shadow_days",
+      "canonicalTerm": "account_reset_shadow_days",
+      "preferredName": "account_reset_shadow_days",
+      "description": "diagnostics field: account reset shadow days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
     {
       "semanticId": "lotus.acquired_at_utc",
       "canonicalTerm": "acquired_at_utc",
@@ -22,6 +36,20 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.active_reset_with_shadow_days",
+      "canonicalTerm": "active_reset_with_shadow_days",
+      "preferredName": "active_reset_with_shadow_days",
+      "description": "diagnostics field: active reset with shadow days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -143,8 +171,25 @@
             "example_supported_input_modes_item"
           ],
           "supports_async": true,
+          "poll_path_template": "example_poll_path_template",
+          "result_path_template": "example_result_path_template",
           "stateful_restrictions": [
             "example_stateful_restrictions_item"
+          ],
+          "contract_notes": [
+            "example_contract_notes_item"
+          ],
+          "options": [
+            {
+              "key": "example_key",
+              "supported_values": [
+                "example_supported_values_item"
+              ],
+              "required_when": "example_required_when",
+              "notes": [
+                "example_notes_item"
+              ]
+            }
           ]
         }
       ],
@@ -309,6 +354,22 @@
       ]
     },
     {
+      "semanticId": "lotus.attribution",
+      "canonicalTerm": "attribution",
+      "preferredName": "attribution",
+      "description": "Optional lightweight attribution summary block configuration.",
+      "example": {
+        "metric_basis": "NET"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.audit",
       "canonicalTerm": "audit",
       "preferredName": "audit",
@@ -373,7 +434,7 @@
       "semanticId": "lotus.benchmark",
       "canonicalTerm": "benchmark",
       "preferredName": "benchmark",
-      "description": "Optional benchmark request resolved and calculated alongside portfolio TWR.",
+      "description": "Optional benchmark request resolved and calculated alongside the workspace summary.",
       "example": {
         "benchmark_id": "BENCHMARK_001",
         "input_mode": "stateless",
@@ -460,7 +521,8 @@
         "body"
       ],
       "observedTypes": [
-        "string"
+        "string",
+        "object"
       ]
     },
     {
@@ -469,6 +531,20 @@
       "preferredName": "benchmark_start_date",
       "description": "Earliest date for which benchmark data is available for the request.",
       "example": "2026-02-27",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.benchmark_version",
+      "canonicalTerm": "benchmark_version",
+      "preferredName": "benchmark_version",
+      "description": "Benchmark version/effective as-of marker used for the exposure context.",
+      "example": "STANDARD_VALUE",
       "type": "string",
       "locations": [
         "body"
@@ -553,7 +629,7 @@
       "semanticId": "lotus.calculation_id",
       "canonicalTerm": "calculation_id",
       "preferredName": "calculation_id",
-      "description": "A unique identifier for the calculation request. If not provided, one will be generated.",
+      "description": "Durable workspace summary calculation handle. If omitted, lotus-performance generates one.",
       "example": "2f4f3e0e-6e0e-4e0e-8e0e-2f4f3e0e6e0e",
       "type": "string",
       "locations": [
@@ -577,6 +653,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.calculation_run_id",
+      "canonicalTerm": "calculation_run_id",
+      "preferredName": "calculation_run_id",
+      "description": "lotus-performance request/calc identifier for this exposure context response.",
+      "example": "CALCULATION_RUN_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -624,6 +714,20 @@
       ]
     },
     {
+      "semanticId": "lotus.candidate_canonical_reset_days",
+      "canonicalTerm": "candidate_canonical_reset_days",
+      "preferredName": "candidate_canonical_reset_days",
+      "description": "diagnostics field: candidate canonical reset days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.cash_flows",
       "canonicalTerm": "cash_flows",
       "preferredName": "cash_flows",
@@ -646,7 +750,7 @@
       "semanticId": "lotus.cashflows_used",
       "canonicalTerm": "cashflows_used",
       "preferredName": "cashflows_used",
-      "description": "money weighted return response field: cashflows used.",
+      "description": "Cash flows used by the MWR calculation in reporting currency units.",
       "example": [
         {
           "amount": 0.1234,
@@ -711,6 +815,20 @@
       "preferredName": "completed_at_utc",
       "description": "execution response field: completed at utc.",
       "example": "example_completed_at_utc",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.component_id",
+      "canonicalTerm": "component_id",
+      "preferredName": "component_id",
+      "description": "Benchmark component identifier when the row represents POSITION-level exposure; null for aggregated groups.",
+      "example": "ENTITY_001",
       "type": "object",
       "locations": [
         "body"
@@ -908,6 +1026,22 @@
       ]
     },
     {
+      "semanticId": "lotus.contract_notes",
+      "canonicalTerm": "contract_notes",
+      "preferredName": "contract_notes",
+      "description": "Surface-specific contract notes that downstream consumers should treat as part of the supported behavior.",
+      "example": [
+        "example_contract_notes_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.contract_version",
       "canonicalTerm": "contract_version",
       "preferredName": "contract_version",
@@ -922,13 +1056,30 @@
       ]
     },
     {
+      "semanticId": "lotus.contribution",
+      "canonicalTerm": "contribution",
+      "preferredName": "contribution",
+      "description": "Optional lightweight contribution summary block configuration.",
+      "example": {
+        "metric_basis": "NET",
+        "top_positions": 1
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.convergence",
       "canonicalTerm": "convergence",
       "preferredName": "convergence",
-      "description": "money weighted return response field: convergence.",
+      "description": "Numerical convergence diagnostics when applicable.",
       "example": {
-        "iterations": 1,
-        "residual": 0.1234,
+        "iterations": 8,
+        "residual": 1e-10,
         "converged": true
       },
       "type": "object",
@@ -987,7 +1138,7 @@
       "semanticId": "lotus.currency",
       "canonicalTerm": "currency",
       "preferredName": "currency",
-      "description": "The three-letter ISO currency code for the request (e.g., 'USD').",
+      "description": "The three-letter ISO currency code for the request.",
       "example": "USD",
       "type": "string",
       "locations": [
@@ -1001,7 +1152,7 @@
       "semanticId": "lotus.currency_mode",
       "canonicalTerm": "currency_mode",
       "preferredName": "currency_mode",
-      "description": "ISO currency code for currency mode.",
+      "description": "Optional multi-currency mode for the portfolio path.",
       "example": "BASE_ONLY",
       "type": "object",
       "locations": [
@@ -1416,8 +1567,8 @@
       "semanticId": "lotus.end_date",
       "canonicalTerm": "end_date",
       "preferredName": "end_date",
-      "description": "Business date for end date.",
-      "example": "2026-02-27",
+      "description": "Inclusive end date for the evaluated window.",
+      "example": "2025-03-31",
       "type": "string",
       "locations": [
         "body"
@@ -1690,7 +1841,7 @@
       "semanticId": "lotus.frequencies",
       "canonicalTerm": "frequencies",
       "preferredName": "frequencies",
-      "description": "Breakdown frequencies to emit for the resolved period. Supported values: daily, weekly, monthly, quarterly, yearly.",
+      "description": "Breakdown frequencies to emit for this workspace horizon.",
       "example": [
         "DAILY"
       ],
@@ -1735,7 +1886,7 @@
       "semanticId": "lotus.fx",
       "canonicalTerm": "fx",
       "preferredName": "fx",
-      "description": "twranalytics request field: fx.",
+      "description": "Optional FX inputs used when currency_mode requires explicit FX data.",
       "example": {
         "source": "example_source",
         "fixing": "example_fixing",
@@ -1842,6 +1993,66 @@
       ]
     },
     {
+      "semanticId": "lotus.group_key",
+      "canonicalTerm": "group_key",
+      "preferredName": "group_key",
+      "description": "Stable canonical group key for this benchmark exposure row.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.group_label",
+      "canonicalTerm": "group_label",
+      "preferredName": "group_label",
+      "description": "Human-readable group label for this benchmark exposure row.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.grouping_dimension",
+      "canonicalTerm": "grouping_dimension",
+      "preferredName": "grouping_dimension",
+      "description": "benchmark exposure grouping dimension schema.",
+      "example": "POSITION",
+      "type": "BenchmarkExposureGroupingDimension",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "BenchmarkExposureGroupingDimension"
+      ]
+    },
+    {
+      "semanticId": "lotus.grouping_dimensions",
+      "canonicalTerm": "grouping_dimensions",
+      "preferredName": "grouping_dimensions",
+      "description": "Benchmark exposure grouping dimensions to return. v1 supports POSITION, SECTOR, and ASSET_CLASS. ISSUER remains gated until issuer benchmark semantics are approved.",
+      "example": [
+        "POSITION",
+        "SECTOR",
+        "ASSET_CLASS"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.hedging",
       "canonicalTerm": "hedging",
       "preferredName": "hedging",
@@ -1884,7 +2095,7 @@
       "semanticId": "lotus.include_benchmark",
       "canonicalTerm": "include_benchmark",
       "preferredName": "include_benchmark",
-      "description": "Whether benchmark performance should be calculated and returned alongside portfolio TWR.",
+      "description": "Whether benchmark and active summary blocks should be returned.",
       "example": true,
       "type": "boolean",
       "locations": [
@@ -2664,6 +2875,22 @@
       ]
     },
     {
+      "semanticId": "lotus.metadata",
+      "canonicalTerm": "metadata",
+      "preferredName": "metadata",
+      "description": "benchmark exposure metadata object.",
+      "example": {
+        "key": "value"
+      },
+      "type": "BenchmarkExposureMetadata",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "BenchmarkExposureMetadata"
+      ]
+    },
+    {
       "semanticId": "lotus.method",
       "canonicalTerm": "method",
       "preferredName": "method",
@@ -2768,8 +2995,8 @@
       "semanticId": "lotus.money_weighted_return",
       "canonicalTerm": "money_weighted_return",
       "preferredName": "money_weighted_return",
-      "description": "Performance metric value for money weighted return.",
-      "example": 0.1234,
+      "description": "Money-weighted return in percentage-point output units.",
+      "example": 0.1,
       "type": "number",
       "locations": [
         "body"
@@ -2782,8 +3009,8 @@
       "semanticId": "lotus.mwr_annualized",
       "canonicalTerm": "mwr_annualized",
       "preferredName": "mwr_annualized",
-      "description": "money weighted return response field: mwr annualized.",
-      "example": 0.1234,
+      "description": "Annualized money-weighted return in percentage-point output units when available.",
+      "example": "STANDARD_VALUE",
       "type": "object",
       "locations": [
         "body"
@@ -2796,7 +3023,7 @@
       "semanticId": "lotus.mwr_method",
       "canonicalTerm": "mwr_method",
       "preferredName": "mwr_method",
-      "description": "money weighted return analytics request field: mwr method.",
+      "description": "Money-weighted return method used for the MWR block.",
       "example": "XIRR",
       "type": "string",
       "locations": [
@@ -2804,6 +3031,34 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.nctrl4_exclusive_reset_days",
+      "canonicalTerm": "nctrl4_exclusive_reset_days",
+      "preferredName": "nctrl4_exclusive_reset_days",
+      "description": "diagnostics field: nctrl4 exclusive reset days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.nctrl4_reset_days",
+      "canonicalTerm": "nctrl4_reset_days",
+      "preferredName": "nctrl4_reset_days",
+      "description": "diagnostics field: nctrl4 reset days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -2849,6 +3104,20 @@
       ]
     },
     {
+      "semanticId": "lotus.next_page_token",
+      "canonicalTerm": "next_page_token",
+      "preferredName": "next_page_token",
+      "description": "Token for the next page, or null when all exposure rows have been returned.",
+      "example": "example_next_page_token",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.nip_days",
       "canonicalTerm": "nip_days",
       "preferredName": "nip_days",
@@ -2863,10 +3132,38 @@
       ]
     },
     {
+      "semanticId": "lotus.nip_days_since_last_reset",
+      "canonicalTerm": "nip_days_since_last_reset",
+      "preferredName": "nip_days_since_last_reset",
+      "description": "diagnostics field: nip days since last reset.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.nip_rule_delta_days",
+      "canonicalTerm": "nip_rule_delta_days",
+      "preferredName": "nip_rule_delta_days",
+      "description": "diagnostics field: nip rule delta days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.notes",
       "canonicalTerm": "notes",
       "preferredName": "notes",
-      "description": "money weighted return response field: notes.",
+      "description": "Method or validation notes returned by the engine.",
       "example": [
         "example_notes_item"
       ],
@@ -3058,6 +3355,31 @@
       ]
     },
     {
+      "semanticId": "lotus.options",
+      "canonicalTerm": "options",
+      "preferredName": "options",
+      "description": "Machine-readable request-option capabilities for this analytics surface.",
+      "example": [
+        {
+          "key": "example_key",
+          "supported_values": [
+            "example_supported_values_item"
+          ],
+          "required_when": "example_required_when",
+          "notes": [
+            "example_notes_item"
+          ]
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.output",
       "canonicalTerm": "output",
       "preferredName": "output",
@@ -3101,6 +3423,51 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.page",
+      "canonicalTerm": "page",
+      "preferredName": "page",
+      "description": "benchmark exposure page request object.",
+      "example": {
+        "key": "value"
+      },
+      "type": "BenchmarkExposurePageRequest",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "BenchmarkExposurePageRequest",
+        "BenchmarkExposurePageResponse"
+      ]
+    },
+    {
+      "semanticId": "lotus.page_size",
+      "canonicalTerm": "page_size",
+      "preferredName": "page_size",
+      "description": "Maximum number of exposure rows to return. Capped at 1000 to match lotus-core benchmark market-series contract.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.page_token",
+      "canonicalTerm": "page_token",
+      "preferredName": "page_token",
+      "description": "Opaque pagination token from a previous benchmark exposure context response.",
+      "example": "STANDARD_VALUE",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -3193,7 +3560,7 @@
       "semanticId": "lotus.performance_start_date",
       "canonicalTerm": "performance_start_date",
       "preferredName": "performance_start_date",
-      "description": "Portfolio inception or earliest performance date. Required in stateless mode. In stateful mode lotus-performance derives the authoritative start date from lotus-core.",
+      "description": "Portfolio inception or earliest date for which performance data is available. In stateful mode lotus-performance can derive this upstream.",
       "example": "2024-12-31",
       "type": "object",
       "locations": [
@@ -3207,13 +3574,14 @@
       "semanticId": "lotus.period",
       "canonicalTerm": "period",
       "preferredName": "period",
-      "description": "Defines the supported period types for performance calculation.",
-      "example": "MTD",
-      "type": "PeriodType",
+      "description": "workspace period type schema.",
+      "example": "1D",
+      "type": "WorkspacePeriodType",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "WorkspacePeriodType",
         "PeriodType",
         "object"
       ]
@@ -3222,23 +3590,21 @@
       "semanticId": "lotus.periods",
       "canonicalTerm": "periods",
       "preferredName": "periods",
-      "description": "money weighted return analytics request field: periods.",
-      "example": {
-        "type": "YTD",
-        "explicit": {
-          "start": "2026-02-27",
-          "end": "2026-02-27"
-        },
-        "rolling": {
-          "months": 1,
-          "days": 1
+      "description": "Requested workspace horizons and their breakdown frequencies.",
+      "example": [
+        {
+          "period": "1D",
+          "frequencies": [
+            "DAILY"
+          ]
         }
-      },
-      "type": "object",
+      ],
+      "type": "array",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "array",
         "object"
       ]
     },
@@ -3290,6 +3656,20 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.poll_path_template",
+      "canonicalTerm": "poll_path_template",
+      "preferredName": "poll_path_template",
+      "description": "Execution polling path template for async-capable surfaces.",
+      "example": "example_poll_path_template",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -3347,7 +3727,7 @@
       "semanticId": "lotus.portfolio_id",
       "canonicalTerm": "portfolio_id",
       "preferredName": "portfolio_id",
-      "description": "A unique identifier for the portfolio being analyzed.",
+      "description": "Portfolio identifier for the workspace.",
       "example": "DEMO_DPM_EUR_001",
       "type": "string",
       "locations": [
@@ -3393,7 +3773,7 @@
       "semanticId": "lotus.precision_mode",
       "canonicalTerm": "precision_mode",
       "preferredName": "precision_mode",
-      "description": "The numerical precision mode for the calculation engine.",
+      "description": "Numerical precision mode for the workspace summary.",
       "example": "FLOAT64",
       "type": "string",
       "locations": [
@@ -3797,7 +4177,7 @@
       "semanticId": "lotus.report_ccy",
       "canonicalTerm": "report_ccy",
       "preferredName": "report_ccy",
-      "description": "twranalytics request field: report ccy.",
+      "description": "Optional reporting currency used for stateful retrieval and output context.",
       "example": "example_report_ccy",
       "type": "object",
       "locations": [
@@ -3811,7 +4191,7 @@
       "semanticId": "lotus.report_end_date",
       "canonicalTerm": "report_end_date",
       "preferredName": "report_end_date",
-      "description": "The final date of the analysis period. Also used as the anchor date for resolving relative periods like YTD.",
+      "description": "Anchor end date for all requested workspace horizons.",
       "example": "2026-01-31",
       "type": "string",
       "locations": [
@@ -3825,7 +4205,7 @@
       "semanticId": "lotus.report_start_date",
       "canonicalTerm": "report_start_date",
       "preferredName": "report_start_date",
-      "description": "The explicit start date for an 'EXPLICIT' period calculation. Ignored for other period types.",
+      "description": "Explicit start date used only when requested periods include EXPLICIT.",
       "example": "2026-01-01",
       "type": "object",
       "locations": [
@@ -3897,6 +4277,20 @@
       ]
     },
     {
+      "semanticId": "lotus.required_when",
+      "canonicalTerm": "required_when",
+      "preferredName": "required_when",
+      "description": "Condition under which this option or companion input becomes required.",
+      "example": "example_required_when",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.reset_days",
       "canonicalTerm": "reset_days",
       "preferredName": "reset_days",
@@ -3908,6 +4302,20 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.reset_delta_days",
+      "canonicalTerm": "reset_delta_days",
+      "preferredName": "reset_delta_days",
+      "description": "diagnostics field: reset delta days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -3997,6 +4405,20 @@
       ]
     },
     {
+      "semanticId": "lotus.result_path_template",
+      "canonicalTerm": "result_path_template",
+      "preferredName": "result_path_template",
+      "description": "Endpoint-specific async result path template for async-capable surfaces.",
+      "example": "example_result_path_template",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.retained_file_names",
       "canonicalTerm": "retained_file_names",
       "preferredName": "retained_file_names",
@@ -4047,6 +4469,22 @@
       "preferredName": "retention_max_age_days",
       "description": "Configured maximum age in days for retained recovery-drill evidence artifacts.",
       "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.retrieval_metadata",
+      "canonicalTerm": "retrieval_metadata",
+      "preferredName": "retrieval_metadata",
+      "description": "Upstream retrieval counters such as chunk and page counts.",
+      "example": {
+        "key": "value"
+      },
       "type": "object",
       "locations": [
         "body"
@@ -4216,7 +4654,7 @@
       "semanticId": "lotus.rounding_precision",
       "canonicalTerm": "rounding_precision",
       "preferredName": "rounding_precision",
-      "description": "The number of decimal places to round final float results to.",
+      "description": "Number of decimal places to round float outputs to.",
       "example": 1,
       "type": "integer",
       "locations": [
@@ -4224,6 +4662,29 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.rows",
+      "canonicalTerm": "rows",
+      "preferredName": "rows",
+      "description": "Benchmark exposure rows aligned to benchmark return context.",
+      "example": [
+        {
+          "valuation_date": "2026-01-02",
+          "component_id": "IDX_GLOBAL_EQUITY",
+          "grouping_dimension": "POSITION",
+          "group_key": "ASSET_CLASS_EQUITY",
+          "group_label": "Equity",
+          "weight": "0.600000"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -4353,6 +4814,24 @@
       ]
     },
     {
+      "semanticId": "lotus.segmentation",
+      "canonicalTerm": "segmentation",
+      "preferredName": "segmentation",
+      "description": "Shared segmentation contract used when optional contribution or attribution workspace blocks are requested.",
+      "example": {
+        "group_by": [
+          "asset_class"
+        ]
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.series_selection",
       "canonicalTerm": "series_selection",
       "preferredName": "series_selection",
@@ -4366,6 +4845,48 @@
       ],
       "observedTypes": [
         "SeriesSelection"
+      ]
+    },
+    {
+      "semanticId": "lotus.served_by",
+      "canonicalTerm": "served_by",
+      "preferredName": "served_by",
+      "description": "Service exposing the performance-aligned benchmark exposure context view.",
+      "example": "example_served_by",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.shadow_only_candidate_reset_days",
+      "canonicalTerm": "shadow_only_candidate_reset_days",
+      "preferredName": "shadow_only_candidate_reset_days",
+      "description": "diagnostics field: shadow only candidate reset days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.shadow_reset_overlap_days",
+      "canonicalTerm": "shadow_reset_overlap_days",
+      "preferredName": "shadow_reset_overlap_days",
+      "description": "diagnostics field: shadow reset overlap days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -4396,6 +4917,20 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.sod_reset_shadow_days",
+      "canonicalTerm": "sod_reset_shadow_days",
+      "preferredName": "sod_reset_shadow_days",
+      "description": "diagnostics field: sod reset shadow days.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -4434,6 +4969,20 @@
       "preferredName": "source_service",
       "description": "integration capabilities response field: source service.",
       "example": "lotus-performance",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_system",
+      "canonicalTerm": "source_system",
+      "preferredName": "source_system",
+      "description": "Authoritative source system for benchmark composition and classifications.",
+      "example": "example_source_system",
       "type": "string",
       "locations": [
         "body"
@@ -4514,7 +5063,7 @@
       "semanticId": "lotus.stateful_input",
       "canonicalTerm": "stateful_input",
       "preferredName": "stateful_input",
-      "description": "Stateful TWR input payload resolved through lotus-core integrations.",
+      "description": "Stateful portfolio source configuration.",
       "example": {
         "key": "value"
       },
@@ -4546,7 +5095,7 @@
       "semanticId": "lotus.stateless_input",
       "canonicalTerm": "stateless_input",
       "preferredName": "stateless_input",
-      "description": "Stateless TWR input payload.",
+      "description": "Stateless portfolio valuation observations.",
       "example": {
         "valuation_points": [
           {
@@ -4703,6 +5252,22 @@
       "description": "Supported execution input modes: stateful and stateless.",
       "example": [
         "example_supported_input_modes_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.supported_values",
+      "canonicalTerm": "supported_values",
+      "preferredName": "supported_values",
+      "description": "Supported values or named options for this request capability.",
+      "example": [
+        "example_supported_values_item"
       ],
       "type": "array",
       "locations": [
@@ -5011,10 +5576,38 @@
       ]
     },
     {
+      "semanticId": "lotus.valid_days_since_last_reset",
+      "canonicalTerm": "valid_days_since_last_reset",
+      "preferredName": "valid_days_since_last_reset",
+      "description": "diagnostics field: valid days since last reset.",
+      "example": 1,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.valuation_date",
+      "canonicalTerm": "valuation_date",
+      "preferredName": "valuation_date",
+      "description": "Observation date for the benchmark exposure row.",
+      "example": "2025-03-31",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.valuation_points",
       "canonicalTerm": "valuation_points",
       "preferredName": "valuation_points",
-      "description": "Legacy stateless valuation input payload using the same canonical valuation-point shape. Prefer stateless_input for new integrations.",
+      "description": "Legacy stateless valuation input payload. Prefer stateless_input for new integrations.",
       "example": [
         {
           "perf_date": "2026-02-27",
@@ -5031,6 +5624,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.weight",
+      "canonicalTerm": "weight",
+      "preferredName": "weight",
+      "description": "Benchmark exposure weight as a decimal fraction. Example: 0.60 means 60%.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -5074,7 +5681,8 @@
         "body"
       ],
       "observedTypes": [
-        "ReturnsWindow"
+        "ReturnsWindow",
+        "BenchmarkExposureWindow"
       ]
     },
     {
@@ -5143,6 +5751,18 @@
     }
   ],
   "controlsCatalog": [
+    {
+      "name": "calculation_id",
+      "kind": "request_option",
+      "location": "path",
+      "required": true,
+      "type": "string",
+      "description": "Canonical calculation id used by lotus-performance APIs.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.calculation_id",
+      "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+    },
     {
       "name": "calculation_id",
       "kind": "request_option",
@@ -5712,6 +6332,402 @@
       "summary": "Metrics",
       "request": {
         "fields": []
+      },
+      "response": {
+        "fields": []
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "POST",
+      "path": "/performance/workspace-summary",
+      "operationId": "calculate_workspace_summary_endpoint_performance_workspace_summary_post",
+      "summary": "Calculate interaction-efficient workspace summary analytics",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "report_end_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.report_end_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_end_date"
+          },
+          {
+            "name": "report_start_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_start_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_start_date"
+          },
+          {
+            "name": "performance_start_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.performance_start_date",
+            "attributeRef": "#/attributeCatalog/lotus.performance_start_date"
+          },
+          {
+            "name": "periods",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.periods",
+            "attributeRef": "#/attributeCatalog/lotus.periods"
+          },
+          {
+            "name": "periods[].period",
+            "location": "body",
+            "required": true,
+            "type": "WorkspacePeriodType",
+            "semanticId": "lotus.period",
+            "attributeRef": "#/attributeCatalog/lotus.period"
+          },
+          {
+            "name": "periods[].frequencies",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.frequencies",
+            "attributeRef": "#/attributeCatalog/lotus.frequencies"
+          },
+          {
+            "name": "input_mode",
+            "location": "body",
+            "required": false,
+            "type": "TWRInputMode",
+            "semanticId": "lotus.input_mode",
+            "attributeRef": "#/attributeCatalog/lotus.input_mode"
+          },
+          {
+            "name": "stateless_input",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.stateless_input",
+            "attributeRef": "#/attributeCatalog/lotus.stateless_input"
+          },
+          {
+            "name": "stateful_input",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.stateful_input",
+            "attributeRef": "#/attributeCatalog/lotus.stateful_input"
+          },
+          {
+            "name": "valuation_points",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.valuation_points",
+            "attributeRef": "#/attributeCatalog/lotus.valuation_points"
+          },
+          {
+            "name": "valuation_points[].perf_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.perf_date",
+            "attributeRef": "#/attributeCatalog/lotus.perf_date"
+          },
+          {
+            "name": "valuation_points[].begin_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.begin_mv",
+            "attributeRef": "#/attributeCatalog/lotus.begin_mv"
+          },
+          {
+            "name": "valuation_points[].bod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.bod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.bod_cf"
+          },
+          {
+            "name": "valuation_points[].eod_cf",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.eod_cf",
+            "attributeRef": "#/attributeCatalog/lotus.eod_cf"
+          },
+          {
+            "name": "valuation_points[].mgmt_fees",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.mgmt_fees",
+            "attributeRef": "#/attributeCatalog/lotus.mgmt_fees"
+          },
+          {
+            "name": "valuation_points[].end_mv",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.end_mv",
+            "attributeRef": "#/attributeCatalog/lotus.end_mv"
+          },
+          {
+            "name": "include_benchmark",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_benchmark",
+            "attributeRef": "#/attributeCatalog/lotus.include_benchmark"
+          },
+          {
+            "name": "benchmark",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.benchmark",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark"
+          },
+          {
+            "name": "segmentation",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.segmentation",
+            "attributeRef": "#/attributeCatalog/lotus.segmentation"
+          },
+          {
+            "name": "contribution",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.contribution",
+            "attributeRef": "#/attributeCatalog/lotus.contribution"
+          },
+          {
+            "name": "attribution",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.attribution",
+            "attributeRef": "#/attributeCatalog/lotus.attribution"
+          },
+          {
+            "name": "mwr_method",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.mwr_method",
+            "attributeRef": "#/attributeCatalog/lotus.mwr_method"
+          },
+          {
+            "name": "solver",
+            "location": "body",
+            "required": false,
+            "type": "Solver",
+            "semanticId": "lotus.solver",
+            "attributeRef": "#/attributeCatalog/lotus.solver"
+          },
+          {
+            "name": "solver.method",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.method",
+            "attributeRef": "#/attributeCatalog/lotus.method"
+          },
+          {
+            "name": "solver.max_iter",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.max_iter",
+            "attributeRef": "#/attributeCatalog/lotus.max_iter"
+          },
+          {
+            "name": "solver.tolerance",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.tolerance",
+            "attributeRef": "#/attributeCatalog/lotus.tolerance"
+          },
+          {
+            "name": "currency",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.currency",
+            "attributeRef": "#/attributeCatalog/lotus.currency"
+          },
+          {
+            "name": "precision_mode",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.precision_mode",
+            "attributeRef": "#/attributeCatalog/lotus.precision_mode"
+          },
+          {
+            "name": "rounding_precision",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.rounding_precision",
+            "attributeRef": "#/attributeCatalog/lotus.rounding_precision"
+          },
+          {
+            "name": "calendar",
+            "location": "body",
+            "required": false,
+            "type": "Calendar",
+            "semanticId": "lotus.calendar",
+            "attributeRef": "#/attributeCatalog/lotus.calendar"
+          },
+          {
+            "name": "calendar.type",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "calendar.trading_calendar",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.trading_calendar",
+            "attributeRef": "#/attributeCatalog/lotus.trading_calendar"
+          },
+          {
+            "name": "annualization",
+            "location": "body",
+            "required": false,
+            "type": "Annualization",
+            "semanticId": "lotus.annualization",
+            "attributeRef": "#/attributeCatalog/lotus.annualization"
+          },
+          {
+            "name": "annualization.enabled",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.enabled",
+            "attributeRef": "#/attributeCatalog/lotus.enabled"
+          },
+          {
+            "name": "annualization.basis",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.basis",
+            "attributeRef": "#/attributeCatalog/lotus.basis"
+          },
+          {
+            "name": "annualization.periods_per_year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.periods_per_year",
+            "attributeRef": "#/attributeCatalog/lotus.periods_per_year"
+          },
+          {
+            "name": "output",
+            "location": "body",
+            "required": false,
+            "type": "Output",
+            "semanticId": "lotus.output",
+            "attributeRef": "#/attributeCatalog/lotus.output"
+          },
+          {
+            "name": "output.include_timeseries",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_timeseries",
+            "attributeRef": "#/attributeCatalog/lotus.include_timeseries"
+          },
+          {
+            "name": "output.include_cumulative",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.include_cumulative",
+            "attributeRef": "#/attributeCatalog/lotus.include_cumulative"
+          },
+          {
+            "name": "output.top_n",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.top_n",
+            "attributeRef": "#/attributeCatalog/lotus.top_n"
+          },
+          {
+            "name": "report_ccy",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_ccy",
+            "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "currency_mode",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.currency_mode",
+            "attributeRef": "#/attributeCatalog/lotus.currency_mode"
+          },
+          {
+            "name": "fx",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.fx",
+            "attributeRef": "#/attributeCatalog/lotus.fx"
+          }
+        ]
+      },
+      "response": {
+        "fields": []
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "GET",
+      "path": "/performance/workspace-summary/results/{calculation_id}",
+      "operationId": "get_workspace_summary_result_performance_workspace_summary_results__calculation_id__get",
+      "summary": "Retrieve async workspace summary result",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "path",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          }
+        ]
       },
       "response": {
         "fields": []
@@ -6630,12 +7646,108 @@
             "attributeRef": "#/attributeCatalog/lotus.nip_days"
           },
           {
+            "name": "diagnostics.nip_rule_delta_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.nip_rule_delta_days",
+            "attributeRef": "#/attributeCatalog/lotus.nip_rule_delta_days"
+          },
+          {
             "name": "diagnostics.reset_days",
             "location": "body",
             "required": true,
             "type": "integer",
             "semanticId": "lotus.reset_days",
             "attributeRef": "#/attributeCatalog/lotus.reset_days"
+          },
+          {
+            "name": "diagnostics.nctrl4_reset_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.nctrl4_reset_days",
+            "attributeRef": "#/attributeCatalog/lotus.nctrl4_reset_days"
+          },
+          {
+            "name": "diagnostics.nctrl4_exclusive_reset_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.nctrl4_exclusive_reset_days",
+            "attributeRef": "#/attributeCatalog/lotus.nctrl4_exclusive_reset_days"
+          },
+          {
+            "name": "diagnostics.account_reset_shadow_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.account_reset_shadow_days",
+            "attributeRef": "#/attributeCatalog/lotus.account_reset_shadow_days"
+          },
+          {
+            "name": "diagnostics.sod_reset_shadow_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.sod_reset_shadow_days",
+            "attributeRef": "#/attributeCatalog/lotus.sod_reset_shadow_days"
+          },
+          {
+            "name": "diagnostics.shadow_reset_overlap_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.shadow_reset_overlap_days",
+            "attributeRef": "#/attributeCatalog/lotus.shadow_reset_overlap_days"
+          },
+          {
+            "name": "diagnostics.shadow_only_candidate_reset_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.shadow_only_candidate_reset_days",
+            "attributeRef": "#/attributeCatalog/lotus.shadow_only_candidate_reset_days"
+          },
+          {
+            "name": "diagnostics.active_reset_with_shadow_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.active_reset_with_shadow_days",
+            "attributeRef": "#/attributeCatalog/lotus.active_reset_with_shadow_days"
+          },
+          {
+            "name": "diagnostics.candidate_canonical_reset_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.candidate_canonical_reset_days",
+            "attributeRef": "#/attributeCatalog/lotus.candidate_canonical_reset_days"
+          },
+          {
+            "name": "diagnostics.reset_delta_days",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reset_delta_days",
+            "attributeRef": "#/attributeCatalog/lotus.reset_delta_days"
+          },
+          {
+            "name": "diagnostics.nip_days_since_last_reset",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.nip_days_since_last_reset",
+            "attributeRef": "#/attributeCatalog/lotus.nip_days_since_last_reset"
+          },
+          {
+            "name": "diagnostics.valid_days_since_last_reset",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.valid_days_since_last_reset",
+            "attributeRef": "#/attributeCatalog/lotus.valid_days_since_last_reset"
           },
           {
             "name": "diagnostics.effective_period_start",
@@ -7139,6 +8251,14 @@
             "type": "string",
             "semanticId": "lotus.benchmark_start_date",
             "attributeRef": "#/attributeCatalog/lotus.benchmark_start_date"
+          },
+          {
+            "name": "report_start_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.report_start_date",
+            "attributeRef": "#/attributeCatalog/lotus.report_start_date"
           },
           {
             "name": "report_end_date",
@@ -8271,12 +9391,76 @@
             "attributeRef": "#/attributeCatalog/lotus.supports_async"
           },
           {
+            "name": "analytics_surfaces[].poll_path_template",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.poll_path_template",
+            "attributeRef": "#/attributeCatalog/lotus.poll_path_template"
+          },
+          {
+            "name": "analytics_surfaces[].result_path_template",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.result_path_template",
+            "attributeRef": "#/attributeCatalog/lotus.result_path_template"
+          },
+          {
             "name": "analytics_surfaces[].stateful_restrictions",
             "location": "body",
             "required": false,
             "type": "array",
             "semanticId": "lotus.stateful_restrictions",
             "attributeRef": "#/attributeCatalog/lotus.stateful_restrictions"
+          },
+          {
+            "name": "analytics_surfaces[].contract_notes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.contract_notes",
+            "attributeRef": "#/attributeCatalog/lotus.contract_notes"
+          },
+          {
+            "name": "analytics_surfaces[].options",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.options",
+            "attributeRef": "#/attributeCatalog/lotus.options"
+          },
+          {
+            "name": "analytics_surfaces[].options[].key",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.key",
+            "attributeRef": "#/attributeCatalog/lotus.key"
+          },
+          {
+            "name": "analytics_surfaces[].options[].supported_values",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.supported_values",
+            "attributeRef": "#/attributeCatalog/lotus.supported_values"
+          },
+          {
+            "name": "analytics_surfaces[].options[].required_when",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.required_when",
+            "attributeRef": "#/attributeCatalog/lotus.required_when"
+          },
+          {
+            "name": "analytics_surfaces[].options[].notes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.notes",
+            "attributeRef": "#/attributeCatalog/lotus.notes"
           },
           {
             "name": "features",
@@ -8595,6 +9779,349 @@
       },
       "response": {
         "fields": []
+      }
+    },
+    {
+      "domain": "integration",
+      "method": "POST",
+      "path": "/integration/benchmarks/exposure-context",
+      "operationId": "get_benchmark_exposure_context_integration_benchmarks_exposure_context_post",
+      "summary": "Get benchmark exposure context for downstream risk attribution",
+      "request": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "benchmark_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.benchmark_id",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "window",
+            "location": "body",
+            "required": true,
+            "type": "BenchmarkExposureWindow",
+            "semanticId": "lotus.window",
+            "attributeRef": "#/attributeCatalog/lotus.window"
+          },
+          {
+            "name": "window.start_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.start_date",
+            "attributeRef": "#/attributeCatalog/lotus.start_date"
+          },
+          {
+            "name": "window.end_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.end_date",
+            "attributeRef": "#/attributeCatalog/lotus.end_date"
+          },
+          {
+            "name": "frequency",
+            "location": "body",
+            "required": false,
+            "type": "ReturnsFrequency",
+            "semanticId": "lotus.frequency",
+            "attributeRef": "#/attributeCatalog/lotus.frequency"
+          },
+          {
+            "name": "reporting_currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "#/attributeCatalog/lotus.reporting_currency"
+          },
+          {
+            "name": "grouping_dimensions",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.grouping_dimensions",
+            "attributeRef": "#/attributeCatalog/lotus.grouping_dimensions"
+          },
+          {
+            "name": "page",
+            "location": "body",
+            "required": false,
+            "type": "BenchmarkExposurePageRequest",
+            "semanticId": "lotus.page",
+            "attributeRef": "#/attributeCatalog/lotus.page"
+          },
+          {
+            "name": "page.page_size",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.page_size",
+            "attributeRef": "#/attributeCatalog/lotus.page_size"
+          },
+          {
+            "name": "page.page_token",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.page_token",
+            "attributeRef": "#/attributeCatalog/lotus.page_token"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "calculation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_id"
+          },
+          {
+            "name": "source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "contract_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.contract_version",
+            "attributeRef": "#/attributeCatalog/lotus.contract_version"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "benchmark_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.benchmark_id",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_id"
+          },
+          {
+            "name": "benchmark_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.benchmark_version",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_version"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "window",
+            "location": "body",
+            "required": true,
+            "type": "BenchmarkExposureWindow",
+            "semanticId": "lotus.window",
+            "attributeRef": "#/attributeCatalog/lotus.window"
+          },
+          {
+            "name": "window.start_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.start_date",
+            "attributeRef": "#/attributeCatalog/lotus.start_date"
+          },
+          {
+            "name": "window.end_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.end_date",
+            "attributeRef": "#/attributeCatalog/lotus.end_date"
+          },
+          {
+            "name": "frequency",
+            "location": "body",
+            "required": true,
+            "type": "ReturnsFrequency",
+            "semanticId": "lotus.frequency",
+            "attributeRef": "#/attributeCatalog/lotus.frequency"
+          },
+          {
+            "name": "reporting_currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "#/attributeCatalog/lotus.reporting_currency"
+          },
+          {
+            "name": "rows",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.rows",
+            "attributeRef": "#/attributeCatalog/lotus.rows"
+          },
+          {
+            "name": "rows[].valuation_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.valuation_date",
+            "attributeRef": "#/attributeCatalog/lotus.valuation_date"
+          },
+          {
+            "name": "rows[].component_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.component_id",
+            "attributeRef": "#/attributeCatalog/lotus.component_id"
+          },
+          {
+            "name": "rows[].grouping_dimension",
+            "location": "body",
+            "required": true,
+            "type": "BenchmarkExposureGroupingDimension",
+            "semanticId": "lotus.grouping_dimension",
+            "attributeRef": "#/attributeCatalog/lotus.grouping_dimension"
+          },
+          {
+            "name": "rows[].group_key",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.group_key",
+            "attributeRef": "#/attributeCatalog/lotus.group_key"
+          },
+          {
+            "name": "rows[].group_label",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.group_label",
+            "attributeRef": "#/attributeCatalog/lotus.group_label"
+          },
+          {
+            "name": "rows[].weight",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.weight",
+            "attributeRef": "#/attributeCatalog/lotus.weight"
+          },
+          {
+            "name": "page",
+            "location": "body",
+            "required": true,
+            "type": "BenchmarkExposurePageResponse",
+            "semanticId": "lotus.page",
+            "attributeRef": "#/attributeCatalog/lotus.page"
+          },
+          {
+            "name": "page.next_page_token",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.next_page_token",
+            "attributeRef": "#/attributeCatalog/lotus.next_page_token"
+          },
+          {
+            "name": "metadata",
+            "location": "body",
+            "required": true,
+            "type": "BenchmarkExposureMetadata",
+            "semanticId": "lotus.metadata",
+            "attributeRef": "#/attributeCatalog/lotus.metadata"
+          },
+          {
+            "name": "metadata.source_system",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "#/attributeCatalog/lotus.source_system"
+          },
+          {
+            "name": "metadata.served_by",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.served_by",
+            "attributeRef": "#/attributeCatalog/lotus.served_by"
+          },
+          {
+            "name": "metadata.calculation_run_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.calculation_run_id",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_run_id"
+          },
+          {
+            "name": "metadata.contract_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.contract_version",
+            "attributeRef": "#/attributeCatalog/lotus.contract_version"
+          },
+          {
+            "name": "metadata.generated_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.generated_at",
+            "attributeRef": "#/attributeCatalog/lotus.generated_at"
+          },
+          {
+            "name": "metadata.retrieval_metadata",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.retrieval_metadata",
+            "attributeRef": "#/attributeCatalog/lotus.retrieval_metadata"
+          }
+        ]
       }
     },
     {

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from starlette.responses import JSONResponse
 
 from app.api.endpoints import (
     benchmark,
+    benchmark_exposure_context,
     contribution,
     executions,
     health,
@@ -153,6 +154,7 @@ app.include_router(executions.router, prefix="/performance")
 app.include_router(lineage.router, prefix="/performance")
 app.include_router(integration_capabilities.router, prefix="/integration")
 app.include_router(returns_series.router, prefix="/integration")
+app.include_router(benchmark_exposure_context.router, prefix="/integration")
 app.include_router(runtime_status.router, prefix="/integration")
 app.include_router(runtime_work_items.router, prefix="/integration")
 app.include_router(runtime_recoveries.router, prefix="/integration")

--- a/tests/integration/test_benchmark_exposure_context_api.py
+++ b/tests/integration/test_benchmark_exposure_context_api.py
@@ -1,0 +1,102 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+class _RecordingStatefulInputService:
+    def __init__(self) -> None:
+        self.assignment_calls: list[dict[str, object]] = []
+        self.market_series_calls: list[dict[str, object]] = []
+        self.index_catalog_calls: list[dict[str, object]] = []
+
+    async def get_benchmark_assignment(self, **kwargs):
+        self.assignment_calls.append(kwargs)
+        return 200, {"benchmark_id": "BMK_GLOBAL_60_40"}
+
+    async def get_index_catalog(self, **kwargs):
+        self.index_catalog_calls.append(kwargs)
+        return (
+            200,
+            {
+                "records": [
+                    {
+                        "index_id": "IDX_GLOBAL_EQUITY",
+                        "classification_labels": {"sector": "Global Equity", "asset_class": "Equity"},
+                    },
+                    {
+                        "index_id": "IDX_GLOBAL_BONDS",
+                        "classification_labels": {"sector": "Global Bonds", "asset_class": "Fixed Income"},
+                    },
+                ]
+            },
+        )
+
+    async def get_benchmark_market_series(self, **kwargs):
+        self.market_series_calls.append(kwargs)
+        return (
+            200,
+            {
+                "component_series": [
+                    {
+                        "index_id": "IDX_GLOBAL_EQUITY",
+                        "points": [{"series_date": "2026-01-02", "component_weight": "0.60"}],
+                    },
+                    {
+                        "index_id": "IDX_GLOBAL_BONDS",
+                        "points": [{"series_date": "2026-01-02", "component_weight": "0.40"}],
+                    },
+                ],
+                "retrieval_metadata": {"chunk_count": 1, "page_count": 1},
+            },
+        )
+
+
+def test_benchmark_exposure_context_api_returns_performance_aligned_view(monkeypatch):
+    stateful_service = _RecordingStatefulInputService()
+    monkeypatch.setattr(
+        "app.api.endpoints.benchmark_exposure_context.build_stateful_input_service",
+        lambda *, settings: stateful_service,
+    )
+
+    payload = {
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-01-02",
+        "window": {"start_date": "2026-01-02", "end_date": "2026-01-02"},
+        "frequency": "DAILY",
+        "reporting_currency": "USD",
+        "grouping_dimensions": ["POSITION", "ASSET_CLASS"],
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/integration/benchmarks/exposure-context", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["source_service"] == "lotus-performance"
+    assert body["metadata"]["source_system"] == "lotus-core"
+    assert body["metadata"]["served_by"] == "lotus-performance"
+    assert body["benchmark_id"] == "BMK_GLOBAL_60_40"
+    assert {(row["grouping_dimension"], row["group_key"], row["weight"]) for row in body["rows"]} == {
+        ("POSITION", "IDX_GLOBAL_EQUITY", "0.60"),
+        ("POSITION", "IDX_GLOBAL_BONDS", "0.40"),
+        ("ASSET_CLASS", "ASSET_CLASS_Equity", "0.60"),
+        ("ASSET_CLASS", "ASSET_CLASS_Fixed Income", "0.40"),
+    }
+    assert stateful_service.assignment_calls[0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert stateful_service.market_series_calls[0]["series_fields"] == ["component_weight"]
+    assert stateful_service.market_series_calls[0]["target_currency"] == "USD"
+
+
+def test_benchmark_exposure_context_api_rejects_issuer_until_contract_exists() -> None:
+    payload = {
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-01-02",
+        "window": {"start_date": "2026-01-02", "end_date": "2026-01-02"},
+        "grouping_dimensions": ["ISSUER"],
+    }
+
+    with TestClient(app) as client:
+        response = client.post("/integration/benchmarks/exposure-context", json=payload)
+
+    assert response.status_code == 422
+    assert "does not yet support" in response.text

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -100,8 +100,17 @@ def test_integration_capabilities_default_contract():
     assert surfaces["returns_series"]["poll_path_template"] == "/performance/executions/{calculation_id}"
     assert surfaces["returns_series"]["result_path_template"] == "/integration/returns/series/results/{calculation_id}"
     assert surfaces["returns_series"]["path"] == "/integration/returns/series"
+    assert surfaces["benchmark_exposure_context"]["path"] == "/integration/benchmarks/exposure-context"
+    assert surfaces["benchmark_exposure_context"]["supported_input_modes"] == ["stateful"]
+    assert surfaces["benchmark_exposure_context"]["supports_async"] is False
+    assert surfaces["benchmark_exposure_context"]["stateful_restrictions"] == [
+        "lotus-core remains the benchmark composition system of record",
+        "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported",
+        "ISSUER remains gated until benchmark issuer exposure semantics are approved",
+    ]
     features = {item["key"] for item in body["features"]}
     assert "pa.analytics.benchmark" in features
+    assert "pa.integration.benchmark_exposure_context" in features
     assert "pa.analytics.workspace_summary" in features
     assert "pa.execution.stateful" in features
     assert "pa.execution.stateless" in features

--- a/tests/unit/app/test_benchmark_exposure_context_endpoint.py
+++ b/tests/unit/app/test_benchmark_exposure_context_endpoint.py
@@ -99,3 +99,33 @@ async def test_benchmark_exposure_context_endpoint_records_http_failures(mocker)
         message="benchmark market-series source unavailable (503).",
         execution_stage_started=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_benchmark_exposure_context_endpoint_wraps_unexpected_failures(mocker) -> None:
+    request = _request()
+
+    mocker.patch("app.api.endpoints.benchmark_exposure_context.get_settings", return_value=object())
+    mocker.patch(
+        "app.api.endpoints.benchmark_exposure_context.build_stateful_input_service",
+        return_value=object(),
+    )
+    mocker.patch("app.api.endpoints.benchmark_exposure_context.register_sync_execution_or_raise")
+    mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "mark_running")
+    mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "start_stage")
+    record_failure = mocker.patch("app.api.endpoints.benchmark_exposure_context.record_execution_failure")
+    mocker.patch(
+        "app.api.endpoints.benchmark_exposure_context.build_benchmark_exposure_context",
+        side_effect=RuntimeError("boom"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await benchmark_exposure_context_endpoint.get_benchmark_exposure_context(request)
+
+    assert exc_info.value.status_code == 500
+    assert "unexpected server error occurred while building benchmark exposure context: boom" in exc_info.value.detail
+    record_failure.assert_called_once_with(
+        calculation_id=request.calculation_id,
+        message="An unexpected server error occurred while building benchmark exposure context: boom",
+        execution_stage_started=True,
+    )

--- a/tests/unit/app/test_benchmark_exposure_context_endpoint.py
+++ b/tests/unit/app/test_benchmark_exposure_context_endpoint.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.endpoints import benchmark_exposure_context as benchmark_exposure_context_endpoint
+from app.models.benchmark_exposure_context import BenchmarkExposureContextRequest
+
+
+def _request() -> BenchmarkExposureContextRequest:
+    return BenchmarkExposureContextRequest.model_validate(
+        {
+            "calculation_id": str(uuid4()),
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "as_of_date": "2026-03-31",
+            "window": {"start_date": "2026-01-01", "end_date": "2026-03-31"},
+            "frequency": "DAILY",
+            "reporting_currency": "USD",
+            "grouping_dimensions": ["SECTOR"],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_benchmark_exposure_context_endpoint_registers_and_completes_execution(mocker) -> None:
+    request = _request()
+    stateful_input_service = object()
+    expected_response = mocker.Mock(rows=[{"group_key": "SECTOR_TECH"}])
+
+    mocker.patch("app.api.endpoints.benchmark_exposure_context.get_settings", return_value=object())
+    mocker.patch(
+        "app.api.endpoints.benchmark_exposure_context.build_stateful_input_service",
+        return_value=stateful_input_service,
+    )
+    register_sync = mocker.patch("app.api.endpoints.benchmark_exposure_context.register_sync_execution_or_raise")
+    mark_running = mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "mark_running")
+    start_stage = mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "start_stage")
+    complete_stage = mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "complete_stage")
+    mark_complete = mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "mark_complete")
+    record_failure = mocker.patch("app.api.endpoints.benchmark_exposure_context.record_execution_failure")
+    builder = mocker.patch(
+        "app.api.endpoints.benchmark_exposure_context.build_benchmark_exposure_context",
+        return_value=expected_response,
+    )
+
+    response = await benchmark_exposure_context_endpoint.get_benchmark_exposure_context(request)
+
+    assert response is expected_response
+    register_sync.assert_called_once_with(
+        calculation_id=request.calculation_id,
+        analytics_type="BENCHMARK_EXPOSURE_CONTEXT",
+        portfolio_id=request.portfolio_id,
+        requested_window={
+            "as_of_date": "2026-03-31",
+            "window_start_date": "2026-01-01",
+            "window_end_date": "2026-03-31",
+            "frequency": "DAILY",
+            "grouping_dimensions": ["SECTOR"],
+            "benchmark_id": None,
+            "reporting_currency": "USD",
+        },
+        input_fingerprint=None,
+        calculation_hash=None,
+    )
+    mark_running.assert_called_once_with(request.calculation_id)
+    start_stage.assert_called_once_with(request.calculation_id, "execution")
+    builder.assert_awaited_once_with(request=request, stateful_input_service=stateful_input_service)
+    complete_stage.assert_called_once_with(request.calculation_id, "execution", details={"row_count": 1})
+    mark_complete.assert_called_once_with(request.calculation_id)
+    record_failure.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_benchmark_exposure_context_endpoint_records_http_failures(mocker) -> None:
+    request = _request()
+
+    mocker.patch("app.api.endpoints.benchmark_exposure_context.get_settings", return_value=object())
+    mocker.patch(
+        "app.api.endpoints.benchmark_exposure_context.build_stateful_input_service",
+        return_value=object(),
+    )
+    mocker.patch("app.api.endpoints.benchmark_exposure_context.register_sync_execution_or_raise")
+    mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "mark_running")
+    mocker.patch.object(benchmark_exposure_context_endpoint.execution_registry, "start_stage")
+    record_failure = mocker.patch("app.api.endpoints.benchmark_exposure_context.record_execution_failure")
+    mocker.patch(
+        "app.api.endpoints.benchmark_exposure_context.build_benchmark_exposure_context",
+        side_effect=HTTPException(status_code=503, detail="benchmark market-series source unavailable (503)."),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await benchmark_exposure_context_endpoint.get_benchmark_exposure_context(request)
+
+    assert exc_info.value.status_code == 503
+    record_failure.assert_called_once_with(
+        calculation_id=request.calculation_id,
+        message="benchmark market-series source unavailable (503).",
+        execution_stage_started=True,
+    )

--- a/tests/unit/app/test_benchmark_exposure_context_models.py
+++ b/tests/unit/app/test_benchmark_exposure_context_models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.models.benchmark_exposure_context import BenchmarkExposureContextRequest, BenchmarkExposureWindow
+
+
+def test_benchmark_exposure_window_rejects_inverted_dates() -> None:
+    with pytest.raises(ValueError, match="window.start_date cannot be after window.end_date"):
+        BenchmarkExposureWindow.model_validate({"start_date": "2026-03-31", "end_date": "2026-01-01"})
+
+
+def test_benchmark_exposure_context_requires_at_least_one_grouping_dimension() -> None:
+    with pytest.raises(ValueError, match="grouping_dimensions must contain at least one value"):
+        BenchmarkExposureContextRequest.model_validate(
+            {
+                "calculation_id": str(uuid4()),
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "as_of_date": "2026-03-31",
+                "window": {"start_date": "2026-01-01", "end_date": "2026-03-31"},
+                "grouping_dimensions": [],
+            }
+        )

--- a/tests/unit/services/test_benchmark_exposure_context_service.py
+++ b/tests/unit/services/test_benchmark_exposure_context_service.py
@@ -8,9 +8,16 @@ from fastapi import HTTPException
 from app.models.benchmark_exposure_context import (
     BenchmarkExposureContextRequest,
     BenchmarkExposureGroupingDimension,
+    BenchmarkExposureRow,
     BenchmarkExposureWindow,
 )
-from app.services.benchmark_exposure_context_service import build_benchmark_exposure_context
+from app.services.benchmark_exposure_context_service import (
+    _build_exposure_rows,
+    _group_identity,
+    _page_rows,
+    _parse_retrieval_metadata,
+    build_benchmark_exposure_context,
+)
 
 
 class _StatefulInputServiceStub:
@@ -168,3 +175,185 @@ async def test_build_benchmark_exposure_context_rejects_bad_upstream_shapes() ->
 def test_benchmark_exposure_context_rejects_issuer_until_semantics_exist() -> None:
     with pytest.raises(ValueError, match="does not yet support"):
         _request(grouping_dimensions=[BenchmarkExposureGroupingDimension.ISSUER])
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_rejects_missing_assignment() -> None:
+    class _NoAssignmentService(_StatefulInputServiceStub):
+        async def get_benchmark_assignment(self, **kwargs):  # noqa: ARG002
+            return 404, {}
+
+    with pytest.raises(HTTPException, match="requires a benchmark assignment"):
+        await build_benchmark_exposure_context(
+            request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+            stateful_input_service=_NoAssignmentService(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_rejects_assignment_source_failure() -> None:
+    class _AssignmentSourceFailureService(_StatefulInputServiceStub):
+        async def get_benchmark_assignment(self, **kwargs):  # noqa: ARG002
+            return 503, {}
+
+    with pytest.raises(HTTPException, match="assignment source unavailable"):
+        await build_benchmark_exposure_context(
+            request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+            stateful_input_service=_AssignmentSourceFailureService(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_rejects_assignment_payload_without_benchmark_id() -> None:
+    class _MissingAssignmentBenchmarkService(_StatefulInputServiceStub):
+        async def get_benchmark_assignment(self, **kwargs):  # noqa: ARG002
+            return 200, {"benchmark_id": ""}
+
+    with pytest.raises(HTTPException, match="payload missing benchmark_id"):
+        await build_benchmark_exposure_context(
+            request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+            stateful_input_service=_MissingAssignmentBenchmarkService(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_rejects_catalog_source_failure() -> None:
+    class _CatalogSourceFailureService(_StatefulInputServiceStub):
+        async def get_index_catalog(self, **kwargs):  # noqa: ARG002
+            return 503, {}
+
+    with pytest.raises(HTTPException, match="index catalog source unavailable"):
+        await build_benchmark_exposure_context(request=_request(), stateful_input_service=_CatalogSourceFailureService())
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_rejects_catalog_without_records_list() -> None:
+    class _CatalogShapeFailureService(_StatefulInputServiceStub):
+        async def get_index_catalog(self, **kwargs):  # noqa: ARG002
+            return 200, {"records": "bad"}
+
+    with pytest.raises(HTTPException, match="records list"):
+        await build_benchmark_exposure_context(request=_request(), stateful_input_service=_CatalogShapeFailureService())
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_maps_market_series_404_to_not_found() -> None:
+    class _MissingMarketSeriesService(_StatefulInputServiceStub):
+        async def get_benchmark_market_series(self, **kwargs):  # noqa: ARG002
+            return 404, {}
+
+    with pytest.raises(HTTPException, match="No benchmark market-series found"):
+        await build_benchmark_exposure_context(
+            request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+            stateful_input_service=_MissingMarketSeriesService(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_maps_market_series_source_failure() -> None:
+    class _MarketSeriesSourceFailureService(_StatefulInputServiceStub):
+        async def get_benchmark_market_series(self, **kwargs):  # noqa: ARG002
+            return 503, {}
+
+    with pytest.raises(HTTPException, match="market-series source unavailable"):
+        await build_benchmark_exposure_context(
+            request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+            stateful_input_service=_MarketSeriesSourceFailureService(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_rejects_empty_usable_rows() -> None:
+    class _NoUsableRowsService(_StatefulInputServiceStub):
+        async def get_benchmark_market_series(self, **kwargs):  # noqa: ARG002
+            return 200, {"component_series": [{"index_id": "", "points": "bad"}]}
+
+    with pytest.raises(HTTPException, match="No usable benchmark exposure rows returned"):
+        await build_benchmark_exposure_context(
+            request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+            stateful_input_service=_NoUsableRowsService(),
+        )
+
+
+def test_build_exposure_rows_skips_invalid_component_shapes_and_rejects_invalid_weights() -> None:
+    rows = _build_exposure_rows(
+        component_series=[
+            {"index_id": "", "points": [{"series_date": "2026-01-02", "component_weight": "0.10"}]},
+            {"index_id": "IDX", "points": "bad"},
+            {"index_id": "IDX", "points": [None, {"series_date": None, "component_weight": "0.10"}, {"series_date": "2026-01-02"}]},
+            {"index_id": "IDX", "points": [{"series_date": "2026-01-02", "component_weight": "0.10"}]},
+        ],
+        grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION],
+        classification_map={},
+    )
+
+    assert len(rows) == 1
+    assert rows[0].group_key == "IDX"
+    assert rows[0].weight == Decimal("0.10")
+
+    with pytest.raises(HTTPException, match="invalid component_weight"):
+        _build_exposure_rows(
+            component_series=[
+                {"index_id": "IDX", "points": [{"series_date": "2026-01-02", "component_weight": "not-a-number"}]}
+            ],
+            grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION],
+            classification_map={},
+        )
+
+
+def test_group_identity_uses_unknown_defaults_and_rejects_unsupported_dimension() -> None:
+    assert _group_identity(
+        index_id="IDX",
+        grouping_dimension=BenchmarkExposureGroupingDimension.SECTOR,
+        classification_map={},
+    ) == ("SECTOR_UNKNOWN", "UNKNOWN", None)
+    assert _group_identity(
+        index_id="IDX",
+        grouping_dimension=BenchmarkExposureGroupingDimension.ASSET_CLASS,
+        classification_map={},
+    ) == ("ASSET_CLASS_UNKNOWN", "UNKNOWN", None)
+
+    with pytest.raises(HTTPException, match="does not yet support grouping_dimension=ISSUER"):
+        _group_identity(
+            index_id="IDX",
+            grouping_dimension=BenchmarkExposureGroupingDimension.ISSUER,
+            classification_map={},
+        )
+
+
+def test_page_rows_rejects_invalid_page_token_inputs() -> None:
+    rows = [
+        BenchmarkExposureRow(
+            valuation_date=date(2026, 1, 2),
+            component_id="IDX_A",
+            grouping_dimension=BenchmarkExposureGroupingDimension.POSITION,
+            group_key="IDX_A",
+            group_label="IDX_A",
+            weight=Decimal("0.10"),
+        )
+    ]
+
+    with pytest.raises(HTTPException, match="numeric offset token"):
+        _page_rows(rows=rows, page_size=10, page_token="bad")
+
+    with pytest.raises(HTTPException, match="must be non-negative"):
+        _page_rows(rows=rows, page_size=10, page_token="-1")
+
+
+def test_parse_retrieval_metadata_defaults_when_missing() -> None:
+    assert _parse_retrieval_metadata({}) == {"chunk_count": 0, "page_count": 0}
+    assert _parse_retrieval_metadata({"retrieval_metadata": None}) == {"chunk_count": 0, "page_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_ignores_non_dict_catalog_records() -> None:
+    class _NoisyCatalogService(_StatefulInputServiceStub):
+        async def get_index_catalog(self, **kwargs):  # noqa: ARG002
+            return 200, {"records": [None, {"index_id": "IDX_TECH_A", "classification_labels": {"sector": "Technology"}}]}
+
+    response = await build_benchmark_exposure_context(
+        request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.SECTOR]),
+        stateful_input_service=_NoisyCatalogService(),
+    )
+
+    assert any(row.group_key == "SECTOR_Technology" for row in response.rows)

--- a/tests/unit/services/test_benchmark_exposure_context_service.py
+++ b/tests/unit/services/test_benchmark_exposure_context_service.py
@@ -223,7 +223,9 @@ async def test_build_benchmark_exposure_context_rejects_catalog_source_failure()
             return 503, {}
 
     with pytest.raises(HTTPException, match="index catalog source unavailable"):
-        await build_benchmark_exposure_context(request=_request(), stateful_input_service=_CatalogSourceFailureService())
+        await build_benchmark_exposure_context(
+            request=_request(), stateful_input_service=_CatalogSourceFailureService()
+        )
 
 
 @pytest.mark.asyncio
@@ -280,7 +282,10 @@ def test_build_exposure_rows_skips_invalid_component_shapes_and_rejects_invalid_
         component_series=[
             {"index_id": "", "points": [{"series_date": "2026-01-02", "component_weight": "0.10"}]},
             {"index_id": "IDX", "points": "bad"},
-            {"index_id": "IDX", "points": [None, {"series_date": None, "component_weight": "0.10"}, {"series_date": "2026-01-02"}]},
+            {
+                "index_id": "IDX",
+                "points": [None, {"series_date": None, "component_weight": "0.10"}, {"series_date": "2026-01-02"}],
+            },
             {"index_id": "IDX", "points": [{"series_date": "2026-01-02", "component_weight": "0.10"}]},
         ],
         grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION],
@@ -349,7 +354,9 @@ def test_parse_retrieval_metadata_defaults_when_missing() -> None:
 async def test_build_benchmark_exposure_context_ignores_non_dict_catalog_records() -> None:
     class _NoisyCatalogService(_StatefulInputServiceStub):
         async def get_index_catalog(self, **kwargs):  # noqa: ARG002
-            return 200, {"records": [None, {"index_id": "IDX_TECH_A", "classification_labels": {"sector": "Technology"}}]}
+            return 200, {
+                "records": [None, {"index_id": "IDX_TECH_A", "classification_labels": {"sector": "Technology"}}]
+            }
 
     response = await build_benchmark_exposure_context(
         request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.SECTOR]),

--- a/tests/unit/services/test_benchmark_exposure_context_service.py
+++ b/tests/unit/services/test_benchmark_exposure_context_service.py
@@ -1,0 +1,167 @@
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.benchmark_exposure_context import (
+    BenchmarkExposureContextRequest,
+    BenchmarkExposureGroupingDimension,
+    BenchmarkExposureWindow,
+)
+from app.services.benchmark_exposure_context_service import build_benchmark_exposure_context
+
+
+class _StatefulInputServiceStub:
+    def __init__(self) -> None:
+        self.assignment_calls: list[dict[str, object]] = []
+        self.market_series_calls: list[dict[str, object]] = []
+        self.index_catalog_calls: list[dict[str, object]] = []
+
+    async def get_benchmark_assignment(self, **kwargs):
+        self.assignment_calls.append(kwargs)
+        return 200, {"benchmark_id": "BMK_GLOBAL_60_40"}
+
+    async def get_index_catalog(self, **kwargs):
+        self.index_catalog_calls.append(kwargs)
+        return (
+            200,
+            {
+                "records": [
+                    {
+                        "index_id": "IDX_TECH_A",
+                        "classification_labels": {"sector": "Technology", "asset_class": "Equity"},
+                    },
+                    {
+                        "index_id": "IDX_TECH_B",
+                        "classification_labels": {"sector": "Technology", "asset_class": "Equity"},
+                    },
+                    {
+                        "index_id": "IDX_BOND",
+                        "classification_labels": {"sector": "Government Bonds", "asset_class": "Fixed Income"},
+                    },
+                ]
+            },
+        )
+
+    async def get_benchmark_market_series(self, **kwargs):
+        self.market_series_calls.append(kwargs)
+        return (
+            200,
+            {
+                "component_series": [
+                    {
+                        "index_id": "IDX_TECH_A",
+                        "points": [
+                            {"series_date": "2026-01-02", "component_weight": "0.35"},
+                            {"series_date": "2026-01-03", "component_weight": "0.36"},
+                        ],
+                    },
+                    {
+                        "index_id": "IDX_TECH_B",
+                        "points": [
+                            {"series_date": "2026-01-02", "component_weight": "0.25"},
+                            {"series_date": "2026-01-03", "component_weight": "0.24"},
+                        ],
+                    },
+                    {
+                        "index_id": "IDX_BOND",
+                        "points": [
+                            {"series_date": "2026-01-02", "component_weight": "0.40"},
+                            {"series_date": "2026-01-03", "component_weight": "0.40"},
+                        ],
+                    },
+                ],
+                "retrieval_metadata": {"chunk_count": 1, "page_count": 2},
+            },
+        )
+
+
+def _request(**overrides) -> BenchmarkExposureContextRequest:
+    payload = {
+        "calculation_id": uuid4(),
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": date(2026, 1, 3),
+        "window": BenchmarkExposureWindow(start_date=date(2026, 1, 2), end_date=date(2026, 1, 3)),
+        "reporting_currency": "USD",
+        "grouping_dimensions": [
+            BenchmarkExposureGroupingDimension.POSITION,
+            BenchmarkExposureGroupingDimension.SECTOR,
+            BenchmarkExposureGroupingDimension.ASSET_CLASS,
+        ],
+    }
+    payload.update(overrides)
+    return BenchmarkExposureContextRequest.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_groups_and_aligns_weights() -> None:
+    service = _StatefulInputServiceStub()
+
+    response = await build_benchmark_exposure_context(request=_request(), stateful_input_service=service)
+
+    assert response.benchmark_id == "BMK_GLOBAL_60_40"
+    assert response.metadata.source_system == "lotus-core"
+    assert response.metadata.served_by == "lotus-performance"
+    assert response.metadata.retrieval_metadata == {
+        "benchmark_market_series_chunk_count": 1,
+        "benchmark_market_series_page_count": 2,
+        "index_catalog_page_count": 1,
+    }
+    weights = {(row.valuation_date.isoformat(), row.grouping_dimension.value, row.group_key): row.weight for row in response.rows}
+    assert weights[("2026-01-02", "SECTOR", "SECTOR_Technology")] == Decimal("0.60")
+    assert weights[("2026-01-02", "ASSET_CLASS", "ASSET_CLASS_Equity")] == Decimal("0.60")
+    assert weights[("2026-01-02", "POSITION", "IDX_TECH_A")] == Decimal("0.35")
+    assert service.assignment_calls[0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert service.market_series_calls[0]["series_fields"] == ["component_weight"]
+    assert service.market_series_calls[0]["target_currency"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_uses_explicit_benchmark_without_assignment_or_catalog() -> None:
+    service = _StatefulInputServiceStub()
+
+    response = await build_benchmark_exposure_context(
+        request=_request(
+            benchmark_id="BMK_EXPLICIT",
+            grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION],
+        ),
+        stateful_input_service=service,
+    )
+
+    assert response.benchmark_id == "BMK_EXPLICIT"
+    assert service.assignment_calls == []
+    assert service.index_catalog_calls == []
+    assert service.market_series_calls[0]["benchmark_id"] == "BMK_EXPLICIT"
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_paginates_derived_rows() -> None:
+    service = _StatefulInputServiceStub()
+
+    response = await build_benchmark_exposure_context(
+        request=_request(page={"page_size": 2, "page_token": None}),
+        stateful_input_service=service,
+    )
+
+    assert len(response.rows) == 2
+    assert response.page.next_page_token == "2"
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_rejects_bad_upstream_shapes() -> None:
+    class _BadMarketSeriesService(_StatefulInputServiceStub):
+        async def get_benchmark_market_series(self, **kwargs):  # noqa: ARG002
+            return 200, {"component_series": "bad"}
+
+    with pytest.raises(HTTPException, match="component_series list"):
+        await build_benchmark_exposure_context(
+            request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+            stateful_input_service=_BadMarketSeriesService(),
+        )
+
+
+def test_benchmark_exposure_context_rejects_issuer_until_semantics_exist() -> None:
+    with pytest.raises(ValueError, match="does not yet support"):
+        _request(grouping_dimensions=[BenchmarkExposureGroupingDimension.ISSUER])

--- a/tests/unit/services/test_benchmark_exposure_context_service.py
+++ b/tests/unit/services/test_benchmark_exposure_context_service.py
@@ -109,7 +109,10 @@ async def test_build_benchmark_exposure_context_groups_and_aligns_weights() -> N
         "benchmark_market_series_page_count": 2,
         "index_catalog_page_count": 1,
     }
-    weights = {(row.valuation_date.isoformat(), row.grouping_dimension.value, row.group_key): row.weight for row in response.rows}
+    weights = {
+        (row.valuation_date.isoformat(), row.grouping_dimension.value, row.group_key): row.weight
+        for row in response.rows
+    }
     assert weights[("2026-01-02", "SECTOR", "SECTOR_Technology")] == Decimal("0.60")
     assert weights[("2026-01-02", "ASSET_CLASS", "ASSET_CLASS_Equity")] == Decimal("0.60")
     assert weights[("2026-01-02", "POSITION", "IDX_TECH_A")] == Decimal("0.35")

--- a/tests/unit/services/test_position_source_service.py
+++ b/tests/unit/services/test_position_source_service.py
@@ -27,7 +27,7 @@ async def test_fetch_stateful_position_timeseries_forwards_request_shape(monkeyp
     stub = _PositionTimeseriesServiceStub()
 
     def _build_stateful_input_service(*, settings: Settings):
-        assert settings.CORE_QUERY_BASE_URL == "http://localhost:8202"
+        assert settings.CORE_QUERY_BASE_URL == "http://core-query.dev.lotus"
         return stub
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- fix benchmark exposure context endpoint execution lifecycle handling
- register and track sync execution before stateful upstream snapshot recording
- add endpoint-level tests for success and failure lifecycle behavior

## Validation
- python -m pytest tests/unit/app/test_benchmark_exposure_context_endpoint.py tests/integration/test_benchmark_exposure_context_api.py tests/unit/services/test_benchmark_exposure_context_service.py -q
- python -m ruff check app/api/endpoints/benchmark_exposure_context.py tests/unit/app/test_benchmark_exposure_context_endpoint.py tests/integration/test_benchmark_exposure_context_api.py tests/unit/services/test_benchmark_exposure_context_service.py
- live probe: POST /integration/benchmarks/exposure-context returns 200 after rebuild
