### PR TITLE
Sync lotus-core contract clarifications in performance

### DIFF
--- a/app/services/benchmark_exposure_context_service.py
+++ b/app/services/benchmark_exposure_context_service.py
@@ -34,10 +34,6 @@ async def build_benchmark_exposure_context(
     stateful_input_service: StatefulInputService,
 ) -> BenchmarkExposureContextResponse:
     benchmark_id = await _resolve_benchmark_id(request=request, stateful_input_service=stateful_input_service)
-    classification_map = await _classification_map_for_request(
-        request=request,
-        stateful_input_service=stateful_input_service,
-    )
     market_status, market_payload = await stateful_input_service.get_benchmark_market_series(
         calculation_id=request.calculation_id,
         benchmark_id=benchmark_id,
@@ -59,8 +55,14 @@ async def build_benchmark_exposure_context(
             detail=f"benchmark market-series source unavailable ({market_status}).",
         )
 
+    component_series = _parse_component_series(market_payload)
+    classification_map = await _classification_map_for_request(
+        request=request,
+        stateful_input_service=stateful_input_service,
+        component_series=component_series,
+    )
     rows = _build_exposure_rows(
-        component_series=_parse_component_series(market_payload),
+        component_series=component_series,
         grouping_dimensions=request.grouping_dimensions,
         classification_map=classification_map,
     )
@@ -137,15 +139,27 @@ async def _classification_map_for_request(
     *,
     request: BenchmarkExposureContextRequest,
     stateful_input_service: StatefulInputService,
+    component_series: list[dict[str, Any]],
 ) -> dict[str, dict[str, str]]:
     if not any(
         dimension in {BenchmarkExposureGroupingDimension.SECTOR, BenchmarkExposureGroupingDimension.ASSET_CLASS}
         for dimension in request.grouping_dimensions
     ):
         return {}
+    index_ids = sorted(
+        {
+            index_id
+            for component in component_series
+            for index_id in [component.get("index_id")]
+            if isinstance(index_id, str) and index_id
+        }
+    )
+    if not index_ids:
+        return {}
     catalog_status, catalog_payload = await stateful_input_service.get_index_catalog(
         calculation_id=request.calculation_id,
         as_of_date=request.as_of_date,
+        index_ids=index_ids,
     )
     if catalog_status >= status.HTTP_400_BAD_REQUEST:
         raise HTTPException(

--- a/app/services/core_integration_service.py
+++ b/app/services/core_integration_service.py
@@ -241,12 +241,15 @@ class CoreIntegrationService:
         self,
         *,
         as_of_date: date,
+        index_ids: list[str] | None = None,
         index_currency: str | None = None,
         index_type: str | None = None,
         index_status: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         url = f"{self._base_url}/integration/indices/catalog"
         payload: dict[str, Any] = {"as_of_date": str(as_of_date)}
+        if index_ids:
+            payload["index_ids"] = index_ids
         if index_currency:
             payload["index_currency"] = index_currency
         if index_type:

--- a/app/services/stateful_attribution_input_service.py
+++ b/app/services/stateful_attribution_input_service.py
@@ -141,9 +141,13 @@ async def retrieve_stateful_attribution_source_input(
         end_date=report_end_date,
         return_source=BenchmarkReturnSource.CALCULATED,
     )
+    benchmark_component_index_ids = sorted(
+        {observation.component_id for observation in benchmark_input.component_observations if observation.component_id}
+    )
 
     index_status, index_payload = await stateful_input_service.get_index_catalog(
         as_of_date=as_of_date,
+        index_ids=benchmark_component_index_ids,
         calculation_id=calculation_id,
     )
     if index_status >= status.HTTP_400_BAD_REQUEST:

--- a/app/services/stateful_input_service.py
+++ b/app/services/stateful_input_service.py
@@ -584,15 +584,23 @@ class StatefulInputService:
         self,
         *,
         as_of_date: date,
+        index_ids: list[str] | None = None,
         calculation_id: UUID | None = None,
     ) -> tuple[int, dict[str, Any]]:
-        response = await self._core_service.get_index_catalog(as_of_date=as_of_date)
+        response = await self._core_service.get_index_catalog(
+            as_of_date=as_of_date,
+            index_ids=index_ids,
+        )
         if calculation_id is not None:
-            request_payload = {"as_of_date": str(as_of_date)}
+            sorted_index_ids = sorted(set(index_ids or []))
+            request_payload = {
+                "as_of_date": str(as_of_date),
+                "index_ids": sorted_index_ids,
+            }
             snapshot_id, request_fingerprint = self._build_snapshot_identity(
                 calculation_id=calculation_id,
                 upstream_endpoint="index_catalog",
-                source_identifier="all_indices",
+                source_identifier="|".join(sorted_index_ids) if sorted_index_ids else "all_indices",
                 request_payload=request_payload,
             )
             existing_snapshot_ids = self._existing_snapshot_ids(calculation_id)
@@ -603,7 +611,7 @@ class StatefulInputService:
                         self._build_snapshot(
                             calculation_id=calculation_id,
                             upstream_endpoint="index_catalog",
-                            source_identifier="all_indices",
+                            source_identifier="|".join(sorted_index_ids) if sorted_index_ids else "all_indices",
                             as_of_date=as_of_date,
                             request_payload=request_payload,
                             response=response,

--- a/docs/guides/twr.md
+++ b/docs/guides/twr.md
@@ -74,6 +74,11 @@ Benchmark selection follows this precedence:
 2. lotus-core benchmark assignment in stateful mode
 3. validation error if stateless mode requests benchmark output without a benchmark configuration
 
+For stateful benchmark assignment, lotus-core currently resolves the assignment by
+`portfolio_id + as_of_date`. Request context such as reporting currency is useful for lineage and
+consumer symmetry, but should not be treated as changing assignment selection unless lotus-core
+explicitly versions that behavior in the public contract.
+
 When benchmark output is requested, TWR returns:
 
 - a parallel `benchmark` block calculated through the shared benchmark engine

--- a/docs/technical/RFC-0082-upstream-contract-family-map.md
+++ b/docs/technical/RFC-0082-upstream-contract-family-map.md
@@ -72,6 +72,19 @@ Implementation entrypoints:
 6. lineage stores upstream request and response fingerprints for reproducibility where a durable calculation is involved;
 7. the watchlist routes above require explicit RFC-0082 review before their semantics are expanded.
 
+Route-specific downstream interpretations that must stay truthful:
+
+1. benchmark assignment resolution is keyed by `portfolio_id` and `as_of_date`; request
+   `reporting_currency` is caller-context metadata and must not be treated as a benchmark-selection
+   key unless lotus-core explicitly versions that behavior in the public contract;
+2. `POST /integration/reference/risk-free-series` returning an empty `points` list means the route
+   is reachable but usable source data is absent for the requested currency/window, so downstream
+   consumers must treat that as a data-availability gap rather than a methodology signal to fall
+   back to zero risk-free inputs;
+3. `POST /integration/indices/catalog` classification labels, including canonical broad-market
+   sector labels such as `broad_market_equity` and `broad_market_fixed_income`, are source-owned
+   metadata; `lotus-performance` must not synthesize missing sector labels locally.
+
 ## Existing Conformance Evidence
 
 Current test and implementation evidence:

--- a/docs/technical/benchmark-exposure-context-endpoint-certification.md
+++ b/docs/technical/benchmark-exposure-context-endpoint-certification.md
@@ -71,7 +71,7 @@ stateful input service:
 
 - benchmark assignment when `benchmark_id` is omitted;
 - benchmark market series with `series_fields=["component_weight"]`;
-- index catalog only when aggregate dimensions need classification labels.
+- targeted index catalog lookup only when aggregate dimensions need classification labels.
 
 If only `POSITION` is requested, the endpoint does not fetch index catalog data. This keeps the
 simple downstream path cheaper and avoids unnecessary upstream dependency.
@@ -100,12 +100,13 @@ Open issue search found no endpoint-specific defects in:
 - `sgajbi/lotus-risk`;
 - `sgajbi/lotus-gateway`.
 
-One upstream data-quality issue was opened:
+Upstream benchmark component classification coverage is now aligned:
 
-- `sgajbi/lotus-core#306`: canonical benchmark index catalog records for
-  `IDX_GLOBAL_EQUITY_TR` and `IDX_GLOBAL_BOND_TR` expose `asset_class` and `region`, but not
-  `sector`. lotus-performance therefore correctly emits `SECTOR_UNKNOWN` for canonical benchmark
-  sector exposure.
+- `sgajbi/lotus-core#306` was fixed in lotus-core.
+- canonical benchmark component indices now publish governed broad-market sector labels such as
+  `broad_market_equity` and `broad_market_fixed_income`.
+- lotus-performance consumes those source-owned labels as published rather than synthesizing local
+  sector fallbacks.
 
 ## Live Canonical Proof
 
@@ -136,8 +137,8 @@ Observed response:
 - `row_count=5`;
 - `POSITION` weight sum for `2026-04-10` is `1.0`;
 - `ASSET_CLASS` weight sum for `2026-04-10` is `1.0`;
-- `SECTOR` weight sum for `2026-04-10` is `1.0`, but the row is `SECTOR_UNKNOWN` because lotus-core
-  does not currently provide sector labels for the canonical benchmark indices.
+- `SECTOR` weight sum for `2026-04-10` is `1.0`, with governed broad-market sector rows sourced
+  from lotus-core index catalog metadata.
 
 Relevant upstream catalog slice:
 
@@ -147,6 +148,7 @@ Relevant upstream catalog slice:
     "index_id": "IDX_GLOBAL_BOND_TR",
     "classification_labels": {
       "asset_class": "fixed_income",
+      "sector": "broad_market_fixed_income",
       "region": "global"
     }
   },
@@ -154,6 +156,7 @@ Relevant upstream catalog slice:
     "index_id": "IDX_GLOBAL_EQUITY_TR",
     "classification_labels": {
       "asset_class": "equity",
+      "sector": "broad_market_equity",
       "region": "global"
     }
   }

--- a/tests/unit/services/test_benchmark_exposure_context_service.py
+++ b/tests/unit/services/test_benchmark_exposure_context_service.py
@@ -116,6 +116,13 @@ async def test_build_benchmark_exposure_context_groups_and_aligns_weights() -> N
         "benchmark_market_series_page_count": 2,
         "index_catalog_page_count": 1,
     }
+    assert service.index_catalog_calls == [
+        {
+            "calculation_id": response.calculation_id,
+            "as_of_date": date(2026, 1, 3),
+            "index_ids": ["IDX_BOND", "IDX_TECH_A", "IDX_TECH_B"],
+        }
+    ]
     weights = {
         (row.valuation_date.isoformat(), row.grouping_dimension.value, row.group_key): row.weight
         for row in response.rows
@@ -364,3 +371,16 @@ async def test_build_benchmark_exposure_context_ignores_non_dict_catalog_records
     )
 
     assert any(row.group_key == "SECTOR_Technology" for row in response.rows)
+
+
+@pytest.mark.asyncio
+async def test_build_benchmark_exposure_context_skips_catalog_for_position_only_grouping() -> None:
+    service = _StatefulInputServiceStub()
+
+    response = await build_benchmark_exposure_context(
+        request=_request(grouping_dimensions=[BenchmarkExposureGroupingDimension.POSITION]),
+        stateful_input_service=service,
+    )
+
+    assert response.rows
+    assert service.index_catalog_calls == []

--- a/tests/unit/services/test_core_integration_service.py
+++ b/tests/unit/services/test_core_integration_service.py
@@ -231,6 +231,7 @@ async def test_get_index_catalog_posts_contract_payload():
 
     status_code, payload = await service.get_index_catalog(
         as_of_date=date(2026, 2, 24),
+        index_ids=["IDX_GLOBAL_EQUITY_TR", "IDX_GLOBAL_BOND_TR"],
         index_currency="USD",
         index_type="BENCHMARK",
         index_status="ACTIVE",
@@ -241,6 +242,7 @@ async def test_get_index_catalog_posts_contract_payload():
     assert _FakeAsyncClient.calls[0]["url"] == "http://core/integration/indices/catalog"
     assert _FakeAsyncClient.calls[0]["json"] == {
         "as_of_date": "2026-02-24",
+        "index_ids": ["IDX_GLOBAL_EQUITY_TR", "IDX_GLOBAL_BOND_TR"],
         "index_currency": "USD",
         "index_type": "BENCHMARK",
         "index_status": "ACTIVE",

--- a/tests/unit/services/test_stateful_attribution_input_service.py
+++ b/tests/unit/services/test_stateful_attribution_input_service.py
@@ -36,6 +36,7 @@ class _AttributionInputServiceStub:
         self.position_response = (200, {"rows": []})
         self.assignment_response = (200, {"benchmark_id": "BMK_1"})
         self.index_response = (200, {"records": []})
+        self.index_catalog_calls: list[dict[str, object]] = []
 
     async def get_position_timeseries(self, **kwargs):
         return self.position_response
@@ -44,6 +45,7 @@ class _AttributionInputServiceStub:
         return self.assignment_response
 
     async def get_index_catalog(self, **kwargs):
+        self.index_catalog_calls.append(kwargs)
         return self.index_response
 
 
@@ -101,10 +103,12 @@ async def test_retrieve_stateful_attribution_source_input_uses_override_benchmar
     )
     service.index_response = (200, {"records": [{"index_id": "IDX_1", "classification_labels": {"sector": "Tech"}}]})
 
+    calculation_id = uuid4()
+
     result = await retrieve_stateful_attribution_source_input(
         settings=object(),
         stateful_input_service=service,
-        calculation_id=uuid4(),
+        calculation_id=calculation_id,
         portfolio_id="P1",
         as_of_date=date(2025, 1, 1),
         report_start_date=date(2025, 1, 1),
@@ -123,6 +127,13 @@ async def test_retrieve_stateful_attribution_source_input_uses_override_benchmar
     assert result.position_retrieval_metadata == RetrievalMetadata(chunk_count=2, page_count=3)
     assert result.benchmark_retrieval_metadata == RetrievalMetadata(chunk_count=4, page_count=5)
     assert result.index_retrieval_metadata == RetrievalMetadata(chunk_count=1, page_count=1)
+    assert service.index_catalog_calls == [
+        {
+            "as_of_date": date(2025, 1, 1),
+            "index_ids": ["IDX_1"],
+            "calculation_id": calculation_id,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_stateful_input_service.py
+++ b/tests/unit/services/test_stateful_input_service.py
@@ -365,6 +365,7 @@ async def test_stateful_input_service_fetches_reference_payloads_and_records_sna
     )
     catalog_status, catalog_payload = await service.get_index_catalog(
         as_of_date=date(2026, 1, 3),
+        index_ids=["IDX_2", "IDX_1"],
         calculation_id=calculation_id,
     )
 
@@ -384,6 +385,10 @@ async def test_stateful_input_service_fetches_reference_payloads_and_records_sna
         "benchmark_composition_window",
         "index_catalog",
     }
+    index_catalog_snapshots = [snapshot for snapshot in snapshots if snapshot.upstream_endpoint == "index_catalog"]
+    assert len(index_catalog_snapshots) == 1
+    assert index_catalog_snapshots[0].source_identifier == "IDX_1|IDX_2"
+    assert index_catalog_snapshots[0].paging_metadata["index_ids"] == ["IDX_1", "IDX_2"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- sync `lotus-performance` docs with the latest certified `lotus-core` contract semantics
- switch benchmark component metadata resolution to targeted `index_ids` lookup instead of scanning the full index catalog
- keep benchmark exposure and stateful attribution aligned with the current core control-plane contract

## Why
`lotus-core` RFC-0082 endpoint certification tightened benchmark and analytics-input contract truth. The material downstream change for performance is to consume targeted benchmark component metadata through `POST /integration/indices/catalog` using known component ids, and to keep local contract docs aligned with current upstream semantics.

## Changes
- pass optional `index_ids` through the core integration and stateful input services
- use targeted index catalog lookup in benchmark exposure context and stateful attribution sourcing
- refresh benchmark exposure certification docs and upstream contract notes

## Validation
- `python -m pytest tests/unit/services/test_core_integration_service.py tests/unit/services/test_stateful_input_service.py tests/unit/services/test_benchmark_exposure_context_service.py tests/unit/services/test_stateful_attribution_input_service.py -q`
- `python -m ruff check app/services/core_integration_service.py app/services/stateful_input_service.py app/services/benchmark_exposure_context_service.py app/services/stateful_attribution_input_service.py tests/unit/services/test_core_integration_service.py tests/unit/services/test_stateful_input_service.py tests/unit/services/test_benchmark_exposure_context_service.py tests/unit/services/test_stateful_attribution_input_service.py`
- `python -m ruff format --check app/services/core_integration_service.py app/services/stateful_input_service.py app/services/benchmark_exposure_context_service.py app/services/stateful_attribution_input_service.py tests/unit/services/test_core_integration_service.py tests/unit/services/test_stateful_input_service.py tests/unit/services/test_benchmark_exposure_context_service.py tests/unit/services/test_stateful_attribution_input_service.py`
- `python -m mypy --config-file mypy.ini app/services/core_integration_service.py app/services/stateful_input_service.py app/services/benchmark_exposure_context_service.py app/services/stateful_attribution_input_service.py`
- live probe: `POST http://performance.dev.lotus/integration/benchmarks/exposure-context` for `PB_SG_GLOBAL_BAL_001` / `2026-04-10` returned `200`

## Upstream follow-on
- aligns downstream issue `#125` with the current `lotus-core` certification and local feature-branch truth