### PR TITLE
docs: standardize lotus-performance readme and wiki

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# Lotus Agent Operating Contract
+
+This is the governed operating contract for Lotus agent work.
+
+Repo-root `AGENTS.md` files across Lotus repositories and the deployed local `AGENTS.md` should
+remain synchronized copies of this file.
+
+Use `automation/Sync-AgentOperatingContract.ps1` to synchronize or verify that deployed copy.
+
+## Mandatory Reading Order
+
+Before doing substantial work, load context in this order:
+
+1. `AGENTS.md`
+2. `lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md`
+3. `lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md`
+4. the target repository's `REPOSITORY-ENGINEERING-CONTEXT.md`
+5. `lotus-platform/context/CONTEXT-REFERENCE-MAP.md`
+6. `lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md` when the task is primarily about how work should be executed
+
+Use the smallest correct working set. Do not load broad context blindly if the task is narrow.
+
+## Mandatory Operating Rules
+
+Always:
+
+1. reduce complexity where possible,
+2. improve readability, maintainability, and modularity as part of the slice,
+3. make code and test improvements that materially improve reliability and maintainability,
+4. update documentation when platform or repository truth changes,
+5. leave the codebase cleaner than you found it,
+6. write meaningful, high-value tests and avoid superficial coverage,
+7. keep commits small, meaningful, and truthful,
+8. remove dead code, duplicate logic, and stale non-standard handling when encountered,
+9. ensure every UI feature is genuinely backed by supported backend functionality.
+
+## Delivery Posture
+
+Operate as a banking-grade engineer, not a generic coding assistant.
+
+That means:
+
+1. prefer truthful implementation over cosmetic output,
+2. prefer reusable patterns over local hacks,
+3. treat naming, contracts, tests, docs, and validation as part of the implementation,
+4. use domain-correct private banking, portfolio, advisory, performance, and risk language.
+
+## Skills, Automation, And Async Execution
+
+When the task matches an available Lotus skill, use it.
+
+Before choosing between overlapping Lotus skills, consult
+`lotus-platform/context/LOTUS-SKILL-ROUTING-MAP.md`.
+
+Prefer:
+
+1. standards, validators, and runbooks before inventing a new pattern,
+2. repo-native commands before ad hoc command sequences,
+3. targeted local checks for quick proof,
+4. GitHub-backed heavy execution for expensive full validation,
+5. async monitoring and fix-forward work rather than blocking on long reruns.
+
+When a task is explicitly about canonical populated Workbench surfaces, demo screenshots, or
+`PB_SG_GLOBAL_BAL_001`, choose `lotus-front-office-runtime` first and use broader QA or delivery
+skills only as supporting guidance.
+
+## Front-Office Runtime Routing Rule
+
+When the task is about:
+
+1. local front-office runtime bring-up,
+2. populated Workbench screens,
+3. panel validation,
+4. demo screenshots,
+5. canonical UI proof,
+
+use the governed `lotus-workbench` runtime and validation flow first:
+
+1. `lotus-workbench/docs/operations/canonical-front-office-local-runtime.md`
+2. `npm run live:stack:up`
+3. `npm run live:validate`
+4. `npm run live:stack:down`
+5. `lotus-platform/automation/Invoke-Canonical-FrontOffice-QA.ps1 -ScreenshotDirectory <path>` when the task needs platform-owned validation evidence and a caller-directed demo screenshot pack
+6. `lotus-platform/context/contracts/canonical-front-office-demo-data-contract.json`
+7. `lotus-platform/context/contracts/canonical-front-office-demo-data-invariants.json`
+
+Use `PB_SG_GLOBAL_BAL_001` as the governed seeded front-office portfolio unless the task explicitly requires another dataset.
+
+Treat the RFC-0076 contract files as the source of truth for canonical portfolio identity, benchmark
+identity, governed as-of date, and minimum supportability thresholds. Runtime evidence should carry
+contract provenance instead of relying on implicit repo convention.
+
+Do not treat `lotus-platform/platform-stack` as the canonical front-office product bring-up path. It owns shared ingress and infrastructure support, not the full governed product-surface flow.
+
+Do not capture or share demo-ready screenshots before canonical API, calculation, and panel validation pass. If a pre-validation capture is necessary for diagnosis, label it with a `diagnostic-` prefix and keep it separate from demo evidence.
+
+## Context Maintenance Rule
+
+Keep the context system up to date as Lotus changes.
+
+Update the relevant context artifacts when:
+
+1. platform architecture changes,
+2. repository responsibilities change,
+3. canonical commands or validation flows change,
+4. CI or governance expectations change,
+5. a repeatable pattern should become durable guidance,
+6. domain vocabulary or operating assumptions materially change.
+
+If the change is platform-wide:
+
+1. update the central context system in `lotus-platform/context/`.
+2. update `LOTUS-SKILL-ROUTING-MAP.md` if task routing expectations changed.
+
+If the change is repository-local:
+
+1. update that repository's `REPOSITORY-ENGINEERING-CONTEXT.md`.
+
+If both changed:
+
+1. update both in the same slice.
+
+## Cross-Links
+
+Central context system:
+
+1. `<lotus-platform>/context/LOTUS-QUICKSTART-CONTEXT.md`
+2. `<lotus-platform>/context/LOTUS-ENGINEERING-CONTEXT.md`
+3. `<lotus-platform>/context/CONTEXT-REFERENCE-MAP.md`
+4. `<lotus-platform>/context/PROCEDURAL-MEMORY-INDEX.md`
+5. `<lotus-platform>/context/LOTUS-SKILL-ROUTING-MAP.md`
+6. `<lotus-platform>/context/lotus-context-manifest.json`
+7. `<lotus-platform>/context/platform-engineering-ledger.md`
+8. `<lotus-platform>/context/recent-architectural-decisions-digest.md`
+9. `<lotus-platform>/docs/onboarding/LOTUS-DEVELOPER-ONBOARDING.md`
+10. `<lotus-platform>/docs/onboarding/LOTUS-AGENT-RAMP-UP.md`
+
+Repository-local context:
+
+1. `REPOSITORY-ENGINEERING-CONTEXT.md` in the repository you are changing
+
+When the central contract changes, keep both this source file and the deployed `AGENTS.md` synchronized.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ The local mapping is:
 - `make ci-local`
   local Docker-parity proof with full coverage and dependency checks
 
+When a slice changes `README.md` or public guides, also run:
+
+```bash
+python -m pytest tests/unit/docs/test_public_docs_contract.py -q
+```
+
 ## Integration Boundaries
 
 Primary ecosystem relationships:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# Portfolio Performance Analytics API
+# lotus-performance
 
-`lotus-performance` is the analytics service in the Lotus platform. It owns:
+Authoritative performance analytics service for the Lotus ecosystem.
 
-- repository-local engineering context: `REPOSITORY-ENGINEERING-CONTEXT.md`
+Repository-local engineering context: [REPOSITORY-ENGINEERING-CONTEXT.md](REPOSITORY-ENGINEERING-CONTEXT.md)
+
+## Purpose And Scope
+
+`lotus-performance` is the Lotus domain service for benchmark-aware performance analytics,
+returns-series integration, durable execution tracking, and lineage-backed reproducibility.
+
+It owns:
 
 - time-weighted return (`POST /performance/twr`)
 - benchmark performance (`POST /performance/benchmark`)
@@ -12,11 +19,20 @@
 - attribution (`POST /performance/attribution`)
 - canonical returns-series integration (`POST /integration/returns/series`)
 - benchmark exposure context (`POST /integration/benchmarks/exposure-context`)
+- execution polling, runtime control-plane, and lineage retrieval surfaces
 
-It also owns durable execution lifecycle tracking, async compute offload for heavier workloads,
-lineage artifact capture, TWR inspection/supportability triage, and execution/result polling surfaces.
+It does not own source-of-record portfolio, benchmark, index, FX, or reference datasets, and it
+does not delegate performance conclusions to `lotus-core`.
 
-## Runtime model
+## Current Operational Posture
+
+1. `lotus-performance` is an active domain service consumed primarily through `lotus-gateway`.
+2. Stateful integration with `lotus-core` is live under the RFC-0082 contract-family map.
+3. Async execution, lineage capture, and durable runtime-control surfaces are shipped parts of the
+   contract.
+4. OpenAPI, API vocabulary, migration, security, and Docker parity are part of the real merge gate.
+
+## Architecture At A Glance
 
 The current runtime is a four-service topology:
 
@@ -25,22 +41,65 @@ The current runtime is a four-service topology:
 3. `performance-lineage-worker`
 4. `performance-lineage-db`
 
+Optional ops profile:
+
+5. `performance-runtime-retention-worker`
+
 Source-of-truth runtime docs:
 
-- [technical/architecture.md](docs/technical/architecture.md)
-- [technical/runtime_topology.md](docs/technical/runtime_topology.md)
-- [technical/RFC-0082-upstream-contract-family-map.md](docs/technical/RFC-0082-upstream-contract-family-map.md)
-- [technical/RFC-0082-retrieval-performance-hardening.md](docs/technical/RFC-0082-retrieval-performance-hardening.md)
-- [technical/execution-polling-endpoint-certification.md](docs/technical/execution-polling-endpoint-certification.md)
-- [technical/integration-capabilities-endpoint-certification.md](docs/technical/integration-capabilities-endpoint-certification.md)
-- [technical/lineage-endpoint-certification.md](docs/technical/lineage-endpoint-certification.md)
-- [technical/platform-surfaces-endpoint-certification.md](docs/technical/platform-surfaces-endpoint-certification.md)
-- [technical/recovery-drills-endpoint-certification.md](docs/technical/recovery-drills-endpoint-certification.md)
-- [technical/runtime-recoveries-endpoint-certification.md](docs/technical/runtime-recoveries-endpoint-certification.md)
-- [technical/runtime-retention-endpoint-certification.md](docs/technical/runtime-retention-endpoint-certification.md)
-- [technical/runtime-status-endpoint-certification.md](docs/technical/runtime-status-endpoint-certification.md)
-- [technical/runtime-work-items-endpoint-certification.md](docs/technical/runtime-work-items-endpoint-certification.md)
-- [technical/twr-inspection-endpoint-certification.md](docs/technical/twr-inspection-endpoint-certification.md)
+- [docs/technical/architecture.md](docs/technical/architecture.md)
+- [docs/technical/runtime_topology.md](docs/technical/runtime_topology.md)
+- [docs/technical/RFC-0082-upstream-contract-family-map.md](docs/technical/RFC-0082-upstream-contract-family-map.md)
+
+Grouped public surfaces are derived from the router layout in [main.py](main.py):
+
+- `/performance`
+  TWR, benchmark, contribution, executions, inspections, and lineage
+- `/integration`
+  capabilities, returns-series, benchmark exposure context, runtime status, runtime work items,
+  runtime recoveries, recovery drill history, and runtime retention history
+- platform surfaces
+  `/`, `/health`, `/health/live`, `/health/ready`, `/metrics`, `/docs`, and `/openapi.json`
+
+## Repository Layout
+
+- `app/`
+  FastAPI application layer, models, services, and workers
+- `engine/`
+  analytics and orchestration logic
+- `core/`
+  shared calculation and support foundations
+- `adapters/`
+  storage and integration seams
+- `docs/`
+  architecture, guides, runbooks, standards, RFCs, and certification evidence
+- `scripts/`
+  repo-native validation and operational tooling
+- `tests/`
+  unit, integration, e2e, benchmarks, and docs regression coverage
+
+## Quick Start
+
+Install dependencies:
+
+```bash
+make install
+```
+
+Run the API locally:
+
+```bash
+make run
+```
+
+Then open `/docs` or `/openapi.json`.
+
+For topology-parity local runs, the governed runtime overlays live in
+[docs/examples/](docs/examples). The production-profile compose overlay command remains:
+
+```bash
+docker compose -f docker-compose.yml -f docs/examples/docker-compose.runtime-thresholds.production.yml up
+```
 
 Canonical stateful TWR inspection can be validated locally with:
 
@@ -53,6 +112,109 @@ python scripts/validate_canonical_twr_inspection.py \
 This probes the lotus-core query-control-plane analytics-input POST routes, runs stateful TWR for
 `PB_SG_GLOBAL_BAL_001` as of `2026-04-10`, and verifies the RFC-045 inspection evidence has no
 source-economics or reconciliation regressions.
+
+## Common Commands
+
+- install
+  `make install`
+- fast local gate
+  `make check`
+- PR-grade local gate
+  `make ci`
+- Docker-parity local gate
+  `make ci-local`
+- full test and coverage run
+  `make test-all`
+- migration and recovery smoke
+  `make migration-smoke`
+- retention smoke
+  `make runtime-retention-smoke`
+- Docker image proof
+  `make docker-build`
+
+## Validation And CI Lanes
+
+`lotus-performance` follows the Lotus multi-lane model:
+
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+
+The local mapping is:
+
+- `make check`
+  lint, no-alias gate, typecheck, OpenAPI gate, API vocabulary gate, and unit tests
+- `make ci`
+  governance, migration smoke, security audit, unit, integration, e2e, coverage, and Docker build
+- `make ci-local`
+  local Docker-parity proof with full coverage and dependency checks
+
+## Integration Boundaries
+
+Primary ecosystem relationships:
+
+- downstream consumers:
+  `lotus-gateway`, selected `lotus-risk` stateful workflows, and operator/support tooling
+- upstream dependencies:
+  `lotus-core` control-plane and source-data contracts for stateful sourcing
+
+Current transport posture remains REST/OpenAPI through `CORE_CONTROL_PLANE_BASE_URL`; there is no
+current gRPC contract between `lotus-performance` and `lotus-core`.
+
+Governed base-URL examples for the control-plane contract family are:
+
+1. local ingress: `http://core-control.dev.lotus`
+2. local host-port: `http://127.0.0.1:8202`
+3. local Docker-to-host: `http://host.docker.internal:8202`
+4. platform-stack internal: `http://lotus-core-control:8002`
+
+## Operations And Runtime Posture
+
+The runtime is intentionally durable:
+
+- `/health/ready` returns `200` only when the API can support executor-backed and lineage-backed workflows
+- `/performance/executions/{calculation_id}` is the canonical polling surface
+- async result routes are durable, not process-local memory
+- runtime status, work-item, recovery-drill, runtime-recovery, and retention surfaces are governed operator APIs
+
+Key operator and certification references:
+
+- [docs/runbooks/runtime-alerts.md](docs/runbooks/runtime-alerts.md)
+- [docs/runbooks/durable-metadata-recovery.md](docs/runbooks/durable-metadata-recovery.md)
+- [docs/runbooks/runtime-retention-cleanup.md](docs/runbooks/runtime-retention-cleanup.md)
+- [docs/technical/lineage-endpoint-certification.md](docs/technical/lineage-endpoint-certification.md)
+- [docs/technical/platform-surfaces-endpoint-certification.md](docs/technical/platform-surfaces-endpoint-certification.md)
+- [docs/technical/execution-polling-endpoint-certification.md](docs/technical/execution-polling-endpoint-certification.md)
+- [docs/technical/runtime-status-endpoint-certification.md](docs/technical/runtime-status-endpoint-certification.md)
+- [docs/technical/runtime-work-items-endpoint-certification.md](docs/technical/runtime-work-items-endpoint-certification.md)
+- [docs/technical/runtime-recoveries-endpoint-certification.md](docs/technical/runtime-recoveries-endpoint-certification.md)
+- [docs/technical/recovery-drills-endpoint-certification.md](docs/technical/recovery-drills-endpoint-certification.md)
+- [docs/technical/runtime-retention-endpoint-certification.md](docs/technical/runtime-retention-endpoint-certification.md)
+- [docs/technical/twr-inspection-endpoint-certification.md](docs/technical/twr-inspection-endpoint-certification.md)
+- [docs/technical/twr-mwr-response-attribute-certification.md](docs/technical/twr-mwr-response-attribute-certification.md)
+
+## Documentation Map
+
+- human API map:
+  [docs/guides/api_reference.md](docs/guides/api_reference.md)
+- complete service reference:
+  [docs/guides/complete_service_reference.md](docs/guides/complete_service_reference.md)
+- reproducibility and lineage:
+  [docs/guides/reproducibility.md](docs/guides/reproducibility.md)
+- workspace-summary guide:
+  [docs/guides/workspace_summary.md](docs/guides/workspace_summary.md)
+- TWR inspection checks:
+  [docs/guides/twr_inspection_checks.md](docs/guides/twr_inspection_checks.md)
+- methodology index:
+  [docs/technical/methodology_index.md](docs/technical/methodology_index.md)
+- local RFC estate:
+  [docs/RFCs/RFC-INDEX.md](docs/RFCs/RFC-INDEX.md)
+
+## Wiki Source
+
+Repository-authored wiki pages live under [wiki/](wiki). If the GitHub wiki is published later,
+keep `wiki/` as the canonical source and treat any separate `*.wiki.git` clone as publication
+plumbing only.
 
 ## Key contracts
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -47,9 +47,11 @@ Primary areas:
    integration seams and storage/runtime adapters.
 5. `docs/`
    service guides, methodology, and technical runtime docs.
-6. `scripts/`
+6. `wiki/`
+   canonical authored source for GitHub wiki publication and repo-operator onboarding summaries.
+7. `scripts/`
    quality gates, migration checks, and dependency-health tooling.
-7. `tests/`
+8. `tests/`
    unit, integration, e2e, and benchmark or characterization coverage.
 
 ## Runtime And Integration Boundaries
@@ -120,7 +122,9 @@ Most relevant current governance:
 2. async execution and lineage are already part of the contract and should not be treated as optional infrastructure details,
 3. benchmark-aware stateful behavior must remain aligned with `lotus-core` sourcing, RFC-0082 contract-family classification, and gateway expectations,
 4. methodology and reproducibility documentation matter here as much as code,
-5. transport optimization between `lotus-performance` and `lotus-core` should start with retrieval-shape evidence before any gRPC proposal.
+5. transport optimization between `lotus-performance` and `lotus-core` should start with retrieval-shape evidence before any gRPC proposal,
+6. repo-local `wiki/` content should stay concise, operator-focused, and derived from repo truth rather
+   than becoming a second uncontrolled documentation tree.
 
 ## Context Maintenance Rule
 
@@ -131,7 +135,8 @@ Update this document when:
 3. stateful integration boundaries with `lotus-core` change,
 4. methodology, lineage, or execution posture changes materially,
 5. current product-support posture changes,
-6. RFC-0082 upstream contract-family classification or consumer conformance posture changes.
+6. RFC-0082 upstream contract-family classification or consumer conformance posture changes,
+7. README or `wiki/` structure changes the repository-local onboarding or operator navigation model.
 
 ## Cross-Links
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -100,7 +100,9 @@ Important validation expectations:
 1. OpenAPI and API vocabulary governance are active,
 2. migration smoke and project-scoped dependency health are required,
 3. unit, integration, e2e, coverage, and Docker build are part of the real merge contract,
-4. analytics quality and runtime characterization matter because downstream product surfaces depend on the truthfulness of these results.
+4. analytics quality and runtime characterization matter because downstream product surfaces depend on the truthfulness of these results,
+5. public documentation is regression-tested and README or guide reshaping should preserve governed
+   contract truth unless the underlying repo truth is intentionally changing.
 
 ## Standards And RFCs That Govern This Repository
 
@@ -124,7 +126,9 @@ Most relevant current governance:
 4. methodology and reproducibility documentation matter here as much as code,
 5. transport optimization between `lotus-performance` and `lotus-core` should start with retrieval-shape evidence before any gRPC proposal,
 6. repo-local `wiki/` content should stay concise, operator-focused, and derived from repo truth rather
-   than becoming a second uncontrolled documentation tree.
+   than becoming a second uncontrolled documentation tree,
+7. `tests/unit/docs/test_public_docs_contract.py` is a meaningful guardrail for README and public-guide
+   changes and should be part of targeted validation when documentation slices touch contract-facing pages.
 
 ## Context Maintenance Rule
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -1,0 +1,70 @@
+# API Surface
+
+## Surface groups
+
+`lotus-performance` exposes three major surface families:
+
+1. analytics surfaces
+2. integration surfaces
+3. operator and platform surfaces
+
+Use this page as the short navigation layer. Use the deep guides for payload detail.
+
+## Analytics surfaces
+
+Authoritative analytics routes:
+
+- `POST /performance/twr`
+- `POST /performance/benchmark`
+- `POST /performance/mwr`
+- `POST /performance/workspace-summary`
+- `POST /performance/contribution`
+- `POST /performance/attribution`
+- `POST /performance/inspections/twr`
+
+Async and supportability routes:
+
+- `GET /performance/executions/{calculation_id}`
+- `GET /performance/twr/results/{calculation_id}`
+- `GET /performance/benchmark/results/{calculation_id}`
+- `GET /performance/workspace-summary/results/{calculation_id}`
+- `GET /performance/contribution/results/{calculation_id}`
+- `GET /performance/attribution/results/{calculation_id}`
+- `GET /performance/inspections/{inspection_id}`
+- `GET /performance/lineage/{calculation_id}`
+
+## Integration surfaces
+
+Cross-service and downstream-facing routes:
+
+- `GET /integration/capabilities`
+- `POST /integration/returns/series`
+- `GET /integration/returns/series/results/{calculation_id}`
+- `POST /integration/benchmarks/exposure-context`
+
+## Operator and platform surfaces
+
+Runtime and supportability routes:
+
+- `GET /health`
+- `GET /health/live`
+- `GET /health/ready`
+- `GET /metrics`
+- `GET /integration/runtime-status`
+- `GET /integration/runtime-work-items`
+- `GET /integration/runtime-recoveries`
+- `GET /integration/recovery-drills`
+- `POST /integration/recovery-drills/run`
+- `GET /integration/runtime-retention-cleanups`
+- `POST /integration/runtime-retention-cleanups/run`
+
+## Where to go next
+
+- contract and payload detail:
+  [docs/guides/api_reference.md](../docs/guides/api_reference.md)
+- full examples and config inventory:
+  [docs/guides/complete_service_reference.md](../docs/guides/complete_service_reference.md)
+- runtime behavior and readiness:
+  [Operations Runbook](Operations-Runbook)
+- upstream contract boundary:
+  [Integrations](Integrations)

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,59 @@
+# Architecture
+
+## Runtime shape
+
+The implemented topology is documented in [docs/technical/runtime_topology.md](../docs/technical/runtime_topology.md):
+
+1. `performance-analytics`
+2. `performance-compute-executor`
+3. `performance-lineage-worker`
+4. `performance-lineage-db`
+5. optional `performance-runtime-retention-worker`
+
+The repo remains one business service with operationally split runtime responsibilities.
+
+## Code layout
+
+- `app/`
+  FastAPI entrypoints, models, services, workers, runtime wiring
+- `engine/`
+  analytics and orchestration logic
+- `core/`
+  shared calculation and utility foundations
+- `adapters/`
+  storage and integration seams
+- `docs/`
+  architecture, standards, runbooks, guides, RFCs, and certification evidence
+- `scripts/`
+  local validation and operational tooling
+- `tests/`
+  unit, integration, e2e, docs regression, and benchmark coverage
+
+## Public surface groups
+
+Router grouping in [main.py](../main.py):
+
+- `/performance`
+  TWR, benchmark, contribution, executions, inspections, lineage, workspace summary, attribution, MWR
+- `/integration`
+  capabilities, returns-series, benchmark exposure context, runtime status, work items, recoveries,
+  recovery drills, runtime retention
+- platform surfaces
+  `/`, health endpoints, metrics, Swagger, and OpenAPI
+
+## Critical seams
+
+- upstream source-data seam:
+  `lotus-core` control-plane and analytics-input contracts
+- async compute seam:
+  durable execution registry plus executor job storage
+- lineage seam:
+  durable metadata plus artifact materialization
+- operator seam:
+  runtime-status, work-items, recoveries, drill history, and retention history
+
+## Deeper docs
+
+- [docs/technical/architecture.md](../docs/technical/architecture.md)
+- [docs/technical/runtime_topology.md](../docs/technical/runtime_topology.md)
+- [docs/technical/RFC-0082-upstream-contract-family-map.md](../docs/technical/RFC-0082-upstream-contract-family-map.md)

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -27,6 +27,12 @@ make ci
 - keep benchmark and stateful integration language aligned to RFC-0082
 - respect the docs regression pack when changing `README.md` or public guides
 
+Targeted documentation proof:
+
+```bash
+python -m pytest tests/unit/docs/test_public_docs_contract.py -q
+```
+
 ## References
 
 - [docs/operations/development-workflow-and-ci-strategy.md](../docs/operations/development-workflow-and-ci-strategy.md)

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -1,0 +1,33 @@
+# Development Workflow
+
+## Daily loop
+
+1. branch from `main`
+2. make a small truthful slice
+3. run targeted validation first
+4. run the lane command that matches the change risk
+5. update docs when repo truth changes
+
+## Common commands
+
+```bash
+make install
+make run
+make test-unit
+make test-integration
+make test-e2e
+make check
+make ci
+```
+
+## Repo-specific expectations
+
+- preserve OpenAPI and vocabulary truth
+- treat async execution and lineage as contract behavior, not implementation detail
+- keep benchmark and stateful integration language aligned to RFC-0082
+- respect the docs regression pack when changing `README.md` or public guides
+
+## References
+
+- [docs/operations/development-workflow-and-ci-strategy.md](../docs/operations/development-workflow-and-ci-strategy.md)
+- [Validation and CI](Validation-and-CI)

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,47 @@
+# Getting Started
+
+## Prerequisites
+
+- Python environment compatible with the repo toolchain
+- local access to any required upstream Lotus services when exercising stateful flows
+- optional Docker if you want topology-parity or threshold-overlay runs
+
+## Install
+
+```bash
+make install
+```
+
+## Run locally
+
+```bash
+make run
+```
+
+Then verify the service at:
+
+- `/health`
+- `/health/ready`
+- `/docs`
+
+## Quick validation loop
+
+```bash
+make check
+```
+
+## Stateful inspection proof
+
+```bash
+python scripts/validate_canonical_twr_inspection.py \
+  --performance-base-url http://127.0.0.1:8002 \
+  --core-control-plane-base-url http://127.0.0.1:8202
+```
+
+Use this when you need governed proof that the canonical TWR inspection path is still aligned.
+
+## Where startup details live
+
+- [docs/technical/runtime_topology.md](../docs/technical/runtime_topology.md)
+- [docs/examples](../docs/examples)
+- [Troubleshooting](Troubleshooting)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,64 @@
+# lotus-performance wiki
+
+`lotus-performance` is the Lotus performance analytics authority. It owns benchmark-aware
+performance calculations, returns-series integration, durable execution tracking, and lineage-backed
+reproducibility for downstream platform consumers.
+
+## Start here
+
+- Repo entrypoint: [README.md](../README.md)
+- Repo context: [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- Architecture: [docs/technical/architecture.md](../docs/technical/architecture.md)
+- Runtime topology: [docs/technical/runtime_topology.md](../docs/technical/runtime_topology.md)
+- API reference: [docs/guides/api_reference.md](../docs/guides/api_reference.md)
+- Complete service reference: [docs/guides/complete_service_reference.md](../docs/guides/complete_service_reference.md)
+
+## Repo role
+
+This repo owns:
+
+- time-weighted return, money-weighted return, benchmark, contribution, attribution, and workspace summary analytics
+- canonical returns-series integration for downstream Lotus consumers
+- execution polling, runtime-status, work-item, recovery, and retention operator surfaces
+- lineage artifacts and reproducibility evidence for durable workflows
+
+This repo does not own:
+
+- source-of-record portfolio, benchmark, index, FX, or reference datasets
+- gateway-facing product shaping or frontend experience composition
+- upstream performance conclusions from `lotus-core`
+
+## Runtime posture
+
+The implemented runtime is a four-service topology with an optional retention worker:
+
+1. `performance-analytics`
+2. `performance-compute-executor`
+3. `performance-lineage-worker`
+4. `performance-lineage-db`
+5. optional `performance-runtime-retention-worker`
+
+Async execution and lineage are real contract features, not optional background conveniences.
+
+## Common commands
+
+```bash
+make install
+make run
+make check
+make ci
+```
+
+## Navigation
+
+- [Overview](Overview)
+- [Architecture](Architecture)
+- [Getting Started](Getting-Started)
+- [Development Workflow](Development-Workflow)
+- [Validation and CI](Validation-and-CI)
+- [Operations Runbook](Operations-Runbook)
+- [Integrations](Integrations)
+- [Security and Governance](Security-and-Governance)
+- [RFC Index](RFC-Index)
+- [Roadmap](Roadmap)
+- [Troubleshooting](Troubleshooting)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -53,6 +53,7 @@ make ci
 
 - [Overview](Overview)
 - [Architecture](Architecture)
+- [API Surface](API-Surface)
 - [Getting Started](Getting-Started)
 - [Development Workflow](Development-Workflow)
 - [Validation and CI](Validation-and-CI)

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -1,0 +1,43 @@
+# Integrations
+
+## Downstream consumers
+
+Primary downstream consumers include:
+
+- `lotus-gateway`
+- selected `lotus-risk` stateful workflows
+- operator and support tooling that consumes execution, runtime, and lineage surfaces
+
+## Upstream dependencies
+
+`lotus-performance` consumes `lotus-core` for governed source data and analytics-input contracts.
+It does not outsource performance conclusions to `lotus-core`.
+
+Current transport posture:
+
+- control-plane base URL:
+  `CORE_CONTROL_PLANE_BASE_URL`
+- compatibility fallback:
+  `CORE_QUERY_BASE_URL`
+- no current gRPC contract
+
+Governed base-URL examples:
+
+1. `http://core-control.dev.lotus`
+2. `http://127.0.0.1:8202`
+3. `http://host.docker.internal:8202`
+4. `http://lotus-core-control:8002`
+
+## Contract grouping
+
+- analytics surfaces:
+  TWR, MWR, benchmark, workspace summary, contribution, attribution
+- integration surfaces:
+  returns-series, benchmark exposure context, capabilities
+- operator surfaces:
+  execution polling, lineage, runtime status, work items, recoveries, drills, retention
+
+## References
+
+- [docs/technical/RFC-0082-upstream-contract-family-map.md](../docs/technical/RFC-0082-upstream-contract-family-map.md)
+- [docs/guides/api_reference.md](../docs/guides/api_reference.md)

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -1,0 +1,46 @@
+# Operations Runbook
+
+## Operator surface summary
+
+Primary runtime surfaces:
+
+- `GET /health`
+- `GET /health/live`
+- `GET /health/ready`
+- `GET /metrics`
+- `GET /integration/runtime-status`
+- `GET /integration/runtime-work-items`
+- `GET /integration/runtime-recoveries`
+- `GET /integration/recovery-drills`
+- `POST /integration/recovery-drills/run`
+- `GET /integration/runtime-retention-cleanups`
+- `POST /integration/runtime-retention-cleanups/run`
+- `GET /performance/executions/{calculation_id}`
+- `GET /performance/lineage/{calculation_id}`
+
+## Readiness semantics
+
+`/health/ready` is intentionally strict. It returns ready only when the API can support durable
+executor-backed and lineage-backed workflows.
+
+## First-response documents
+
+- alert handling:
+  [docs/runbooks/runtime-alerts.md](../docs/runbooks/runtime-alerts.md)
+- durable recovery:
+  [docs/runbooks/durable-metadata-recovery.md](../docs/runbooks/durable-metadata-recovery.md)
+- retention cleanup:
+  [docs/runbooks/runtime-retention-cleanup.md](../docs/runbooks/runtime-retention-cleanup.md)
+
+## Runtime thresholds and overlays
+
+Threshold policy and compose overlays live in:
+
+- [docs/standards/runtime-alert-policy.md](../docs/standards/runtime-alert-policy.md)
+- [docs/standards/runtime-threshold-profiles.md](../docs/standards/runtime-threshold-profiles.md)
+- [docs/examples](../docs/examples)
+
+## Related pages
+
+- [Architecture](Architecture)
+- [Troubleshooting](Troubleshooting)

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -1,0 +1,41 @@
+# Overview
+
+## Business role
+
+`lotus-performance` is the authoritative Lotus service for performance analytics and performance
+adjacent integration surfaces. It serves the contract that downstream services use for:
+
+- TWR and MWR
+- benchmark analytics
+- contribution and attribution
+- interaction-efficient workspace summaries
+- canonical returns-series and benchmark exposure context
+- execution polling and lineage retrieval
+
+## Ownership boundaries
+
+This repo owns:
+
+1. performance methodology execution and emitted performance conclusions
+2. durable execution lifecycle and async replay semantics
+3. lineage materialization and reproducibility evidence
+4. runtime control-plane surfaces for queue, recovery, and retention visibility
+
+This repo does not own:
+
+1. source portfolio, benchmark, index, FX, or reference truth
+2. gateway payload shaping or UI orchestration
+3. upstream benchmark or portfolio master-data stewardship
+
+## Current posture
+
+- `lotus-performance` is an active domain service in the Lotus runtime, not a prototype.
+- Stateful sourcing from `lotus-core` is a governed shipped path under RFC-0082.
+- The service already enforces OpenAPI, vocabulary, migration, and security gates.
+- Async compute offload and lineage capture are contract features.
+
+## Related pages
+
+- [Architecture](Architecture)
+- [Integrations](Integrations)
+- [Operations Runbook](Operations-Runbook)

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -1,0 +1,33 @@
+# RFC Index
+
+## Platform-governing RFCs
+
+- RFC-0067
+  OpenAPI and API vocabulary governance
+- RFC-0072
+  multi-lane CI validation and release governance
+- RFC-0073
+  ecosystem engineering context and agent guidance
+- RFC-0082
+  lotus-core domain authority and analytics-serving boundary hardening
+
+## High-value local RFCs
+
+- RFC-030
+  integration capabilities contract API
+- RFC-039
+  returns-series integration contract for `lotus-risk`
+- RFC-041
+  API orchestrator, compute executor, and PostgreSQL durable state
+- RFC-042
+  core-sourced benchmark performance engine
+- RFC-044
+  interaction-efficient workspace analytics contract
+- RFC-045
+  TWR inspection and supportability contract
+
+## Full local RFC estate
+
+- [docs/RFCs/RFC-INDEX.md](../docs/RFCs/RFC-INDEX.md)
+- [docs/RFCs/RFC_IMPLEMENTATION_STATUS.md](../docs/RFCs/RFC_IMPLEMENTATION_STATUS.md)
+- [docs/RFCs/RFC-DELTA-BACKLOG.md](../docs/RFCs/RFC-DELTA-BACKLOG.md)

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+## Current phase
+
+`lotus-performance` is in an active hardening and operator-readiness phase rather than initial
+scaffolding.
+
+## Delivered foundations
+
+- stateful `lotus-core` sourcing for major performance workflows
+- durable async execution lifecycle
+- lineage-backed reproducibility
+- benchmark-aware analytics and workspace summary surfaces
+- runtime-status, recovery, and retention operator APIs
+
+## Intentional limitations
+
+- upstream source-data authority remains outside this repo
+- transport optimization to `lotus-core` is deferred until retrieval-shape evidence justifies it
+- wiki pages should stay navigational and operational, not duplicate the full guide and RFC estate
+
+## Near-term focus
+
+- keep public docs and wiki aligned with the shipped contract
+- keep operator/runtime guidance easier to navigate for support workflows
+- continue reducing drift between code surfaces, deep docs, and onboarding material

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -1,0 +1,30 @@
+# Security and Governance
+
+## Governing standards
+
+The most relevant current governance for this repo includes:
+
+- `lotus-platform/rfcs/RFC-0067-centralized-api-vocabulary-inventory-and-openapi-documentation-governance.md`
+- `lotus-platform/rfcs/RFC-0072-platform-wide-multi-lane-ci-validation-and-release-governance.md`
+- `lotus-platform/rfcs/RFC-0073-lotus-ecosystem-engineering-context-and-agent-guidance-system.md`
+- `lotus-platform/rfcs/RFC-0082-lotus-core-domain-authority-and-analytics-serving-boundary-hardening.md`
+
+## Local governance surfaces
+
+- enterprise readiness:
+  [docs/standards/enterprise-readiness.md](../docs/standards/enterprise-readiness.md)
+- durability consistency:
+  [docs/standards/durability-consistency.md](../docs/standards/durability-consistency.md)
+- durable schema inventory:
+  [docs/standards/durable-schema-inventory.md](../docs/standards/durable-schema-inventory.md)
+- migration contract:
+  [docs/standards/migration-contract.md](../docs/standards/migration-contract.md)
+- runtime alerts:
+  [docs/standards/runtime-alert-policy.md](../docs/standards/runtime-alert-policy.md)
+
+## Important cautions
+
+- emitted figures are product-facing and must stay auditably correct
+- privileged operator read and write surfaces are governed, not ad hoc
+- async execution and lineage behavior must remain durable and observable
+- benchmark and stateful integration wording must stay truthful to shipped behavior

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,40 @@
+# Troubleshooting
+
+## Service starts but readiness fails
+
+Check:
+
+- durable metadata database reachability
+- runtime config required by enterprise-readiness validation
+- whether the API is intentionally draining
+
+References:
+
+- [docs/technical/runtime_topology.md](../docs/technical/runtime_topology.md)
+- [docs/runbooks/durable-metadata-recovery.md](../docs/runbooks/durable-metadata-recovery.md)
+
+## Stateful requests fail against upstream sources
+
+Check:
+
+- `CORE_CONTROL_PLANE_BASE_URL`
+- local ingress or host-port reachability to `lotus-core`
+- whether the request depends on source data that is absent, not a methodology fallback
+
+Reference:
+
+- [docs/technical/RFC-0082-upstream-contract-family-map.md](../docs/technical/RFC-0082-upstream-contract-family-map.md)
+
+## Async workflows stall
+
+Check:
+
+- `GET /integration/runtime-status`
+- `GET /integration/runtime-work-items`
+- `GET /integration/runtime-recoveries`
+- `GET /performance/executions/{calculation_id}`
+
+References:
+
+- [docs/runbooks/runtime-alerts.md](../docs/runbooks/runtime-alerts.md)
+- [docs/technical/runtime-status-endpoint-certification.md](../docs/technical/runtime-status-endpoint-certification.md)

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -38,3 +38,13 @@ References:
 
 - [docs/runbooks/runtime-alerts.md](../docs/runbooks/runtime-alerts.md)
 - [docs/technical/runtime-status-endpoint-certification.md](../docs/technical/runtime-status-endpoint-certification.md)
+
+## README or public-guide edits fail validation
+
+Run:
+
+```bash
+python -m pytest tests/unit/docs/test_public_docs_contract.py -q
+```
+
+Treat failures there as public-contract drift first, not as superficial wording checks.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -26,6 +26,16 @@
 - runtime-control surfaces are part of supportability, not optional extras
 - public docs are regression-tested and should stay aligned to shipped behavior
 
+## Documentation contract proof
+
+When a slice changes `README.md` or public guides, run:
+
+```bash
+python -m pytest tests/unit/docs/test_public_docs_contract.py -q
+```
+
+That pack protects the shipped public contract language and examples, not just formatting.
+
 ## References
 
 - [docs/operations/development-workflow-and-ci-strategy.md](../docs/operations/development-workflow-and-ci-strategy.md)

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -1,0 +1,32 @@
+# Validation and CI
+
+## Lane model
+
+`lotus-performance` follows the Lotus multi-lane validation posture:
+
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+
+## Local command mapping
+
+- `make check`
+  fast engineering proof: lint, no-alias gate, typecheck, OpenAPI gate, API vocabulary gate, unit tests
+- `make ci`
+  PR-grade proof: migration smoke, security audit, unit, integration, e2e, coverage, Docker build
+- `make ci-local`
+  local Docker-parity coverage run
+- `make test-all`
+  full local pytest plus coverage gate
+
+## Why the gates matter here
+
+- downstream product surfaces trust the emitted figures
+- contract drift breaks gateway and operator consumers
+- runtime-control surfaces are part of supportability, not optional extras
+- public docs are regression-tested and should stay aligned to shipped behavior
+
+## References
+
+- [docs/operations/development-workflow-and-ci-strategy.md](../docs/operations/development-workflow-and-ci-strategy.md)
+- [docs/technical/runtime_topology.md](../docs/technical/runtime_topology.md)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -4,6 +4,8 @@
 
 [Architecture](Architecture)
 
+[API Surface](API-Surface)
+
 [Getting Started](Getting-Started)
 
 [Development Workflow](Development-Workflow)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,23 @@
+[Home](Home)
+
+[Overview](Overview)
+
+[Architecture](Architecture)
+
+[Getting Started](Getting-Started)
+
+[Development Workflow](Development-Workflow)
+
+[Validation and CI](Validation-and-CI)
+
+[Operations Runbook](Operations-Runbook)
+
+[Integrations](Integrations)
+
+[Security and Governance](Security-and-Governance)
+
+[RFC Index](RFC-Index)
+
+[Roadmap](Roadmap)
+
+[Troubleshooting](Troubleshooting)


### PR DESCRIPTION
## Summary
- standardize the lotus-performance README as a tighter repo front door while preserving governed public-contract truth
- add a full repo-local wiki source set, including an API surface page for operator and onboarding navigation
- document the repo's docs-regression guardrails in local context and wiki workflow guidance

## Validation
- python -m pytest tests/unit/docs/test_public_docs_contract.py -q
- make check
