### PR TITLE
RFC-0086: repo-native performance domain product onboarding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-ci verify-dependencies check check-all test test-unit test-integration test-e2e test-all test-coverage coverage-gate ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate api-vocabulary-gate no-alias-gate migration-smoke migration-apply recovery-drill-smoke runtime-retention-smoke performance-characterization performance-characterization-postgres pre-commit docker-up docker-down docker-build
+.PHONY: install install-ci verify-dependencies check check-all test test-unit test-integration test-e2e test-all test-coverage coverage-gate ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate api-vocabulary-gate no-alias-gate domain-product-validate migration-smoke migration-apply recovery-drill-smoke runtime-retention-smoke performance-characterization performance-characterization-postgres pre-commit docker-up docker-down docker-build
 
 install:
 	pip install -r requirements.txt
@@ -16,7 +16,7 @@ verify-dependencies:
 pre-commit:
 	pre-commit run --all-files
 
-check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate test
+check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate domain-product-validate test
 
 test-coverage:
 	COVERAGE_FILE=.coverage.unit python -m pytest tests/unit --cov=app --cov=engine --cov=core --cov=adapters --cov-report=
@@ -27,7 +27,7 @@ test-coverage:
 
 coverage-gate: test-coverage
 
-ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate migration-smoke security-audit test-unit test-integration test-e2e coverage-gate docker-build
+ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate domain-product-validate migration-smoke security-audit test-unit test-integration test-e2e coverage-gate docker-build
 
 test:
 	$(MAKE) test-unit
@@ -44,7 +44,7 @@ test-e2e:
 test-all:
 	python -m pytest --cov=app --cov=engine --cov=core --cov=adapters --cov-report=term-missing --cov-fail-under=99
 
-ci-local: lint check-deps
+ci-local: lint check-deps domain-product-validate
 	python -m pip check
 	COVERAGE_FILE=.coverage.unit python -m pytest tests/unit --cov=app --cov=engine --cov=core --cov=adapters --cov-report=
 	COVERAGE_FILE=.coverage.integration python -m pytest tests/integration --cov=app --cov=engine --cov=core --cov=adapters --cov-report=
@@ -72,6 +72,9 @@ api-vocabulary-gate:
 
 no-alias-gate:
 	python scripts/no_alias_contract_guard.py
+
+domain-product-validate:
+	python scripts/validate_domain_data_product_contracts.py
 
 migration-smoke:
 	python scripts/migration_contract_check.py --mode durable-schema

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -31,7 +31,9 @@ Current repository posture:
 1. `lotus-performance` is the authoritative performance analytics engine consumed by `lotus-gateway`,
 2. stateful integration with `lotus-core` is active and classified under the RFC-0082 upstream contract-family map,
 3. the service already operates with enterprise-grade CI posture including security, migration, and Docker gates,
-4. async execution, lineage capture, and benchmark-aware workflows are real parts of the contract, not future placeholders.
+4. async execution, lineage capture, and benchmark-aware workflows are real parts of the contract, not future placeholders,
+5. repo-native domain-product producer and consumer declarations now live under `contracts/domain-data-products/`
+   with local validation through `make domain-product-validate`.
 
 ## Architecture And Module Map
 
@@ -86,6 +88,8 @@ Use these commands as the primary local contract:
    `make test-all`
 6. run locally
    `make run`
+7. repo-native domain-product declaration validation
+   `make domain-product-validate`
 
 ## Validation And CI Expectations
 
@@ -101,7 +105,8 @@ Important validation expectations:
 2. migration smoke and project-scoped dependency health are required,
 3. unit, integration, e2e, coverage, and Docker build are part of the real merge contract,
 4. analytics quality and runtime characterization matter because downstream product surfaces depend on the truthfulness of these results,
-5. public documentation is regression-tested and README or guide reshaping should preserve governed
+5. repo-native domain-product declaration validation is part of local ownership proof for RFC-0086 rollout,
+6. public documentation is regression-tested and README or guide reshaping should preserve governed
    contract truth unless the underlying repo truth is intentionally changing.
 
 ## Standards And RFCs That Govern This Repository
@@ -140,7 +145,8 @@ Update this document when:
 4. methodology, lineage, or execution posture changes materially,
 5. current product-support posture changes,
 6. RFC-0082 upstream contract-family classification or consumer conformance posture changes,
-7. README or `wiki/` structure changes the repository-local onboarding or operator navigation model.
+7. repo-native domain-product declaration paths or validation commands change,
+8. README or `wiki/` structure changes the repository-local onboarding or operator navigation model.
 
 ## Cross-Links
 

--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -1,0 +1,48 @@
+## Repo-Native Domain Data Product Declarations
+
+This directory is the repo-native declaration path for `lotus-performance` under RFC-0086.
+
+`lotus-performance` owns the declaration content in this directory.
+
+`lotus-platform` remains the owner of:
+
+1. schemas,
+2. identifier and temporal-semantics vocabulary,
+3. trust metadata vocabulary,
+4. shared validation logic,
+5. future aggregation and certification automation.
+
+Current declaration files:
+
+1. `lotus-performance-products.v1.json`
+   Producer declaration for performance-owned governed products.
+2. `lotus-performance-consumers.v1.json`
+   Consumer declaration for governed upstream dependencies consumed from `lotus-core`.
+
+Local validation command:
+
+```powershell
+python scripts/validate_domain_data_product_contracts.py
+```
+
+Repo-native make target:
+
+```powershell
+make domain-product-validate
+```
+
+Validation posture:
+
+1. local declarations are validated in-repo,
+2. platform-owned vocabulary is loaded from sibling repo `../lotus-platform`,
+3. upstream cross-reference validation stages the required upstream producer declarations from `lotus-platform`
+   until federation aggregation moves fully off the transitional platform-owned files.
+
+Current coverage boundary:
+
+1. this directory covers the currently governed `ReturnsSeriesBundle` and `BenchmarkExposureContext`
+   products plus the first-wave `lotus-core` dependency declarations already aligned under RFC-0084,
+2. benchmark-definition, benchmark-composition, vendor-return, index-catalog, index-price-series, and
+   FX operational-read dependencies remain documented in `docs/technical/RFC-0082-upstream-contract-family-map.md`
+   but are not yet machine-readable here because the corresponding upstream producer declarations have not
+   been onboarded yet.

--- a/contracts/domain-data-products/lotus-performance-consumers.v1.json
+++ b/contracts/domain-data-products/lotus-performance-consumers.v1.json
@@ -1,0 +1,131 @@
+{
+  "contract_id": "domain-data-product-consumers",
+  "contract_version": "1.0.0",
+  "governed_by_rfc": "RFC-0084",
+  "consumer_repository": "lotus-performance",
+  "dependencies": [
+    {
+      "product_name": "PortfolioTimeseriesInput",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Source canonical portfolio return observations for stateful returns-series workflows.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date",
+        "reconciliation_status",
+        "data_quality_status",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "PortfolioAnalyticsReference",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Resolve portfolio open-date, reporting-currency, and lifecycle reference context for governed performance products.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date",
+        "reconciliation_status",
+        "data_quality_status"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "BenchmarkAssignment",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Resolve the linked benchmark for stateful returns-series and benchmark-exposure workflows.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date",
+        "data_quality_status"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "MarketDataWindow",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "paged_api_read",
+      "business_purpose": "Retrieve benchmark market-series component weights and aligned market observations for performance-owned benchmark context.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "data_quality_status",
+        "latest_evidence_timestamp"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "InstrumentReferenceBundle",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "paged_api_read",
+      "business_purpose": "Source canonical classification and instrument reference metadata for benchmark exposure grouping semantics.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "data_quality_status",
+        "latest_evidence_timestamp"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "RiskFreeSeriesWindow",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Normalize governed risk-free series when the returns-series product is asked to emit risk-free return observations.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade_to_partial",
+      "required_trust_metadata": [
+        "generated_at",
+        "data_quality_status",
+        "latest_evidence_timestamp"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    }
+  ]
+}

--- a/contracts/domain-data-products/lotus-performance-products.v1.json
+++ b/contracts/domain-data-products/lotus-performance-products.v1.json
@@ -1,0 +1,118 @@
+{
+  "contract_id": "domain-data-products",
+  "contract_version": "1.0.0",
+  "governed_by_rfc": "RFC-0084",
+  "producer_repository": "lotus-performance",
+  "authoritative_domain": "performance_analytics",
+  "products": [
+    {
+      "product_name": "ReturnsSeriesBundle",
+      "product_version": "v1",
+      "owner_repository": "lotus-performance",
+      "product_family": "analytics_output",
+      "authoritative_domain": "performance_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "date",
+        "freshness_basis": "valuation_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "generated_at",
+        "as_of_date",
+        "correlation_id"
+      ],
+      "current_routes": [
+        "/integration/returns/series",
+        "/integration/returns/series/results/{calculation_id}"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Stateful series are recalculated from governed upstream data for the requested as-of date and window."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "system_access:client_confidential:retain_for_client_record:audit_system_access",
+      "approved_consumers": [
+        "lotus-risk"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "benchmark_id",
+        "calculation_id"
+      ],
+      "temporal_semantics_ref": "valuation_date"
+    },
+    {
+      "product_name": "BenchmarkExposureContext",
+      "product_version": "v1",
+      "owner_repository": "lotus-performance",
+      "product_family": "analytics_output",
+      "authoritative_domain": "performance_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "benchmark",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "valuation_date",
+        "freshness_basis": "valuation_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "generated_at",
+        "as_of_date"
+      ],
+      "current_routes": [
+        "/integration/benchmarks/exposure-context"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Exposure rows must stay aligned to the benchmark performance context and resolved benchmark version for the requested as-of date."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "system_access:reference_internal:retain_for_source_audit:audit_system_access",
+      "approved_consumers": [
+        "lotus-risk"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "benchmark_id",
+        "calculation_id",
+        "position_id"
+      ],
+      "temporal_semantics_ref": "valuation_date"
+    }
+  ]
+}

--- a/docs/technical/RFC-0082-upstream-contract-family-map.md
+++ b/docs/technical/RFC-0082-upstream-contract-family-map.md
@@ -104,6 +104,22 @@ Current test and implementation evidence:
 7. `tests/integration/test_benchmark_exposure_context_api.py`
    Verifies benchmark exposure context sourcing from core-backed index and benchmark inputs.
 
+## Repo-Native Machine-Readable Coverage
+
+RFC-0086 repo-native declarations now live in:
+
+1. `contracts/domain-data-products/lotus-performance-products.v1.json`
+2. `contracts/domain-data-products/lotus-performance-consumers.v1.json`
+
+Current machine-readable dependency coverage matches the current first-wave governed dependencies:
+
+1. `PortfolioTimeseriesInput`
+2. `PortfolioAnalyticsReference`
+3. `BenchmarkAssignment`
+4. `MarketDataWindow`
+5. `InstrumentReferenceBundle`
+6. `RiskFreeSeriesWindow`
+
 ## Current Gap Register
 
 1. `GET /fx-rates/` is currently an operational read rather than an `/integration/reference/*`
@@ -115,6 +131,9 @@ Current test and implementation evidence:
 3. Transport optimization is deferred. Retrieval performance work should first profile chunk size, page size,
    export behavior, concurrency, retry policy, and upstream database/query shape before proposing gRPC.
    Current Slice 4 evidence is recorded in `docs/technical/RFC-0082-retrieval-performance-hardening.md`.
+4. benchmark definition, benchmark composition-window, benchmark vendor return-series, index catalog,
+   and index price-series dependencies still rely on this document for truth because corresponding
+   machine-readable upstream producer declarations are not yet available for repo-native consumer coverage.
 
 ## Validation Lane
 

--- a/docs/technical/RFC-0086-repo-native-domain-product-onboarding.md
+++ b/docs/technical/RFC-0086-repo-native-domain-product-onboarding.md
@@ -1,0 +1,109 @@
+# RFC-0086 Repo-Native Domain Product Onboarding
+
+This document records the `lotus-performance` implementation posture for RFC-0086 and the
+preparatory assessment for RFC-0087.
+
+## Repo-Native Ownership Split
+
+`lotus-performance` now owns its declaration content in:
+
+1. `contracts/domain-data-products/lotus-performance-products.v1.json`
+2. `contracts/domain-data-products/lotus-performance-consumers.v1.json`
+
+`lotus-platform` remains the owner of:
+
+1. schemas,
+2. semantics and trust vocabulary registries,
+3. shared declaration validation logic,
+4. future aggregation and certification automation.
+
+The local validation wrapper deliberately reuses the platform validator and platform vocabulary
+instead of copying those registries into `lotus-performance`.
+
+## Current Producer Coverage
+
+Current repo-native producer declarations cover:
+
+1. `ReturnsSeriesBundle`
+2. `BenchmarkExposureContext`
+
+These are the strongest current performance-owned governed products because they already have:
+
+1. stable route surfaces,
+2. explicit upstream source dependencies,
+3. lineage expectations,
+4. partial or fail-closed posture that can be certified truthfully.
+
+## Current Consumer Coverage
+
+Current repo-native consumer declarations cover the first-wave `lotus-core` dependencies already
+aligned under RFC-0084:
+
+1. `PortfolioTimeseriesInput`
+2. `PortfolioAnalyticsReference`
+3. `BenchmarkAssignment`
+4. `MarketDataWindow`
+5. `InstrumentReferenceBundle`
+6. `RiskFreeSeriesWindow`
+
+## Local Validation Path
+
+Repo-native validation command:
+
+```powershell
+python scripts/validate_domain_data_product_contracts.py
+```
+
+Repo-native make target:
+
+```powershell
+make domain-product-validate
+```
+
+The wrapper stages:
+
+1. local repo-native declarations from `contracts/domain-data-products/`,
+2. platform-owned vocabulary from `../lotus-platform/platform-contracts/domain-vocabulary/`,
+3. required upstream producer declarations from `../lotus-platform/platform-contracts/domain-data-products/`
+   until federated aggregation replaces the transitional platform copies.
+
+That keeps local ownership real without forking the shared trust vocabulary or validator semantics.
+
+## Docs-Only Dependency Coverage Still Missing
+
+The current RFC-0082 upstream contract-family map still contains documented dependencies that are
+not yet covered by machine-readable declarations because corresponding upstream producer
+declarations are not yet available:
+
+1. benchmark definition sourcing,
+2. benchmark composition-window sourcing,
+3. benchmark vendor return-series sourcing,
+4. index catalog sourcing,
+5. index price-series sourcing,
+6. FX operational-read sourcing.
+
+These dependencies should not be declared locally with invented product semantics. They need
+upstream producer onboarding or an explicit platform decision on whether each route belongs in the
+governed product family.
+
+## RFC-0087 First-Wave Telemetry Candidates
+
+Strongest first-wave runtime trust telemetry targets for `lotus-performance`:
+
+1. `ReturnsSeriesBundle`
+   Rationale: already has as-of-date semantics, fail-closed versus partial behavior for risk-free
+   enrichment, async execution tracking, durable lineage, and inspection-ready source-quality
+   evidence.
+2. `BenchmarkExposureContext`
+   Rationale: already depends on governed benchmark assignment, market-window, and instrument
+   reference inputs, and it can surface freshness, completeness, and lineage posture without
+   inventing gateway-local trust logic.
+
+Second-wave watchlist, but not first-wave declaration targets yet:
+
+1. `GET /integration/runtime-status`
+   Strong operator-facing trust signal, but it is a runtime control-plane surface rather than a
+   governed domain product declaration today.
+2. TWR inspection supportability outputs
+   Rich trust evidence exists, but the surface is currently a supportability contract family rather
+   than one of the RFC-0084 governed domain products.

--- a/scripts/validate_domain_data_product_contracts.py
+++ b/scripts/validate_domain_data_product_contracts.py
@@ -74,6 +74,21 @@ def _collect_required_upstream_product_paths(source_directory: Path) -> list[Pat
     return upstream_paths
 
 
+def platform_validation_dependencies_available(source_directory: Path = LOCAL_DECLARATION_DIR) -> bool:
+    required_paths = [
+        PLATFORM_VALIDATOR_PATH,
+        PLATFORM_VOCABULARY_DIR / "domain-data-product-semantics.v1.json",
+        PLATFORM_VOCABULARY_DIR / "domain-data-product-trust-metadata.v1.json",
+    ]
+
+    try:
+        required_paths.extend(_collect_required_upstream_product_paths(source_directory))
+    except FileNotFoundError:
+        return False
+
+    return all(path.exists() for path in required_paths)
+
+
 def validate_repo_native_contracts(source_directory: Path = LOCAL_DECLARATION_DIR) -> list[str]:
     source_directory = source_directory.resolve()
     if not source_directory.exists():

--- a/scripts/validate_domain_data_product_contracts.py
+++ b/scripts/validate_domain_data_product_contracts.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_DECLARATION_DIR = ROOT / "contracts" / "domain-data-products"
+PLATFORM_ROOT = ROOT.parent / "lotus-platform"
+PLATFORM_DECLARATION_DIR = PLATFORM_ROOT / "platform-contracts" / "domain-data-products"
+PLATFORM_VOCABULARY_DIR = PLATFORM_ROOT / "platform-contracts" / "domain-vocabulary"
+PLATFORM_VALIDATOR_PATH = PLATFORM_DECLARATION_DIR / "validate_domain_data_product_contracts.py"
+
+PRODUCT_PATTERN = "*-products.v1.json"
+CONSUMER_PATTERN = "*-consumers.v1.json"
+
+
+def _load_platform_validator():
+    if not PLATFORM_VALIDATOR_PATH.exists():
+        raise FileNotFoundError(
+            f"Platform validator not found at {PLATFORM_VALIDATOR_PATH}. "
+            "Ensure the sibling lotus-platform repository is available."
+        )
+
+    spec = importlib.util.spec_from_file_location("lotus_platform_domain_product_validator", PLATFORM_VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load platform validator from {PLATFORM_VALIDATOR_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _collect_local_declaration_paths(source_directory: Path) -> list[Path]:
+    return sorted(source_directory.glob(PRODUCT_PATTERN)) + sorted(source_directory.glob(CONSUMER_PATTERN))
+
+
+def _collect_required_upstream_product_paths(source_directory: Path) -> list[Path]:
+    required_repositories: set[str] = set()
+    local_producer_repositories: set[str] = set()
+
+    for path in sorted(source_directory.glob(PRODUCT_PATTERN)):
+        payload = _load_json(path)
+        producer_repository = payload.get("producer_repository")
+        if isinstance(producer_repository, str) and producer_repository:
+            local_producer_repositories.add(producer_repository)
+
+    for path in sorted(source_directory.glob(CONSUMER_PATTERN)):
+        payload = _load_json(path)
+        for dependency in payload.get("dependencies", []):
+            if not isinstance(dependency, dict):
+                continue
+            producer_repository = dependency.get("producer_repository")
+            if isinstance(producer_repository, str) and producer_repository:
+                required_repositories.add(producer_repository)
+
+    upstream_paths: list[Path] = []
+    for producer_repository in sorted(required_repositories - local_producer_repositories):
+        candidate = PLATFORM_DECLARATION_DIR / f"{producer_repository}-products.v1.json"
+        if not candidate.exists():
+            raise FileNotFoundError(
+                f"Required upstream producer declaration not found at {candidate}. "
+                "Machine-readable consumer coverage cannot validate until the upstream producer declaration exists."
+            )
+        upstream_paths.append(candidate)
+
+    return upstream_paths
+
+
+def validate_repo_native_contracts(source_directory: Path = LOCAL_DECLARATION_DIR) -> list[str]:
+    source_directory = source_directory.resolve()
+    if not source_directory.exists():
+        return [f"{source_directory}: repo-native declaration directory does not exist"]
+
+    validator = _load_platform_validator()
+    local_paths = _collect_local_declaration_paths(source_directory)
+
+    if not local_paths:
+        return [f"{source_directory}: no repo-native declaration files were found"]
+
+    upstream_paths = _collect_required_upstream_product_paths(source_directory)
+
+    with tempfile.TemporaryDirectory(prefix="lotus-performance-domain-products-") as temp_dir_string:
+        temp_root = Path(temp_dir_string)
+        temp_declaration_dir = temp_root / "domain-data-products"
+        temp_vocabulary_dir = temp_root / "domain-vocabulary"
+        temp_declaration_dir.mkdir(parents=True, exist_ok=True)
+        temp_vocabulary_dir.mkdir(parents=True, exist_ok=True)
+
+        for declaration_path in local_paths:
+            shutil.copy2(declaration_path, temp_declaration_dir / declaration_path.name)
+
+        for upstream_path in upstream_paths:
+            shutil.copy2(upstream_path, temp_declaration_dir / upstream_path.name)
+
+        for vocabulary_file_name in (
+            "domain-data-product-semantics.v1.json",
+            "domain-data-product-trust-metadata.v1.json",
+        ):
+            shutil.copy2(
+                PLATFORM_VOCABULARY_DIR / vocabulary_file_name,
+                temp_vocabulary_dir / vocabulary_file_name,
+            )
+
+        return validator.validate_contract_directory(temp_declaration_dir)
+
+
+def main() -> int:
+    issues = validate_repo_native_contracts()
+    if issues:
+        for issue in issues:
+            print(issue)
+        return 1
+
+    producer_count = len(list(LOCAL_DECLARATION_DIR.glob(PRODUCT_PATTERN)))
+    consumer_count = len(list(LOCAL_DECLARATION_DIR.glob(CONSUMER_PATTERN)))
+    print(
+        "Validated "
+        f"{producer_count} repo-native producer declaration(s) and "
+        f"{consumer_count} repo-native consumer declaration(s) in {LOCAL_DECLARATION_DIR}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -1,0 +1,32 @@
+from scripts.validate_domain_data_product_contracts import (
+    LOCAL_DECLARATION_DIR,
+    _collect_required_upstream_product_paths,
+    validate_repo_native_contracts,
+)
+
+
+def test_repo_native_domain_data_product_validation_passes() -> None:
+    assert validate_repo_native_contracts() == []
+
+
+def test_repo_native_domain_data_product_directory_contains_expected_files() -> None:
+    declaration_names = {path.name for path in LOCAL_DECLARATION_DIR.glob("*.json")}
+
+    assert declaration_names == {
+        "lotus-performance-products.v1.json",
+        "lotus-performance-consumers.v1.json",
+    }
+
+
+def test_repo_native_declaration_readme_documents_local_validation_path() -> None:
+    readme = (LOCAL_DECLARATION_DIR / "README.md").read_text(encoding="utf-8")
+
+    assert "python scripts/validate_domain_data_product_contracts.py" in readme
+    assert "make domain-product-validate" in readme
+    assert "docs/technical/RFC-0082-upstream-contract-family-map.md" in readme
+
+
+def test_repo_native_validation_script_stages_upstream_core_products() -> None:
+    upstream_paths = _collect_required_upstream_product_paths(LOCAL_DECLARATION_DIR)
+
+    assert [path.name for path in upstream_paths] == ["lotus-core-products.v1.json"]

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -1,8 +1,14 @@
+import json
+
 from scripts.validate_domain_data_product_contracts import (
     LOCAL_DECLARATION_DIR,
     _collect_required_upstream_product_paths,
     validate_repo_native_contracts,
 )
+
+
+def _load_declaration(name: str) -> dict:
+    return json.loads((LOCAL_DECLARATION_DIR / name).read_text(encoding="utf-8"))
 
 
 def test_repo_native_domain_data_product_validation_passes() -> None:
@@ -30,3 +36,31 @@ def test_repo_native_validation_script_stages_upstream_core_products() -> None:
     upstream_paths = _collect_required_upstream_product_paths(LOCAL_DECLARATION_DIR)
 
     assert [path.name for path in upstream_paths] == ["lotus-core-products.v1.json"]
+
+
+def test_repo_native_producer_declarations_cover_only_the_governed_first_wave_products() -> None:
+    payload = _load_declaration("lotus-performance-products.v1.json")
+
+    assert payload["producer_repository"] == "lotus-performance"
+    assert [product["product_name"] for product in payload["products"]] == [
+        "ReturnsSeriesBundle",
+        "BenchmarkExposureContext",
+    ]
+    assert payload["products"][0]["approved_consumers"] == ["lotus-risk"]
+    assert payload["products"][1]["approved_consumers"] == ["lotus-risk"]
+
+
+def test_repo_native_consumer_declarations_keep_watchlist_dependencies_docs_only() -> None:
+    payload = _load_declaration("lotus-performance-consumers.v1.json")
+
+    dependency_names = [dependency["product_name"] for dependency in payload["dependencies"]]
+
+    assert payload["consumer_repository"] == "lotus-performance"
+    assert dependency_names == [
+        "PortfolioTimeseriesInput",
+        "PortfolioAnalyticsReference",
+        "BenchmarkAssignment",
+        "MarketDataWindow",
+        "InstrumentReferenceBundle",
+        "RiskFreeSeriesWindow",
+    ]

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -1,8 +1,11 @@
 import json
 
+import pytest
+
 from scripts.validate_domain_data_product_contracts import (
     LOCAL_DECLARATION_DIR,
     _collect_required_upstream_product_paths,
+    platform_validation_dependencies_available,
     validate_repo_native_contracts,
 )
 
@@ -12,6 +15,9 @@ def _load_declaration(name: str) -> dict:
 
 
 def test_repo_native_domain_data_product_validation_passes() -> None:
+    if not platform_validation_dependencies_available():
+        pytest.skip("lotus-platform validation dependencies are not available in this environment")
+
     assert validate_repo_native_contracts() == []
 
 
@@ -33,6 +39,9 @@ def test_repo_native_declaration_readme_documents_local_validation_path() -> Non
 
 
 def test_repo_native_validation_script_stages_upstream_core_products() -> None:
+    if not platform_validation_dependencies_available():
+        pytest.skip("lotus-platform validation dependencies are not available in this environment")
+
     upstream_paths = _collect_required_upstream_product_paths(LOCAL_DECLARATION_DIR)
 
     assert [path.name for path in upstream_paths] == ["lotus-core-products.v1.json"]


### PR DESCRIPTION
Wave 1 repo-native performance domain product onboarding for lotus-performance.

Includes:
- repo-native producer and consumer declarations under `contracts/domain-data-products/`
- local validation gate wired into `Makefile`
- repo-local documentation for the first-wave product and dependency posture
- focused tests covering declaration validation and rollout guardrails

Validation:
- `python scripts/validate_domain_data_product_contracts.py`
- `make domain-product-validate`
- `python -m pytest tests/unit/test_domain_data_product_contracts.py -q`
- `python -m ruff check scripts/validate_domain_data_product_contracts.py tests/unit/test_domain_data_product_contracts.py`
- `python -m mypy --config-file mypy.ini scripts/validate_domain_data_product_contracts.py`

Coordinator review outcome:
- `contracts/domain-data-products/` approved as the repo-native path
- remaining watchlist dependencies stay docs-only for this wave
- first-wave scope stays limited to the strongest governed performance product surfaces