### PR TITLE
docs(mesh): document mesh wiki posture

### DIFF
--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -1,0 +1,20 @@
+# Mesh Data Products
+
+## Mesh role
+
+`lotus-performance` is a maturity-wave producer in the Lotus enterprise data mesh.
+
+## Governed product
+
+- Product ID: `lotus-performance:ReturnsSeriesBundle:v1`
+- Product role: governed return-series and performance evidence consumed by risk, advisory, reporting, gateway, and Workbench discovery flows
+- Source declaration: `contracts/domain-data-products/`
+- Trust telemetry: `contracts/trust-telemetry/`
+
+## Platform relationship
+
+`lotus-platform` aggregates the repo-native declaration, validates trust telemetry, applies mesh SLO/access/evidence policies, and includes this product in generated catalog, dependency graph, live certification, maturity matrix, evidence packs, and RFC-0092 operating reports.
+
+## Operating rule
+
+Performance product identity, lifecycle, telemetry, reconciliation, and evidence posture belong in `lotus-performance`. Gateway and Workbench publish or display certified evidence; they do not redefine performance product truth.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -23,3 +23,5 @@
 [Roadmap](Roadmap)
 
 [Troubleshooting](Troubleshooting)
+
+- [Mesh Data Products](Mesh-Data-Products)


### PR DESCRIPTION
Updates the authored repo wiki with an explicit Mesh Data Products page and sidebar link so the repo's published wiki can reflect the implemented Lotus mesh RFC posture. This is documentation-only; no runtime or API behavior changes.