### PR TITLE
Normalize returns-series period vocabulary

### DIFF
--- a/app/models/returns_series.py
+++ b/app/models/returns_series.py
@@ -4,7 +4,7 @@ from datetime import date as dt_date
 from datetime import datetime as dt_datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Literal
+from typing import Any, ClassVar, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -21,9 +21,9 @@ class ReturnsRelativePeriod(str, Enum):
     MTD = "MTD"
     QTD = "QTD"
     YTD = "YTD"
-    ONE_YEAR = "ONE_YEAR"
-    THREE_YEAR = "THREE_YEAR"
-    FIVE_YEAR = "FIVE_YEAR"
+    ONE_YEAR = "1Y"
+    THREE_YEAR = "3Y"
+    FIVE_YEAR = "5Y"
     SI = "SI"
     YEAR = "YEAR"
 
@@ -77,6 +77,13 @@ class ReturnPoint(BaseModel):
 
 
 class ReturnsWindow(BaseModel):
+    PERIOD_ALIASES: ClassVar[dict[str, str]] = {
+        "ONE_YEAR": "1Y",
+        "THREE_YEAR": "3Y",
+        "FIVE_YEAR": "5Y",
+        "ITD": "SI",
+    }
+
     mode: ReturnsWindowMode = Field(
         description=(
             "Window-resolution mode. Use EXPLICIT when the caller owns the exact observation dates; "
@@ -96,14 +103,29 @@ class ReturnsWindow(BaseModel):
     )
     period: ReturnsRelativePeriod | None = Field(
         default=None,
-        description="Relative period label when mode=RELATIVE.",
-        examples=["YTD"],
+        description=(
+            "Relative period label when mode=RELATIVE. Prefer canonical values MTD, QTD, "
+            "YTD, 1Y, 3Y, 5Y, SI, and YEAR. Legacy aliases ONE_YEAR, THREE_YEAR, "
+            "FIVE_YEAR, and ITD are accepted and normalized."
+        ),
+        examples=["3Y"],
     )
     year: int | None = Field(
         default=None,
         description="Calendar year when period=YEAR.",
         examples=[2026],
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_period_aliases(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            period = data.get("period")
+            if isinstance(period, str):
+                normalized_period = cls.PERIOD_ALIASES.get(period, period)
+                if normalized_period != period:
+                    return {**data, "period": normalized_period}
+        return data
 
     @model_validator(mode="after")
     def validate_mode_fields(self) -> "ReturnsWindow":

--- a/docs/RFCs/RFC 039 - Returns Series Integration Contract for lotus-risk Stateful Risk Analytics.md
+++ b/docs/RFCs/RFC 039 - Returns Series Integration Contract for lotus-risk Stateful Risk Analytics.md
@@ -65,8 +65,9 @@ Ownership boundary:
 - `window` required
   - `mode: EXPLICIT | RELATIVE`
   - `from_date`, `to_date` required for `EXPLICIT`
-  - `period` required for `RELATIVE` (`MTD|QTD|YTD|ONE_YEAR|THREE_YEAR|FIVE_YEAR|SI|YEAR`)
+  - `period` required for `RELATIVE` (`MTD|QTD|YTD|1Y|3Y|5Y|SI|YEAR`)
   - `year` required when `period=YEAR`
+  - legacy aliases `ONE_YEAR`, `THREE_YEAR`, `FIVE_YEAR`, and `ITD` are accepted and normalized at the API boundary
 - `frequency: DAILY | WEEKLY | MONTHLY` required
 - `metric_basis: NET | GROSS` required
 - `reporting_currency: str | None` optional

--- a/poetry.lock
+++ b/poetry.lock
@@ -1164,20 +1164,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
-    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 
@@ -1186,21 +1186,22 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.3.0"
 description = "Pytest support for asyncio"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
-    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
 ]
 
 [package.dependencies]
-pytest = ">=7.0.0,<9"
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
@@ -1279,14 +1280,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
-    {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
 
 [package.extras]
@@ -1701,4 +1702,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "9924181cd70541fa9e189675cc71f53bbe6c7d5f1c7ee19bc67aa1fdd7136f17"
+content-hash = "42c71b423cea900ee7b7422b0b66b542491c760fc78d1c71ea33013dd9331708"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ psycopg = {version = "^3.2.6", extras = ["binary"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.3"
-python-dotenv = "^1.1.1"
+python-dotenv = "^1.2.2"
 pre-commit = "^4.2.0"
 pytest-cov = "^6.2.1"
 pytest-benchmark = "^4.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pytest-benchmark==4.0.0
 pytest-cov==4.1.0
 pytest-mock==3.15.1
 python-dateutil==2.9.0.post0
-python-dotenv==1.1.1
+python-dotenv==1.2.2
 pytz==2025.2
 scipy==1.16.1
 six==1.17.0

--- a/tests/unit/app/test_returns_series_endpoint_helpers.py
+++ b/tests/unit/app/test_returns_series_endpoint_helpers.py
@@ -112,6 +112,16 @@ def test_resolve_window_relative_success_and_missing_period_error():
     assert exc.value.status_code == 400
 
 
+def test_returns_window_normalizes_legacy_relative_period_aliases():
+    window = ReturnsWindow.model_validate({"mode": "RELATIVE", "period": "THREE_YEAR"})
+
+    assert window.period == ReturnsRelativePeriod.THREE_YEAR
+    assert window.period.value == "3Y"
+
+    since_inception = ReturnsWindow.model_validate({"mode": "RELATIVE", "period": "ITD"})
+    assert since_inception.period == ReturnsRelativePeriod.SI
+
+
 def test_dataframe_and_window_helpers_handle_error_paths():
     with pytest.raises(HTTPException) as exc:
         _to_dataframe([], series_type="portfolio")


### PR DESCRIPTION
## Summary
- normalize returns-series relative period aliases to platform canonical period codes
- expose canonical 1Y, 3Y, 5Y, and SI values from the model
- update the risk integration RFC and tests for alias normalization
- upgrade python-dotenv to 1.2.2 and refresh lock metadata so security audit and dependency truth are aligned

## Validation
- python -m pytest tests/unit/app/test_returns_series_endpoint_helpers.py -q
- python -m ruff check app/models/returns_series.py tests/unit/app/test_returns_series_endpoint_helpers.py
- python scripts/openapi_quality_gate.py
- python scripts/no_alias_contract_guard.py
- python -m mypy --config-file mypy.ini app/models/returns_series.py tests/unit/app/test_returns_series_endpoint_helpers.py
- make security-audit