### PR TITLE
Implement RFC-0108 performance calculation supportability

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -39,7 +39,11 @@ Current repository posture:
    the platform trust telemetry validator when `lotus-platform` is available,
 7. the TWR inspection supportability contract can now preserve bounded Lotus AI workflow-pack run
    posture and the optional `support_brief.md` artifact without making the inspection verdict
-   dependent on Lotus AI availability.
+   dependent on Lotus AI availability,
+8. completed TWR, MWR, contribution, and attribution responses expose the shared
+   `calculation_supportability` block and emit the bounded
+   `lotus_performance_calculation_supportability_total` metric for front-office freshness and
+   degraded-state handling.
 
 ## Architecture And Module Map
 

--- a/app/api/endpoints/performance.py
+++ b/app/api/endpoints/performance.py
@@ -19,6 +19,10 @@ from app.models.workspace_summary_responses import WorkspaceSummaryAcceptedRespo
 from app.services.async_result_service import resolve_async_result
 from app.services.attribution_mode_service import resolve_attribution_request
 from app.services.attribution_service import calculate_attribution
+from app.services.calculation_supportability_service import (
+    build_calculation_supportability,
+    record_supportability_metric,
+)
 from app.services.execution_lifecycle_service import (
     complete_execution_with_lineage,
     record_execution_failure,
@@ -631,6 +635,14 @@ async def calculate_mwr_endpoint(request: MoneyWeightedReturnAnalyticsRequest):
         notes=mwr_result.notes,
     )
     audit = Audit(counts={"cashflows": len(mwr_request.cash_flows)})
+    calculation_supportability = build_calculation_supportability(
+        input_row_count=len(mwr_request.cash_flows) + 2,
+        resolved_period_count=1,
+        latest_observation_date=mwr_result.end_date,
+        report_end_date=mwr_request.as_of,
+        minimum_input_row_count=2,
+    )
+    record_supportability_metric(operation="mwr", supportability=calculation_supportability)
 
     response_payload = {
         "calculation_id": request.calculation_id,
@@ -644,6 +656,7 @@ async def calculate_mwr_endpoint(request: MoneyWeightedReturnAnalyticsRequest):
         "notes": mwr_result.notes,
         "convergence": mwr_result.convergence,
         "cashflows_used": mwr_request.cash_flows if mwr_request.emit_cashflows_used else None,
+        "calculation_supportability": calculation_supportability,
         "meta": meta,
         "diagnostics": diagnostics,
         "audit": audit,

--- a/app/models/attribution_responses.py
+++ b/app/models/attribution_responses.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.models.attribution_analytics_requests import AttributionInputMode
+from app.models.responses import PerformanceCalculationSupportability
 from common.enums import AttributionModel, LinkingMethod
 from core.envelope import Audit, Diagnostics, Meta
 
@@ -201,6 +202,12 @@ class AttributionResponse(BaseModel):
     benchmark_context: Optional[AttributionBenchmarkContext] = Field(
         default=None,
         description="Resolved benchmark context when the request sourced a benchmark.",
+    )
+    calculation_supportability: PerformanceCalculationSupportability = Field(
+        description=(
+            "Bounded supportability state for completed attribution output, including source freshness and "
+            "resolved input and benchmark counts used by front-office degraded-state handling."
+        )
     )
 
     meta: Meta = Field(description="Shared metadata envelope for the calculation.")

--- a/app/models/contribution_responses.py
+++ b/app/models/contribution_responses.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.models.contribution_analytics_requests import ContributionInputMode
+from app.models.responses import PerformanceCalculationSupportability
 from core.envelope import Audit, Diagnostics, Meta
 
 
@@ -219,6 +220,12 @@ class ContributionResponse(BaseModel):
 
     results_by_period: Dict[str, SinglePeriodContributionResult] = Field(
         description="Per-period contribution outputs. Contribution and return figures are emitted in percentage-point output units unless explicitly labeled otherwise."
+    )
+    calculation_supportability: PerformanceCalculationSupportability = Field(
+        description=(
+            "Bounded supportability state for completed contribution output, including source freshness and "
+            "resolved-input counts used by front-office degraded-state handling."
+        )
     )
 
     # Shared footer

--- a/app/models/mwr_responses.py
+++ b/app/models/mwr_responses.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from app.models.mwr_analytics_requests import MWRInputMode
 from app.models.mwr_requests import CashFlow
+from app.models.responses import PerformanceCalculationSupportability
 from core.envelope import Audit, Diagnostics, Meta
 
 
@@ -67,6 +68,12 @@ class MoneyWeightedReturnResponse(BaseModel):
     start_date: date = Field(description="Inclusive start date for the evaluated window.", examples=["2026-01-01"])
     end_date: date = Field(description="Inclusive end date for the evaluated window.", examples=["2026-03-31"])
     notes: List[str] = Field(description="Method or validation notes returned by the engine.")
+    calculation_supportability: PerformanceCalculationSupportability = Field(
+        description=(
+            "Bounded supportability state for completed MWR output, including source freshness and "
+            "resolved-input counts used by front-office degraded-state handling."
+        )
+    )
 
     meta: Meta = Field(description="Shared metadata envelope for the calculation.")
     diagnostics: Diagnostics = Field(description="Diagnostic details for the calculation.")

--- a/app/services/attribution_service.py
+++ b/app/services/attribution_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pandas as pd
 from fastapi import HTTPException, status
 
@@ -7,6 +9,10 @@ from app.core.config import get_settings
 from app.models.attribution_analytics_requests import AttributionInputMode
 from app.models.attribution_requests import AttributionRequest
 from app.models.attribution_responses import AttributionResponse
+from app.services.calculation_supportability_service import (
+    build_calculation_supportability,
+    record_supportability_metric,
+)
 from app.services.execution_lifecycle_service import (
     complete_execution_with_lineage,
     record_execution_failure,
@@ -16,6 +22,35 @@ from core.envelope import Meta
 from core.periods import resolve_periods
 from engine.attribution import aggregate_attribution_results, run_attribution_calculations
 from engine.exceptions import EngineCalculationError, InvalidEngineInputError
+
+
+def _count_attribution_benchmark_rows(request: AttributionRequest) -> int:
+    return sum(len(group.observations) for group in request.benchmark_groups_data)
+
+
+def _count_attribution_input_rows(request: AttributionRequest) -> int:
+    portfolio_observations = len(request.portfolio_data.valuation_points) if request.portfolio_data is not None else 0
+    instrument_observations = sum(len(instrument.valuation_points) for instrument in (request.instruments_data or []))
+    portfolio_group_observations = sum(len(group.observations) for group in (request.portfolio_groups_data or []))
+    return (
+        portfolio_observations
+        + instrument_observations
+        + portfolio_group_observations
+        + _count_attribution_benchmark_rows(request)
+    )
+
+
+def _latest_attribution_observation_date(request: AttributionRequest):
+    dates: list[Any] = []
+    if request.portfolio_data is not None:
+        dates.extend(point.perf_date for point in request.portfolio_data.valuation_points)
+    for instrument in request.instruments_data or []:
+        dates.extend(point.perf_date for point in instrument.valuation_points)
+    for group in request.portfolio_groups_data or []:
+        dates.extend(observation.get("date") for observation in group.observations if observation.get("date"))
+    for group in request.benchmark_groups_data:
+        dates.extend(observation.date for observation in group.observations)
+    return max(pd.Timestamp(point).date() for point in dates) if dates else None
 
 
 def calculate_attribution(
@@ -84,6 +119,14 @@ def calculate_attribution(
             input_fingerprint=input_fingerprint,
             calculation_hash=calculation_hash,
         )
+        calculation_supportability = build_calculation_supportability(
+            input_row_count=_count_attribution_input_rows(request),
+            resolved_period_count=len(results_by_period),
+            latest_observation_date=_latest_attribution_observation_date(request),
+            report_end_date=request.report_end_date,
+            benchmark_row_count=_count_attribution_benchmark_rows(request),
+        )
+        record_supportability_metric(operation="attribution", supportability=calculation_supportability)
 
         response_model = AttributionResponse(
             calculation_id=request.calculation_id,
@@ -100,6 +143,7 @@ def calculate_attribution(
                 if resolved_benchmark_id is not None and resolved_benchmark_return_source is not None
                 else None
             ),
+            calculation_supportability=calculation_supportability,
             meta=meta,
         )
 

--- a/app/services/calculation_supportability_service.py
+++ b/app/services/calculation_supportability_service.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pandas as pd
+
+from app.models.responses import (
+    PerformanceCalculationSupportability,
+    PerformanceFreshnessBucket,
+    PerformanceSupportabilityReason,
+    PerformanceSupportabilityState,
+)
+from app.observability import record_calculation_supportability
+
+
+def resolve_freshness_bucket(
+    *,
+    latest_observation_date: Any,
+    report_end_date: Any,
+) -> PerformanceFreshnessBucket:
+    if latest_observation_date is None or report_end_date is None:
+        return "unknown"
+    latest = pd.Timestamp(latest_observation_date).date()
+    expected = pd.Timestamp(report_end_date).date()
+    if latest >= expected:
+        return "current"
+    if latest == expected:
+        return "same_day"
+    return "stale"
+
+
+def build_calculation_supportability(
+    *,
+    input_row_count: int,
+    resolved_period_count: int,
+    report_end_date: date,
+    latest_observation_date: Any,
+    benchmark_row_count: int = 0,
+    minimum_input_row_count: int = 1,
+) -> PerformanceCalculationSupportability:
+    freshness_bucket = resolve_freshness_bucket(
+        latest_observation_date=latest_observation_date,
+        report_end_date=report_end_date,
+    )
+    state: PerformanceSupportabilityState
+    reason: PerformanceSupportabilityReason
+    if input_row_count < minimum_input_row_count:
+        state = "empty"
+        reason = "insufficient_valuation_points"
+    elif resolved_period_count <= 0:
+        state = "empty"
+        reason = "empty_resolved_periods"
+    elif freshness_bucket == "stale":
+        state = "stale"
+        reason = "stale_source_observations"
+    else:
+        state = "ready"
+        reason = "calculation_complete"
+
+    return PerformanceCalculationSupportability(
+        state=state,
+        reason=reason,
+        freshness_bucket=freshness_bucket,
+        input_row_count=input_row_count,
+        resolved_period_count=resolved_period_count,
+        benchmark_row_count=benchmark_row_count,
+    )
+
+
+def record_supportability_metric(
+    *,
+    operation: str,
+    supportability: PerformanceCalculationSupportability,
+) -> None:
+    record_calculation_supportability(
+        operation=operation,
+        supportability_state=supportability.state,
+        reason=supportability.reason,
+        freshness_bucket=supportability.freshness_bucket,
+    )

--- a/app/services/contribution_service.py
+++ b/app/services/contribution_service.py
@@ -17,6 +17,10 @@ from app.models.contribution_responses import (
     PositionDailyContribution,
     SinglePeriodContributionResult,
 )
+from app.services.calculation_supportability_service import (
+    build_calculation_supportability,
+    record_supportability_metric,
+)
 from app.services.execution_lifecycle_service import (
     complete_execution_with_lineage,
     record_execution_failure,
@@ -942,6 +946,19 @@ def _classify_average_weight_shadow_cutover_blockers(
     return blockers
 
 
+def _count_contribution_input_rows(request: ContributionRequest) -> int:
+    return len(request.portfolio_data.valuation_points) + sum(
+        len(position.valuation_points) for position in request.positions_data
+    )
+
+
+def _latest_contribution_observation_date(request: ContributionRequest):
+    dates = [point.perf_date for point in request.portfolio_data.valuation_points]
+    for position in request.positions_data:
+        dates.extend(point.perf_date for point in position.valuation_points)
+    return max(dates) if dates else None
+
+
 def calculate_contribution(
     request: ContributionRequest,
     *,
@@ -1591,12 +1608,20 @@ def calculate_contribution(
             **position_flow_balance_counts,
         }
     )
+    calculation_supportability = build_calculation_supportability(
+        input_row_count=_count_contribution_input_rows(request),
+        resolved_period_count=len(results_by_period),
+        latest_observation_date=_latest_contribution_observation_date(request),
+        report_end_date=request.report_end_date,
+    )
+    record_supportability_metric(operation="contribution", supportability=calculation_supportability)
 
     response_model = ContributionResponse(
         calculation_id=request.calculation_id,
         portfolio_id=request.portfolio_id,
         input_mode=input_mode,
         results_by_period=results_by_period,
+        calculation_supportability=calculation_supportability,
         meta=meta,
         diagnostics=diagnostics,
         audit=audit,

--- a/app/services/twr_service.py
+++ b/app/services/twr_service.py
@@ -16,16 +16,17 @@ from app.models.responses import (
     ComparativeReturnValue,
     ComparativeSummary,
     PerformanceCalculationSupportability,
-    PerformanceFreshnessBucket,
     PerformanceResponse,
-    PerformanceSupportabilityReason,
     PortfolioReturnDecomposition,
     SinglePeriodPerformanceResult,
     TWRBenchmarkContext,
 )
 from app.models.twr_requests import TWRInputMode
-from app.observability import record_calculation_supportability
 from app.services.benchmark_calculation_service import calculate_benchmark_artifacts
+from app.services.calculation_supportability_service import (
+    build_calculation_supportability,
+    record_supportability_metric,
+)
 from app.services.execution_lifecycle_service import complete_execution_with_lineage
 from app.services.execution_registry import execution_registry
 from common.enums import Frequency
@@ -361,18 +362,6 @@ def _get_benchmark_cumulative_return_to_date(
     return _calculate_benchmark_return_from_slice(cumulative_rows)
 
 
-def _resolve_freshness_bucket(*, latest_observation_date, report_end_date) -> PerformanceFreshnessBucket:
-    if latest_observation_date is None or report_end_date is None:
-        return "unknown"
-    latest = pd.Timestamp(latest_observation_date).date()
-    expected = pd.Timestamp(report_end_date).date()
-    if latest >= expected:
-        return "current"
-    if latest == expected:
-        return "same_day"
-    return "stale"
-
-
 def _resolve_twr_supportability(
     *,
     performance_request: PerformanceRequest,
@@ -384,30 +373,13 @@ def _resolve_twr_supportability(
     latest_observation_date = None
     if daily_results_df is not None and not daily_results_df.empty:
         latest_observation_date = daily_results_df[PortfolioColumns.PERF_DATE.value].max()
-    freshness_bucket = _resolve_freshness_bucket(
-        latest_observation_date=latest_observation_date,
-        report_end_date=performance_request.report_end_date,
-    )
-    if input_row_count < 2:
-        state = "empty"
-        reason: PerformanceSupportabilityReason = "insufficient_valuation_points"
-    elif not results_by_period:
-        state = "empty"
-        reason = "empty_resolved_periods"
-    elif freshness_bucket == "stale":
-        state = "stale"
-        reason = "stale_source_observations"
-    else:
-        state = "ready"
-        reason = "calculation_complete"
-
-    return PerformanceCalculationSupportability(
-        state=state,
-        reason=reason,
-        freshness_bucket=freshness_bucket,
+    return build_calculation_supportability(
         input_row_count=input_row_count,
         resolved_period_count=len(results_by_period),
+        latest_observation_date=latest_observation_date,
+        report_end_date=performance_request.report_end_date,
         benchmark_row_count=benchmark_row_count,
+        minimum_input_row_count=2,
     )
 
 
@@ -564,11 +536,9 @@ def calculate_twr_response(
         daily_results_df=daily_results_df,
         benchmark_row_count=benchmark_row_count,
     )
-    record_calculation_supportability(
+    record_supportability_metric(
         operation="twr",
-        supportability_state=calculation_supportability.state,
-        reason=calculation_supportability.reason,
-        freshness_bucket=calculation_supportability.freshness_bucket,
+        supportability=calculation_supportability,
     )
 
     response_model = PerformanceResponse(

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-04-29T09:15:36.485751+00:00",
+  "generatedAt": "2026-04-30T05:54:54.104836+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.account_reset_shadow_days",
@@ -526,6 +526,20 @@
       ]
     },
     {
+      "semanticId": "lotus.benchmark_row_count",
+      "canonicalTerm": "benchmark_row_count",
+      "preferredName": "benchmark_row_count",
+      "description": "Resolved benchmark observation count used when benchmark analytics were requested.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.benchmark_start_date",
       "canonicalTerm": "benchmark_start_date",
       "preferredName": "benchmark_start_date",
@@ -665,6 +679,22 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.calculation_supportability",
+      "canonicalTerm": "calculation_supportability",
+      "preferredName": "calculation_supportability",
+      "description": "performance calculation supportability object.",
+      "example": {
+        "key": "value"
+      },
+      "type": "PerformanceCalculationSupportability",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "PerformanceCalculationSupportability"
       ]
     },
     {
@@ -1849,6 +1879,20 @@
       ]
     },
     {
+      "semanticId": "lotus.freshness_bucket",
+      "canonicalTerm": "freshness_bucket",
+      "preferredName": "freshness_bucket",
+      "description": "Freshness bucket comparing resolved source observations with the requested report date.",
+      "example": "current",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.from_date",
       "canonicalTerm": "from_date",
       "preferredName": "from_date",
@@ -2198,6 +2242,20 @@
         "BenchmarkInputMode",
         "ContributionInputMode",
         "InputMode"
+      ]
+    },
+    {
+      "semanticId": "lotus.input_row_count",
+      "canonicalTerm": "input_row_count",
+      "preferredName": "input_row_count",
+      "description": "Resolved valuation observation count used by the calculation.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -3964,8 +4022,8 @@
       "semanticId": "lotus.reason",
       "canonicalTerm": "reason",
       "preferredName": "reason",
-      "description": "Concrete degradation trigger identifier.",
-      "example": "example_reason",
+      "description": "Bounded reason explaining the supportability state.",
+      "example": "calculation_complete",
       "type": "string",
       "locations": [
         "body"
@@ -4576,6 +4634,20 @@
       ],
       "observedTypes": [
         "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.resolved_period_count",
+      "canonicalTerm": "resolved_period_count",
+      "preferredName": "resolved_period_count",
+      "description": "Number of requested analysis periods that produced a result block.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -5258,6 +5330,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.state",
+      "canonicalTerm": "state",
+      "preferredName": "state",
+      "description": "Bounded supportability state for the completed performance calculation.",
+      "example": "ready",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -7781,6 +7867,62 @@
             "type": "array",
             "semanticId": "lotus.notes",
             "attributeRef": "#/attributeCatalog/lotus.notes"
+          },
+          {
+            "name": "calculation_supportability",
+            "location": "body",
+            "required": true,
+            "type": "PerformanceCalculationSupportability",
+            "semanticId": "lotus.calculation_supportability",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
+          },
+          {
+            "name": "calculation_supportability.state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.state",
+            "attributeRef": "#/attributeCatalog/lotus.state"
+          },
+          {
+            "name": "calculation_supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "calculation_supportability.freshness_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.freshness_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "calculation_supportability.input_row_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.input_row_count",
+            "attributeRef": "#/attributeCatalog/lotus.input_row_count"
+          },
+          {
+            "name": "calculation_supportability.resolved_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.resolved_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.resolved_period_count"
+          },
+          {
+            "name": "calculation_supportability.benchmark_row_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.benchmark_row_count",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_row_count"
           },
           {
             "name": "meta",

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-15T13:08:41Z",
+  "generated_at": "2026-04-30T05:56:07Z",
   "allowlist": [
     {
       "finding": "app/models/attribution_requests.py:56:weight_bop: float = Field(",
@@ -28,46 +28,46 @@
       "review_by": "2026-10-12"
     },
     {
-      "finding": "app/models/attribution_responses.py:114:total_active_return: float = Field(",
+      "finding": "app/models/attribution_responses.py:115:total_active_return: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/attribution_responses.py:153:weight_portfolio_avg: float = Field(",
+      "finding": "app/models/attribution_responses.py:154:weight_portfolio_avg: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/attribution_responses.py:157:weight_benchmark_avg: float = Field(",
+      "finding": "app/models/attribution_responses.py:158:weight_benchmark_avg: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/attribution_responses.py:18:portfolio_weight_avg: float = Field(",
+      "finding": "app/models/attribution_responses.py:19:portfolio_weight_avg: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-23"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/attribution_responses.py:22:benchmark_weight_avg: float = Field(",
+      "finding": "app/models/attribution_responses.py:23:benchmark_weight_avg: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-23"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/attribution_responses.py:26:portfolio_return: float = Field(",
+      "finding": "app/models/attribution_responses.py:27:portfolio_return: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-23"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/attribution_responses.py:30:benchmark_return: float = Field(",
+      "finding": "app/models/attribution_responses.py:31:benchmark_return: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-23"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "app/models/benchmark_analytics_requests.py:33:weight_bop: float = Field(",
@@ -214,28 +214,28 @@
       "review_by": "2026-10-12"
     },
     {
-      "finding": "app/models/contribution_responses.py:100:weight_avg: Optional[float] = Field(",
+      "finding": "app/models/contribution_responses.py:101:weight_avg: Optional[float] = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/contribution_responses.py:175:total_portfolio_return: Optional[float] = Field(",
+      "finding": "app/models/contribution_responses.py:176:total_portfolio_return: Optional[float] = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/contribution_responses.py:20:average_weight: float = Field(",
+      "finding": "app/models/contribution_responses.py:21:average_weight: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/contribution_responses.py:24:total_return: float = Field(description=\"Position return in percentage-point output units.\", examples=[4.96])",
+      "finding": "app/models/contribution_responses.py:25:total_return: float = Field(description=\"Position return in percentage-point output units.\", examples=[4.96])",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "app/models/mwr_requests.py:14:amount: float",
@@ -244,16 +244,16 @@
       "review_by": "2026-08-24"
     },
     {
-      "finding": "app/models/mwr_responses.py:28:mwr: float = Field(description=\"Money-weighted return in percentage-point output units.\", examples=[11.723])",
+      "finding": "app/models/mwr_responses.py:29:mwr: float = Field(description=\"Money-weighted return in percentage-point output units.\", examples=[11.723])",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/models/mwr_responses.py:50:money_weighted_return: float = Field(",
+      "finding": "app/models/mwr_responses.py:51:money_weighted_return: float = Field(",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "app/models/requests.py:39:end_mv: float = Field(..., description=\"The market value of the portfolio at the end of the day.\")",
@@ -418,52 +418,52 @@
       "review_by": "2026-09-17"
     },
     {
-      "finding": "app/services/contribution_service.py:343:current_average_weights[\"reset_aware_average_weight_shadow\"] = pd.Series(dtype=float)",
+      "finding": "app/services/contribution_service.py:347:current_average_weights[\"reset_aware_average_weight_shadow\"] = pd.Series(dtype=float)",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/contribution_service.py:42:return int(round(float(decimal_ratio) * 10000))",
+      "finding": "app/services/contribution_service.py:46:return int(round(float(decimal_ratio) * 10000))",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/contribution_service.py:47:return int(round(float(percentage_point_delta) * 100))",
+      "finding": "app/services/contribution_service.py:51:return int(round(float(percentage_point_delta) * 100))",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/contribution_service.py:60:return pd.Series(0, index=df.index, dtype=float)",
+      "finding": "app/services/contribution_service.py:626:allocation_weights = pd.Series(0.0, index=position_slice.index, dtype=float)",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/contribution_service.py:622:allocation_weights = pd.Series(0.0, index=position_slice.index, dtype=float)",
+      "finding": "app/services/contribution_service.py:628:allocation_weights = pd.Series(1.0, index=position_slice.index, dtype=float)",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/contribution_service.py:624:allocation_weights = pd.Series(1.0, index=position_slice.index, dtype=float)",
+      "finding": "app/services/contribution_service.py:64:return pd.Series(0, index=df.index, dtype=float)",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/contribution_service.py:778:threshold = max(0.0, float(request.emit.threshold_weight))",
+      "finding": "app/services/contribution_service.py:782:threshold = max(0.0, float(request.emit.threshold_weight))",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/contribution_service.py:851:float(pd.to_numeric(average_weight_series, errors=\"coerce\").fillna(0.0).sum()) * 100",
+      "finding": "app/services/contribution_service.py:855:float(pd.to_numeric(average_weight_series, errors=\"coerce\").fillna(0.0).sum()) * 100",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-12"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "app/services/stateful_benchmark_input_service.py:183:benchmark_return=float(point[\"benchmark_return\"]),",
@@ -526,22 +526,22 @@
       "review_by": "2026-09-17"
     },
     {
-      "finding": "app/services/twr_service.py:149:def _link_return_series(series: pd.Series) -> float:",
+      "finding": "app/services/twr_service.py:150:def _link_return_series(series: pd.Series) -> float:",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/twr_service.py:153:return float((running - Decimal(\"1\")) * Decimal(\"100\"))",
+      "finding": "app/services/twr_service.py:154:return float((running - Decimal(\"1\")) * Decimal(\"100\"))",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "app/services/twr_service.py:41:numeric = float(str(value))",
+      "finding": "app/services/twr_service.py:42:numeric = float(str(value))",
       "justification": "Temporary approved monetary floating-point usage; convert to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-09-17"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "core/annualize.py:9:def annualize_return(period_return: float, num_periods: int, periods_per_year: float, basis: BasisType) -> float:",

--- a/docs/technical/attribution-endpoint-certification.md
+++ b/docs/technical/attribution-endpoint-certification.md
@@ -89,6 +89,18 @@ Downstream certification status:
 - `lotus-gateway` issue `#105` tracks removal of the historical dependency on UI-side attribution
   total reconstruction once the lotus-performance totals contract is merged.
 
+## Supportability and Observability
+
+Completed attribution responses now include `calculation_supportability` with bounded `state`,
+`reason`, and `freshness_bucket` values plus input-row, resolved-period, and benchmark-row counts.
+The service also increments:
+
+`lotus_performance_calculation_supportability_total{operation="attribution",supportability_state,reason,freshness_bucket}`
+
+Use this block as the source-owned freshness and degraded-state signal for front-office attribution
+panels. The metric labels remain bounded and must not include portfolio, tenant, account, or
+security identifiers.
+
 ## Canonical Live Findings
 
 For `PB_SG_GLOBAL_BAL_001` as of `2026-04-10`, the stateful attribution endpoint now reconciles

--- a/docs/technical/contribution-endpoint-certification.md
+++ b/docs/technical/contribution-endpoint-certification.md
@@ -104,6 +104,18 @@ Current downstream consumers are:
 | `lotus-advise` through gateway-generated advisor brief context | Consumes Workbench performance contribution context rather than calling lotus-performance directly. | `lotus-gateway/src/app/services/advisor_brief_service.py` |
 | `lotus-risk` | Does not consume `/performance/contribution`; its contribution terminology is risk-component contribution and attribution, not performance contribution. | `lotus-risk` client search |
 
+## Supportability and Observability
+
+Completed contribution responses now include `calculation_supportability` with bounded `state`,
+`reason`, and `freshness_bucket` values plus input-row and resolved-period counts. The service also
+increments:
+
+`lotus_performance_calculation_supportability_total{operation="contribution",supportability_state,reason,freshness_bucket}`
+
+Use this block as the source-owned freshness and degraded-state signal for front-office contribution
+panels. The metric labels remain bounded and must not include portfolio, tenant, account, or
+security identifiers.
+
 ## GitHub Issue Disposition
 
 Open issue search for contribution currently finds only broad stateful-sourcing issue `#83`. That

--- a/docs/technical/mwr-endpoint-certification.md
+++ b/docs/technical/mwr-endpoint-certification.md
@@ -67,6 +67,17 @@ Downstream certification status:
   not a required summary display field.
 - No direct open gateway issue was found for MWR endpoint misuse during this pass.
 
+## Supportability and Observability
+
+Completed MWR responses now include `calculation_supportability` with bounded `state`, `reason`,
+and `freshness_bucket` values plus input-row and resolved-period counts. The service also increments:
+
+`lotus_performance_calculation_supportability_total{operation="mwr",supportability_state,reason,freshness_bucket}`
+
+Use this block as the source-owned freshness and degraded-state signal for front-office MWR panels.
+The metric labels remain bounded and must not include portfolio, tenant, account, or security
+identifiers.
+
 ## GitHub Issue Disposition
 
 Open issue search for MWR currently finds only broad stateful-sourcing issue `#83`. That issue

--- a/docs/technical/twr-endpoint-certification.md
+++ b/docs/technical/twr-endpoint-certification.md
@@ -55,9 +55,11 @@ The Prometheus metric is:
 
 `lotus_performance_calculation_supportability_total{operation,supportability_state,reason,freshness_bucket}`
 
-Current implemented operation scope is `operation="twr"`. Broader performance surfaces such as
-workspace summary, MWR, contribution, attribution, benchmark, and returns-series supportability
-remain separate implementation work and must not be inferred from this TWR proof.
+Implemented operation scope now includes `operation="twr"`, `operation="mwr"`,
+`operation="contribution"`, and `operation="attribution"` for completed synchronous calculations
+and completed async result payloads. Workspace summary, benchmark, and returns-series
+supportability remain separate implementation work and must not be inferred from this endpoint
+proof.
 
 ## Downstream Consumers
 

--- a/tests/integration/test_attribution_api.py
+++ b/tests/integration/test_attribution_api.py
@@ -134,7 +134,16 @@ def test_attribution_endpoint_by_instrument_happy_path(client):
 
     response = client.post("/performance/attribution", json=payload)
     assert response.status_code == 200
-    response_data = response.json()["results_by_period"]["ITD"]
+    body = response.json()
+    assert body["calculation_supportability"] == {
+        "state": "ready",
+        "reason": "calculation_complete",
+        "freshness_bucket": "current",
+        "input_row_count": 5,
+        "resolved_period_count": 1,
+        "benchmark_row_count": 2,
+    }
+    response_data = body["results_by_period"]["ITD"]
     assert response_data["reconciliation"]["total_active_return"] == pytest.approx(0.1)
     level = response_data["levels"][0]
     _assert_authoritative_level_totals(level)

--- a/tests/integration/test_contribution_api.py
+++ b/tests/integration/test_contribution_api.py
@@ -56,6 +56,14 @@ def test_contribution_endpoint_happy_path_and_envelope(client, happy_path_payloa
     assert response_data["portfolio_id"] == "CONTRIB_TEST_01"
     assert "results_by_period" in response_data
     assert "ITD" in response_data["results_by_period"]
+    assert response_data["calculation_supportability"] == {
+        "state": "ready",
+        "reason": "calculation_complete",
+        "freshness_bucket": "current",
+        "input_row_count": 4,
+        "resolved_period_count": 1,
+        "benchmark_row_count": 0,
+    }
 
 
 def test_contribution_endpoint_reports_zero_grouped_return_alignment_drift_for_simple_aligned_case(client):

--- a/tests/integration/test_mwr_api.py
+++ b/tests/integration/test_mwr_api.py
@@ -42,6 +42,14 @@ def test_calculate_mwr_endpoint_xirr_happy_path(client):
     assert response_data["method"] == "XIRR"
     assert response_data["money_weighted_return"] == pytest.approx(11.723, abs=1e-3)
     assert response_data["mwr_annualized"] is not None
+    assert response_data["calculation_supportability"] == {
+        "state": "ready",
+        "reason": "calculation_complete",
+        "freshness_bucket": "current",
+        "input_row_count": 4,
+        "resolved_period_count": 1,
+        "benchmark_row_count": 0,
+    }
 
 
 def test_calculate_mwr_endpoint_supports_stateful_mode(client, monkeypatch):

--- a/tests/integration/test_response_attribute_certification.py
+++ b/tests/integration/test_response_attribute_certification.py
@@ -151,6 +151,7 @@ def test_mwr_response_attributes_tie_to_deterministic_stateless_inputs(client):
         "start_date",
         "end_date",
         "notes",
+        "calculation_supportability",
         "meta",
         "diagnostics",
         "audit",
@@ -161,6 +162,14 @@ def test_mwr_response_attributes_tie_to_deterministic_stateless_inputs(client):
     assert body["start_date"] == "2026-01-02"
     assert body["end_date"] == "2026-01-03"
     assert body["notes"] == []
+    assert body["calculation_supportability"] == {
+        "state": "ready",
+        "reason": "calculation_complete",
+        "freshness_bucket": "current",
+        "input_row_count": 4,
+        "resolved_period_count": 1,
+        "benchmark_row_count": 0,
+    }
     assert body["cashflows_used"] == [
         {"amount": 100.0, "date": "2026-01-02"},
         {"amount": -20.0, "date": "2026-01-03"},

--- a/tests/unit/app/test_front_office_supportability_openapi_contract.py
+++ b/tests/unit/app/test_front_office_supportability_openapi_contract.py
@@ -1,0 +1,25 @@
+from main import app
+
+
+def test_front_office_calculation_surfaces_expose_supportability_contract() -> None:
+    spec = app.openapi()
+    schemas = spec["components"]["schemas"]
+
+    for schema_name in (
+        "MoneyWeightedReturnResponse",
+        "ContributionResponse",
+        "AttributionResponse",
+    ):
+        schema = schemas[schema_name]
+        assert "calculation_supportability" in schema["properties"]
+        assert "calculation_supportability" in schema["required"]
+
+    supportability_schema = schemas["PerformanceCalculationSupportability"]
+    assert set(supportability_schema["properties"]) >= {
+        "state",
+        "reason",
+        "freshness_bucket",
+        "input_row_count",
+        "resolved_period_count",
+        "benchmark_row_count",
+    }

--- a/tests/unit/app/test_mwr_openapi_contract.py
+++ b/tests/unit/app/test_mwr_openapi_contract.py
@@ -16,3 +16,6 @@ def test_mwr_openapi_explains_capital_timing_purpose_and_modes() -> None:
     assert "period Dietz return" in mwr_post["description"]
     assert "200" in mwr_post["responses"]
     assert "422" in mwr_post["responses"]
+    response_schema = spec["components"]["schemas"]["MoneyWeightedReturnResponse"]
+    assert "calculation_supportability" in response_schema["properties"]
+    assert "source freshness" in response_schema["properties"]["calculation_supportability"]["description"]

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -597,6 +597,24 @@ def test_workspace_summary_guide_documents_explicit_return_vocabulary():
     assert "it should not fabricate pseudo market values or pseudo cash flows" in rfc
 
 
+def test_front_office_supportability_docs_cover_all_completed_calculation_surfaces():
+    twr_certification = _read("docs/technical/twr-endpoint-certification.md")
+    mwr_certification = _read("docs/technical/mwr-endpoint-certification.md")
+    contribution_certification = _read("docs/technical/contribution-endpoint-certification.md")
+    attribution_certification = _read("docs/technical/attribution-endpoint-certification.md")
+    runbook = _read("wiki/Operations-Runbook.md")
+    repo_context = _read("REPOSITORY-ENGINEERING-CONTEXT.md")
+
+    for operation in ("twr", "mwr", "contribution", "attribution"):
+        assert f'operation="{operation}"' in twr_certification or f"`{operation}`" in runbook
+
+    assert 'operation="mwr"' in mwr_certification
+    assert 'operation="contribution"' in contribution_certification
+    assert 'operation="attribution"' in attribution_certification
+    assert "`calculation_supportability`" in repo_context
+    assert 'supportability_state="stale"' in runbook
+
+
 def test_workspace_summary_docs_publish_canonical_examples():
     api_reference = _read("docs/guides/api_reference.md")
     rfc = _read("docs/RFCs/RFC 044 - Interaction-Efficient Performance Workspace Analytics Contract.md")

--- a/tests/unit/models/test_contribution_models.py
+++ b/tests/unit/models/test_contribution_models.py
@@ -44,6 +44,14 @@ def base_response_footer():
             "effective_period_start": "2025-01-01",
         },
         "audit": {"counts": {"input_rows": 10}},
+        "calculation_supportability": {
+            "state": "ready",
+            "reason": "calculation_complete",
+            "freshness_bucket": "current",
+            "input_row_count": 3,
+            "resolved_period_count": 1,
+            "benchmark_row_count": 0,
+        },
     }
 
 

--- a/tests/unit/services/test_calculation_supportability_service.py
+++ b/tests/unit/services/test_calculation_supportability_service.py
@@ -1,0 +1,46 @@
+from datetime import date
+
+from app.services.calculation_supportability_service import build_calculation_supportability
+
+
+def test_calculation_supportability_marks_current_completed_calculation_ready() -> None:
+    supportability = build_calculation_supportability(
+        input_row_count=4,
+        resolved_period_count=1,
+        latest_observation_date=date(2026, 3, 31),
+        report_end_date=date(2026, 3, 31),
+        benchmark_row_count=2,
+    )
+
+    assert supportability.state == "ready"
+    assert supportability.reason == "calculation_complete"
+    assert supportability.freshness_bucket == "current"
+    assert supportability.input_row_count == 4
+    assert supportability.resolved_period_count == 1
+    assert supportability.benchmark_row_count == 2
+
+
+def test_calculation_supportability_marks_missing_periods_empty() -> None:
+    supportability = build_calculation_supportability(
+        input_row_count=4,
+        resolved_period_count=0,
+        latest_observation_date=date(2026, 3, 31),
+        report_end_date=date(2026, 3, 31),
+    )
+
+    assert supportability.state == "empty"
+    assert supportability.reason == "empty_resolved_periods"
+    assert supportability.freshness_bucket == "current"
+
+
+def test_calculation_supportability_marks_lagged_observations_stale() -> None:
+    supportability = build_calculation_supportability(
+        input_row_count=4,
+        resolved_period_count=1,
+        latest_observation_date=date(2026, 3, 29),
+        report_end_date=date(2026, 3, 31),
+    )
+
+    assert supportability.state == "stale"
+    assert supportability.reason == "stale_source_observations"
+    assert supportability.freshness_bucket == "stale"

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -18,16 +18,17 @@ Primary runtime surfaces:
 - `GET /performance/executions/{calculation_id}`
 - `GET /performance/lineage/{calculation_id}`
 
-## TWR supportability metric
+## Calculation supportability metric
 
-`POST /performance/twr` emits a bounded calculation supportability posture on completed
-synchronous responses and increments:
+Completed TWR, MWR, contribution, and attribution responses emit a bounded calculation
+supportability posture and increment:
 
-`lotus_performance_calculation_supportability_total{operation="twr",supportability_state,reason,freshness_bucket}`
+`lotus_performance_calculation_supportability_total{operation,supportability_state,reason,freshness_bucket}`
 
 Use `supportability_state="stale"` or `supportability_state="empty"` as operator attention signals
-for front-office TWR surfaces. The labels are intentionally bounded and must not carry portfolio,
-client, tenant, account, or security identifiers.
+for front-office performance surfaces. Current operation labels are `twr`, `mwr`, `contribution`,
+and `attribution`. The labels are intentionally bounded and must not carry portfolio, client,
+tenant, account, or security identifiers.
 
 ## Readiness semantics
 


### PR DESCRIPTION
## Summary
- add shared calculation supportability construction and metric recording for completed MWR, contribution, and attribution results
- keep TWR on the shared helper and require the supportability block in OpenAPI response contracts
- update API vocabulary, monetary-float baseline line references, docs, repo context, and wiki source for the expanded operation scope

## Evidence
- \\python -m pytest tests/unit/services/test_calculation_supportability_service.py tests/unit/models/test_contribution_models.py tests/unit/app/test_mwr_openapi_contract.py tests/unit/app/test_front_office_supportability_openapi_contract.py tests/unit/docs/test_public_docs_contract.py::test_front_office_supportability_docs_cover_all_completed_calculation_surfaces tests/integration/test_mwr_api.py::test_calculate_mwr_endpoint_xirr_happy_path tests/integration/test_contribution_api.py::test_contribution_endpoint_happy_path_and_envelope tests/integration/test_attribution_api.py::test_attribution_endpoint_by_instrument_happy_path\\ -> 25 passed
- \\python scripts\\openapi_quality_gate.py\\ -> passed
- \\python scripts\\api_vocabulary_inventory.py --validate-only\\ -> passed
- \\python scripts\\no_alias_contract_guard.py\\ -> passed
- \\python scripts\\validate_domain_data_product_contracts.py\\ -> passed
- \\python scripts\\check_monetary_float_usage.py\\ -> passed
- \\make check\\ -> 1157 unit tests passed after lint, mypy, OpenAPI, vocabulary, no-alias, monetary-float, and domain product gates

## Wiki
- Repo-authored wiki source changed: \\wiki/Operations-Runbook.md\\
- Pre-merge \\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance\\ reports expected drift for \\Operations-Runbook.md\\; publish after merge from repo source.