### PR TITLE
Emit backend freshness supportability metric

### DIFF
--- a/app/observability.py
+++ b/app/observability.py
@@ -21,6 +21,11 @@ PERFORMANCE_CALCULATION_SUPPORTABILITY_TOTAL = Counter(
     "Performance calculation supportability posture by operation, bounded reason, and freshness bucket.",
     ["operation", "supportability_state", "reason", "freshness_bucket"],
 )
+ANALYTICS_FRESHNESS_BUCKET_TOTAL = Counter(
+    "lotus_analytics_freshness_bucket_total",
+    "Backend analytics freshness and supportability posture by service, operation, and bounded freshness bucket.",
+    ["service", "operation", "freshness_bucket", "supportability_state"],
+)
 
 
 class JsonFormatter(logging.Formatter):
@@ -93,6 +98,20 @@ def record_calculation_supportability(
         supportability_state=supportability_state,
         reason=reason,
         freshness_bucket=freshness_bucket,
+    ).inc()
+
+
+def record_analytics_freshness_bucket(
+    *,
+    operation: str,
+    freshness_bucket: str,
+    supportability_state: str,
+) -> None:
+    ANALYTICS_FRESHNESS_BUCKET_TOTAL.labels(
+        service="lotus-performance",
+        operation=operation,
+        freshness_bucket=freshness_bucket,
+        supportability_state=supportability_state,
     ).inc()
 
 

--- a/app/services/calculation_supportability_service.py
+++ b/app/services/calculation_supportability_service.py
@@ -11,7 +11,7 @@ from app.models.responses import (
     PerformanceSupportabilityReason,
     PerformanceSupportabilityState,
 )
-from app.observability import record_calculation_supportability
+from app.observability import record_analytics_freshness_bucket, record_calculation_supportability
 
 
 def resolve_freshness_bucket(
@@ -78,4 +78,9 @@ def record_supportability_metric(
         supportability_state=supportability.state,
         reason=supportability.reason,
         freshness_bucket=supportability.freshness_bucket,
+    )
+    record_analytics_freshness_bucket(
+        operation=operation,
+        freshness_bucket=supportability.freshness_bucket,
+        supportability_state=supportability.state,
     )

--- a/docs/guides/twr.md
+++ b/docs/guides/twr.md
@@ -95,6 +95,8 @@ supportability block is the source-owned front-office posture for the calculatio
 
 The same posture is exported through
 `lotus_performance_calculation_supportability_total{operation="twr",supportability_state,reason,freshness_bucket}`.
+It also increments the RFC-0108 backend freshness counter
+`lotus_analytics_freshness_bucket_total{service="lotus-performance",operation="twr",freshness_bucket,supportability_state}`.
 Labels are intentionally bounded and must not include portfolio, client, tenant, account, or
 security identifiers.
 

--- a/tests/integration/test_performance_api.py
+++ b/tests/integration/test_performance_api.py
@@ -71,6 +71,11 @@ def test_twr_reports_reset_events_when_requested(client):
     assert 'supportability_state="ready"' in metrics.text
     assert 'reason="calculation_complete"' in metrics.text
     assert 'freshness_bucket="current"' in metrics.text
+    assert "lotus_analytics_freshness_bucket_total" in metrics.text
+    assert (
+        'lotus_analytics_freshness_bucket_total{freshness_bucket="current",'
+        'operation="twr",service="lotus-performance",supportability_state="ready"}'
+    ) in metrics.text
 
 
 def test_workspace_summary_endpoint_returns_multi_horizon_summary_blocks(client):

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -25,6 +25,10 @@ supportability posture and increment:
 
 `lotus_performance_calculation_supportability_total{operation,supportability_state,reason,freshness_bucket}`
 
+The same source-owned posture also increments the RFC-0108 cross-service freshness counter:
+
+`lotus_analytics_freshness_bucket_total{service="lotus-performance",operation,freshness_bucket,supportability_state}`
+
 Use `supportability_state="stale"` or `supportability_state="empty"` as operator attention signals
 for front-office performance surfaces. Current operation labels are `twr`, `mwr`, `contribution`,
 and `attribution`. The labels are intentionally bounded and must not carry portfolio, client,


### PR DESCRIPTION
## Summary
- emit RFC-0108 `lotus_analytics_freshness_bucket_total` from the existing performance calculation supportability path
- keep labels bounded to `service`, `operation`, `freshness_bucket`, and `supportability_state`
- update TWR and operations docs/wiki source with the new backend freshness signal

## Local proof
- `make lint`
- `make typecheck`
- `python -m pytest tests\integration\test_performance_api.py::test_twr_reports_reset_events_when_requested tests\unit\services\test_calculation_supportability_service.py -q`
- `make check`
- `git diff --check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance` reported expected branch-local drift in `Operations-Runbook.md`; publish is required after merge.