### PR TITLE
Harden performance supportability capability scope

### DIFF
--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -19,6 +19,12 @@ ConsumerSystem = Literal[
     "UNKNOWN",
 ]
 
+CALCULATION_SUPPORTABILITY_SURFACE_KEYS = ("twr", "mwr", "contribution", "attribution")
+CALCULATION_SUPPORTABILITY_DESCRIPTION = (
+    "Bounded TWR, MWR, contribution, and attribution calculation supportability response metadata "
+    "and Prometheus posture metrics."
+)
+
 INTEGRATION_CAPABILITIES_RESPONSE_EXAMPLES = [
     {
         "contract_version": "v1",
@@ -241,7 +247,7 @@ INTEGRATION_CAPABILITIES_RESPONSE_EXAMPLES = [
                 "key": "performance.observability.calculation_supportability",
                 "enabled": True,
                 "owner_service": "lotus-performance",
-                "description": "Bounded TWR calculation supportability response metadata and Prometheus posture metric.",
+                "description": CALCULATION_SUPPORTABILITY_DESCRIPTION,
             },
             {
                 "key": "performance.execution.stateful",
@@ -466,6 +472,15 @@ async def get_integration_capabilities(
     workspace_summary_enabled = _env_bool("PA_CAP_WORKSPACE_SUMMARY_ENABLED", True)
     stateful_mode_enabled = _env_bool("PLATFORM_INPUT_MODE_STATEFUL_ENABLED", True)
     stateless_mode_enabled = _env_bool("PLATFORM_INPUT_MODE_STATELESS_ENABLED", True)
+    calculation_supportability_surface_enabled = {
+        "twr": twr_enabled,
+        "mwr": mwr_enabled,
+        "contribution": contribution_enabled,
+        "attribution": attribution_enabled,
+    }
+    calculation_supportability_enabled = any(
+        calculation_supportability_surface_enabled[key] for key in CALCULATION_SUPPORTABILITY_SURFACE_KEYS
+    )
 
     features = [
         FeatureCapability(
@@ -518,9 +533,9 @@ async def get_integration_capabilities(
         ),
         FeatureCapability(
             key="performance.observability.calculation_supportability",
-            enabled=twr_enabled,
+            enabled=calculation_supportability_enabled,
             owner_service="lotus-performance",
-            description="Bounded TWR calculation supportability response metadata and Prometheus posture metric.",
+            description=CALCULATION_SUPPORTABILITY_DESCRIPTION,
         ),
         FeatureCapability(
             key="performance.execution.stateful",

--- a/docs/examples/integration_capabilities_response.json
+++ b/docs/examples/integration_capabilities_response.json
@@ -244,7 +244,7 @@
       "owner_service": "lotus-performance"
     },
     {
-      "description": "Bounded TWR calculation supportability response metadata and Prometheus posture metric.",
+      "description": "Bounded TWR, MWR, contribution, and attribution calculation supportability response metadata and Prometheus posture metrics.",
       "enabled": true,
       "key": "performance.observability.calculation_supportability",
       "owner_service": "lotus-performance"

--- a/docs/technical/integration-capabilities-endpoint-certification.md
+++ b/docs/technical/integration-capabilities-endpoint-certification.md
@@ -73,6 +73,11 @@ Certified surface keys:
 - `returns_series`
 - `benchmark_exposure_context`
 
+`performance.observability.calculation_supportability` is the shared feature key for the
+implemented TWR, MWR, contribution, and attribution calculation supportability posture. It remains
+enabled when any of those calculation surfaces is enabled; disabling only TWR must not hide
+supportability posture for MWR, contribution, or attribution.
+
 ## Behavior And Feature Controls
 
 Environment controls:

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -116,12 +116,16 @@ def test_integration_capabilities_default_contract():
         "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported",
         "ISSUER remains gated until benchmark issuer exposure semantics are approved",
     ]
-    features = {item["key"] for item in body["features"]}
+    features = {item["key"]: item for item in body["features"]}
     assert "performance.analytics.benchmark" in features
     assert "performance.integration.benchmark_exposure_context" in features
     assert "performance.analytics.workspace_summary" in features
     assert "performance.support.twr_inspection" in features
-    assert "performance.observability.calculation_supportability" in features
+    assert features["performance.observability.calculation_supportability"]["enabled"] is True
+    assert (
+        features["performance.observability.calculation_supportability"]["description"]
+        == "Bounded TWR, MWR, contribution, and attribution calculation supportability response metadata and Prometheus posture metrics."
+    )
     assert "performance.execution.stateful" in features
     assert "performance.execution.stateless" in features
     assert response.headers.get("X-Correlation-Id")
@@ -161,6 +165,25 @@ def test_integration_capabilities_env_override(monkeypatch):
         == "/performance/workspace-summary/results/{calculation_id}"
     )
     assert {item["key"] for item in surfaces["workspace_summary"]["options"]} == {"benchmark_mode"}
+
+
+def test_integration_capabilities_keeps_supportability_enabled_when_twr_is_disabled(monkeypatch):
+    monkeypatch.setenv("PA_CAP_TWR_ENABLED", "false")
+
+    with TestClient(app) as client:
+        response = client.get("/integration/capabilities?consumer_system=lotus-gateway&tenant_id=default")
+
+    assert response.status_code == 200
+    body = response.json()
+    features = {item["key"]: item for item in body["features"]}
+    surfaces = {item["key"]: item for item in body["analytics_surfaces"]}
+
+    assert surfaces["twr"]["enabled"] is False
+    assert surfaces["mwr"]["enabled"] is True
+    assert surfaces["contribution"]["enabled"] is True
+    assert surfaces["attribution"]["enabled"] is True
+    assert features["performance.support.twr_inspection"]["enabled"] is False
+    assert features["performance.observability.calculation_supportability"]["enabled"] is True
 
 
 def test_integration_capabilities_honors_canonical_query_controls():

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -373,6 +373,7 @@ def test_api_reference_documents_endpoint_level_capabilities_contract():
     assert "lotus-gateway#109" in certification
     assert "Downstream Consumers" in certification
     assert "Test Pyramid Assessment" in certification
+    assert "implemented TWR, MWR, contribution, and attribution calculation supportability posture" in certification
     assert {surface["key"] for surface in example["analytics_surfaces"]} == {
         "twr",
         "twr_inspection",
@@ -613,6 +614,10 @@ def test_front_office_supportability_docs_cover_all_completed_calculation_surfac
     assert 'operation="attribution"' in attribution_certification
     assert "`calculation_supportability`" in repo_context
     assert 'supportability_state="stale"' in runbook
+    assert (
+        "Bounded TWR, MWR, contribution, and attribution calculation supportability response metadata and Prometheus posture metrics."
+        in _read("docs/examples/integration_capabilities_response.json")
+    )
 
 
 def test_workspace_summary_docs_publish_canonical_examples():


### PR DESCRIPTION
## Summary
- Corrects `performance.observability.calculation_supportability` so capability discovery stays enabled when any implemented calculation supportability surface is enabled, not only TWR.
- Updates the capability description and example payload to cover TWR, MWR, contribution, and attribution.
- Adds regression coverage for the TWR-disabled/MWR-still-supported case and docs proof for the certified scope.

## RFC-0108 Scope
This is a narrow RFC-0108 supportability truth slice for `lotus-performance` capability discovery. The underlying TWR, MWR, contribution, and attribution response/metric supportability behavior was already implementation-backed; this PR fixes the integration capability contract so Gateway/Workbench consumers are not given stale TWR-only posture.

## Validation
- `python -m pytest tests\integration\test_integration_capabilities_api.py tests\unit\docs\test_public_docs_contract.py -q` => 55 passed
- `python scripts\openapi_quality_gate.py` => passed
- `python scripts\api_vocabulary_inventory.py --validate-only` => passed, no drift
- `python -m mypy --config-file mypy.ini app\api\endpoints\integration_capabilities.py` => passed
- `python -m ruff check app\api\endpoints\integration_capabilities.py tests\integration\test_integration_capabilities_api.py tests\unit\docs\test_public_docs_contract.py` => passed
- `python -m ruff format --check app\api\endpoints\integration_capabilities.py tests\integration\test_integration_capabilities_api.py tests\unit\docs\test_public_docs_contract.py` => passed
- `make check` => passed, including lint/format, monetary float guard, no-alias guard, mypy, OpenAPI gate, API vocabulary gate, domain-product validation, and `tests/unit` (1157 passed, 60 warnings)
- `git diff --check` => passed

## Wiki
No repo-local wiki source change. `wiki/Operations-Runbook.md` already states that TWR, MWR, contribution, and attribution emit the calculation supportability metric and bounded labels; this PR fixes the API capability contract to match that existing wiki truth.