### PR TITLE
Harden performance supportability metric labels

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -41,9 +41,11 @@ Current repository posture:
    posture and the optional `support_brief.md` artifact without making the inspection verdict
    dependent on Lotus AI availability,
 8. completed TWR, MWR, contribution, and attribution responses expose the shared
-   `calculation_supportability` block and emit the bounded
+   `calculation_supportability` block, publish the allowed `metric_labels`, and emit the bounded
    `lotus_performance_calculation_supportability_total` metric for front-office freshness and
-   degraded-state handling.
+   degraded-state handling. Tests prove the Prometheus exposition uses only bounded labels and does
+   not promote portfolio, account, client, trace, correlation, calculation, benchmark, security, or
+   request/response payload values into metric labels.
 
 ## Architecture And Module Map
 

--- a/app/models/responses.py
+++ b/app/models/responses.py
@@ -168,6 +168,8 @@ PerformanceSupportabilityReason = Literal[
 ]
 PerformanceFreshnessBucket = Literal["current", "same_day", "stale", "unknown"]
 
+from app.observability_contracts import PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS  # noqa: E402
+
 
 class PerformanceCalculationSupportability(BaseModel):
     state: PerformanceSupportabilityState = Field(
@@ -199,6 +201,16 @@ class PerformanceCalculationSupportability(BaseModel):
         ge=0,
         description="Resolved benchmark observation count used when benchmark analytics were requested.",
         examples=[252],
+    )
+    metric_labels: tuple[str, ...] = Field(
+        default=PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
+        description=(
+            "Bounded Prometheus label keys emitted by "
+            "lotus_performance_calculation_supportability_total. Identifiers, trace or correlation values, "
+            "and request or response payload fields must not be metric labels."
+        ),
+        examples=[list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)],
+        json_schema_extra={"example": list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)},
     )
 
 

--- a/app/observability.py
+++ b/app/observability.py
@@ -10,6 +10,10 @@ from fastapi import FastAPI, Request
 from prometheus_client import REGISTRY, Counter
 from prometheus_fastapi_instrumentator import Instrumentator
 
+from app.observability_contracts import (
+    PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS,
+    PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
+)
 from app.services.queue_metrics_service import DurableQueueCollector
 
 correlation_id_var: ContextVar[str] = ContextVar("correlation_id", default="")
@@ -19,12 +23,12 @@ trace_id_var: ContextVar[str] = ContextVar("trace_id", default="")
 PERFORMANCE_CALCULATION_SUPPORTABILITY_TOTAL = Counter(
     "lotus_performance_calculation_supportability_total",
     "Performance calculation supportability posture by operation, bounded reason, and freshness bucket.",
-    ["operation", "supportability_state", "reason", "freshness_bucket"],
+    PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
 )
 ANALYTICS_FRESHNESS_BUCKET_TOTAL = Counter(
     "lotus_analytics_freshness_bucket_total",
     "Backend analytics freshness and supportability posture by service, operation, and bounded freshness bucket.",
-    ["service", "operation", "freshness_bucket", "supportability_state"],
+    PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS,
 )
 
 

--- a/app/observability_contracts.py
+++ b/app/observability_contracts.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS: tuple[str, ...] = (
+    "operation",
+    "supportability_state",
+    "reason",
+    "freshness_bucket",
+)
+
+PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS: tuple[str, ...] = (
+    "service",
+    "operation",
+    "freshness_bucket",
+    "supportability_state",
+)

--- a/docs/guides/twr.md
+++ b/docs/guides/twr.md
@@ -92,13 +92,15 @@ supportability block is the source-owned front-office posture for the calculatio
   `stale_source_observations`, or `insufficient_valuation_points`
 - `freshness_bucket`: `current`, `same_day`, `stale`, or `unknown`
 - `input_row_count`, `resolved_period_count`, and `benchmark_row_count`
+- `metric_labels`: the bounded Prometheus label keys emitted for supportability metrics
 
 The same posture is exported through
 `lotus_performance_calculation_supportability_total{operation="twr",supportability_state,reason,freshness_bucket}`.
 It also increments the RFC-0108 backend freshness counter
 `lotus_analytics_freshness_bucket_total{service="lotus-performance",operation="twr",freshness_bucket,supportability_state}`.
-Labels are intentionally bounded and must not include portfolio, client, tenant, account, or
-security identifiers.
+Labels are intentionally bounded and must not include portfolio, client, tenant, account, benchmark,
+calculation, trace, correlation, request body, response body, or security identifiers. Tests assert
+that the response contract and Prometheus exposition stay aligned.
 
 Benchmark requests support the same benchmark modes as the dedicated benchmark endpoint:
 

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-04-30T05:54:54.104836+00:00",
+  "generatedAt": "2026-05-01T13:22:57.397291+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.account_reset_shadow_days",
@@ -2998,6 +2998,25 @@
       "observedTypes": [
         "string",
         "MetricBasis"
+      ]
+    },
+    {
+      "semanticId": "lotus.metric_labels",
+      "canonicalTerm": "metric_labels",
+      "preferredName": "metric_labels",
+      "description": "Bounded Prometheus label keys emitted by lotus_performance_calculation_supportability_total. Identifiers, trace or correlation values, and request or response payload fields must not be metric labels.",
+      "example": [
+        "operation",
+        "supportability_state",
+        "reason",
+        "freshness_bucket"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -7923,6 +7942,14 @@
             "type": "integer",
             "semanticId": "lotus.benchmark_row_count",
             "attributeRef": "#/attributeCatalog/lotus.benchmark_row_count"
+          },
+          {
+            "name": "calculation_supportability.metric_labels",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.metric_labels",
+            "attributeRef": "#/attributeCatalog/lotus.metric_labels"
           },
           {
             "name": "meta",

--- a/docs/technical/attribution-endpoint-certification.md
+++ b/docs/technical/attribution-endpoint-certification.md
@@ -98,8 +98,9 @@ The service also increments:
 `lotus_performance_calculation_supportability_total{operation="attribution",supportability_state,reason,freshness_bucket}`
 
 Use this block as the source-owned freshness and degraded-state signal for front-office attribution
-panels. The metric labels remain bounded and must not include portfolio, tenant, account, or
-security identifiers.
+panels. The response publishes `calculation_supportability.metric_labels` with the same bounded
+label keys used by the metric. The metric labels must not include portfolio, tenant, account,
+benchmark, calculation, trace, correlation, request body, response body, or security identifiers.
 
 ## Canonical Live Findings
 

--- a/docs/technical/contribution-endpoint-certification.md
+++ b/docs/technical/contribution-endpoint-certification.md
@@ -113,8 +113,9 @@ increments:
 `lotus_performance_calculation_supportability_total{operation="contribution",supportability_state,reason,freshness_bucket}`
 
 Use this block as the source-owned freshness and degraded-state signal for front-office contribution
-panels. The metric labels remain bounded and must not include portfolio, tenant, account, or
-security identifiers.
+panels. The response publishes `calculation_supportability.metric_labels` with the same bounded
+label keys used by the metric. The metric labels must not include portfolio, tenant, account,
+benchmark, calculation, trace, correlation, request body, response body, or security identifiers.
 
 ## GitHub Issue Disposition
 

--- a/docs/technical/mwr-endpoint-certification.md
+++ b/docs/technical/mwr-endpoint-certification.md
@@ -75,8 +75,9 @@ and `freshness_bucket` values plus input-row and resolved-period counts. The ser
 `lotus_performance_calculation_supportability_total{operation="mwr",supportability_state,reason,freshness_bucket}`
 
 Use this block as the source-owned freshness and degraded-state signal for front-office MWR panels.
-The metric labels remain bounded and must not include portfolio, tenant, account, or security
-identifiers.
+The response publishes `calculation_supportability.metric_labels` with the same bounded label keys
+used by the metric. The metric labels must not include portfolio, tenant, account, benchmark,
+calculation, trace, correlation, request body, response body, or security identifiers.
 
 ## GitHub Issue Disposition
 

--- a/docs/technical/twr-endpoint-certification.md
+++ b/docs/technical/twr-endpoint-certification.md
@@ -55,6 +55,12 @@ The Prometheus metric is:
 
 `lotus_performance_calculation_supportability_total{operation,supportability_state,reason,freshness_bucket}`
 
+The response also publishes `calculation_supportability.metric_labels` with the same bounded label
+keys so Gateway, Workbench, and operators can inspect the service-owned label contract without
+scraping Prometheus metadata. The implementation-backed proof covers both the JSON response and the
+actual Prometheus exposition, and verifies that portfolio, account, client, benchmark, calculation,
+security, trace, correlation, request body, and response body values are not labels.
+
 Implemented operation scope now includes `operation="twr"`, `operation="mwr"`,
 `operation="contribution"`, and `operation="attribution"` for completed synchronous calculations
 and completed async result payloads. Workspace summary, benchmark, and returns-series

--- a/tests/integration/test_attribution_api.py
+++ b/tests/integration/test_attribution_api.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from app.core.config import get_settings
 from app.models.attribution_analytics_requests import AttributionAnalyticsRequest
 from app.models.benchmark_requests import BenchmarkComponentObservation
+from app.observability_contracts import PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from app.services.async_result_store import async_result_store
 from app.services.attribution_mode_service import resolve_attribution_request
 from app.services.compute_job_store import compute_job_store
@@ -23,6 +24,7 @@ from main import app
 from tests.conftest import drain_compute_queue, drain_lineage_queue
 
 settings = get_settings()
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
 
 def _stateful_benchmark_input(*observations: BenchmarkComponentObservation) -> StatefulBenchmarkNormalizedInput:
@@ -142,6 +144,7 @@ def test_attribution_endpoint_by_instrument_happy_path(client):
         "input_row_count": 5,
         "resolved_period_count": 1,
         "benchmark_row_count": 2,
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
     }
     response_data = body["results_by_period"]["ITD"]
     assert response_data["reconciliation"]["total_active_return"] == pytest.approx(0.1)

--- a/tests/integration/test_contribution_api.py
+++ b/tests/integration/test_contribution_api.py
@@ -10,6 +10,7 @@ from app.api.endpoints.contribution import _build_execution_window
 from app.core.config import get_settings
 from app.models.contribution_analytics_requests import ContributionAnalyticsRequest
 from app.models.contribution_requests import ContributionRequest
+from app.observability_contracts import PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from app.services.async_result_store import async_result_store
 from app.services.compute_job_store import compute_job_store
 from app.services.execution_registry import execution_registry
@@ -20,6 +21,7 @@ from main import app
 from tests.conftest import drain_compute_queue, drain_lineage_queue
 
 settings = get_settings()
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
 
 @pytest.fixture()
@@ -63,6 +65,7 @@ def test_contribution_endpoint_happy_path_and_envelope(client, happy_path_payloa
         "input_row_count": 4,
         "resolved_period_count": 1,
         "benchmark_row_count": 0,
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
     }
 
 

--- a/tests/integration/test_mwr_api.py
+++ b/tests/integration/test_mwr_api.py
@@ -6,9 +6,12 @@ from fastapi.testclient import TestClient
 
 from app.core.config import get_settings
 from app.models.mwr_requests import MoneyWeightedReturnRequest
+from app.observability_contracts import PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from core.repro import generate_canonical_hash
 from main import app
 from tests.conftest import drain_lineage_queue
+
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
 
 @pytest.fixture(scope="module")
@@ -49,6 +52,7 @@ def test_calculate_mwr_endpoint_xirr_happy_path(client):
         "input_row_count": 4,
         "resolved_period_count": 1,
         "benchmark_row_count": 0,
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
     }
 
 

--- a/tests/integration/test_performance_api.py
+++ b/tests/integration/test_performance_api.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from prometheus_client import REGISTRY, generate_latest
 
 from app.api.endpoints.performance import _generate_twr_request_hashes
 from app.core.config import get_settings
@@ -11,10 +12,29 @@ from app.models.benchmark_analytics_requests import BenchmarkInputMode
 from app.models.benchmark_requests import BenchmarkPerformanceRequest
 from app.models.requests import PerformanceRequest
 from app.models.twr_requests import TWRAnalyticsRequest, TWRResolvedExecutionRequest
+from app.observability_contracts import (
+    PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS,
+    PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
+)
 from app.services.twr_mode_service import ResolvedTWRRequest
 from core.repro import generate_canonical_hash_from_value
 from engine.exceptions import EngineCalculationError, InvalidEngineInputError
 from main import app
+
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
+_FORBIDDEN_METRIC_LABELS = {
+    "portfolio_id",
+    "account_id",
+    "client_id",
+    "correlation_id",
+    "trace_id",
+    "transaction_id",
+    "security_id",
+    "benchmark_id",
+    "calculation_id",
+    "request_body",
+    "response_body",
+}
 
 
 @pytest.fixture(scope="module")
@@ -62,6 +82,7 @@ def test_twr_reports_reset_events_when_requested(client):
         "input_row_count": 4,
         "resolved_period_count": 1,
         "benchmark_row_count": 0,
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
     }
 
     metrics = client.get("/metrics")
@@ -76,6 +97,46 @@ def test_twr_reports_reset_events_when_requested(client):
         'lotus_analytics_freshness_bucket_total{freshness_bucket="current",'
         'operation="twr",service="lotus-performance",supportability_state="ready"}'
     ) in metrics.text
+
+
+def test_twr_supportability_metric_labels_are_bounded_and_support_safe(client):
+    payload = {
+        "portfolio_id": "TWR_LABEL_BOUNDARY_TEST",
+        "performance_start_date": "2025-01-01",
+        "report_end_date": "2025-01-02",
+        "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
+        "metric_basis": "NET",
+        "valuation_points": [
+            {"perf_date": "2025-01-01", "begin_mv": 1000.0, "end_mv": 1010.0},
+            {"perf_date": "2025-01-02", "begin_mv": 1010.0, "end_mv": 1020.1},
+        ],
+    }
+
+    response = client.post("/performance/twr", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["calculation_supportability"]["metric_labels"] == _EXPECTED_SUPPORTABILITY_METRIC_LABELS
+    metrics_text = generate_latest(REGISTRY).decode("utf-8")
+    supportability_lines = [
+        line
+        for line in metrics_text.splitlines()
+        if line.startswith("lotus_performance_calculation_supportability_total{") and 'operation="twr"' in line
+    ]
+    freshness_lines = [
+        line
+        for line in metrics_text.splitlines()
+        if line.startswith("lotus_analytics_freshness_bucket_total{") and 'operation="twr"' in line
+    ]
+
+    assert supportability_lines
+    assert freshness_lines
+    for label in PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS:
+        assert f"{label}=" in supportability_lines[-1]
+    for label in PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS:
+        assert f"{label}=" in freshness_lines[-1]
+    for label in _FORBIDDEN_METRIC_LABELS:
+        assert f"{label}=" not in supportability_lines[-1]
+        assert f"{label}=" not in freshness_lines[-1]
 
 
 def test_workspace_summary_endpoint_returns_multi_horizon_summary_blocks(client):

--- a/tests/integration/test_response_attribute_certification.py
+++ b/tests/integration/test_response_attribute_certification.py
@@ -3,7 +3,10 @@ import math
 import pytest
 from fastapi.testclient import TestClient
 
+from app.observability_contracts import PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from main import app
+
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
 
 @pytest.fixture
@@ -78,6 +81,7 @@ def test_twr_response_attributes_tie_to_deterministic_stateless_inputs(client):
         "input_row_count": 3,
         "resolved_period_count": 1,
         "benchmark_row_count": 0,
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
     }
     assert body["audit"]["residual_applied_bp"] == 0.0
     assert body["diagnostics"]["effective_period_start"] == "2026-01-01"
@@ -169,6 +173,7 @@ def test_mwr_response_attributes_tie_to_deterministic_stateless_inputs(client):
         "input_row_count": 4,
         "resolved_period_count": 1,
         "benchmark_row_count": 0,
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
     }
     assert body["cashflows_used"] == [
         {"amount": 100.0, "date": "2026-01-02"},

--- a/tests/unit/app/test_front_office_supportability_openapi_contract.py
+++ b/tests/unit/app/test_front_office_supportability_openapi_contract.py
@@ -1,3 +1,4 @@
+from app.observability_contracts import PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from main import app
 
 
@@ -22,4 +23,9 @@ def test_front_office_calculation_surfaces_expose_supportability_contract() -> N
         "input_row_count",
         "resolved_period_count",
         "benchmark_row_count",
+        "metric_labels",
     }
+    metric_labels = supportability_schema["properties"]["metric_labels"]
+    assert metric_labels["default"] == list(PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
+    assert "lotus_performance_calculation_supportability_total" in metric_labels["description"]
+    assert "request or response payload fields must not be metric labels" in metric_labels["description"]

--- a/tests/unit/services/test_calculation_supportability_service.py
+++ b/tests/unit/services/test_calculation_supportability_service.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from app.observability_contracts import PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from app.services.calculation_supportability_service import build_calculation_supportability
 
 
@@ -18,6 +19,7 @@ def test_calculation_supportability_marks_current_completed_calculation_ready() 
     assert supportability.input_row_count == 4
     assert supportability.resolved_period_count == 1
     assert supportability.benchmark_row_count == 2
+    assert supportability.metric_labels == PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 
 
 def test_calculation_supportability_marks_missing_periods_empty() -> None:

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -25,6 +25,15 @@ supportability posture and increment:
 
 `lotus_performance_calculation_supportability_total{operation,supportability_state,reason,freshness_bucket}`
 
+The same response block includes `metric_labels` so downstream operators can see the exact
+Prometheus label set that the service owns:
+
+```json
+{
+  "metric_labels": ["operation", "supportability_state", "reason", "freshness_bucket"]
+}
+```
+
 The same source-owned posture also increments the RFC-0108 cross-service freshness counter:
 
 `lotus_analytics_freshness_bucket_total{service="lotus-performance",operation,freshness_bucket,supportability_state}`
@@ -32,7 +41,19 @@ The same source-owned posture also increments the RFC-0108 cross-service freshne
 Use `supportability_state="stale"` or `supportability_state="empty"` as operator attention signals
 for front-office performance surfaces. Current operation labels are `twr`, `mwr`, `contribution`,
 and `attribution`. The labels are intentionally bounded and must not carry portfolio, client,
-tenant, account, or security identifiers.
+tenant, account, benchmark, calculation, trace, correlation, request body, response body, or
+security identifiers.
+
+```mermaid
+flowchart LR
+    A[Performance calculation endpoint] --> B[calculation_supportability response block]
+    B --> C[Gateway source_supportability]
+    B --> D[lotus_performance_calculation_supportability_total]
+    B --> E[lotus_analytics_freshness_bucket_total]
+    D --> F[Platform dashboard and alerts]
+    E --> F
+    C --> G[Workbench performance support state]
+```
 
 ## Readiness semantics
 


### PR DESCRIPTION
## Summary
- Adds a shared RFC-0108 observability label contract for performance calculation supportability and analytics freshness metrics.
- Exposes `calculation_supportability.metric_labels` on completed TWR, MWR, contribution, and attribution responses, with OpenAPI and API vocabulary proof.
- Adds integration proof that real Prometheus exposition uses only bounded support-safe labels and excludes portfolio/account/client/security/benchmark/calculation/trace/correlation/request/response payload labels.
- Updates repo context, technical certification docs, TWR guide, and the operator wiki runbook with the implementation-backed metric-label flow and diagram.

## Local Evidence
- Focused behavior/OpenAPI/docs tests: `python -m pytest tests\integration\test_performance_api.py tests\integration\test_mwr_api.py tests\integration\test_contribution_api.py tests\integration\test_attribution_api.py tests\integration\test_response_attribute_certification.py tests\unit\app\test_front_office_supportability_openapi_contract.py tests\unit\services\test_calculation_supportability_service.py -q` -> 108 passed, 3 existing deprecation warnings.
- Docs contract tests: `python -m pytest tests\unit\docs\test_public_docs_contract.py tests\unit\app\test_front_office_supportability_openapi_contract.py tests\unit\services\test_calculation_supportability_service.py -q` -> 41 passed.
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-performance-api-vocabulary.v1.json` -> wrote regenerated inventory.
- `make lint` -> passed, including monetary float guard.
- `make typecheck` -> passed.
- `make openapi-gate` -> passed.
- `make api-vocabulary-gate` -> passed.
- `make no-alias-gate` -> passed.
- `make domain-product-validate` -> passed.
- `make migration-smoke` -> passed.
- `make test-unit` -> 1157 passed, existing warnings only.
- `make test-integration` -> 271 passed, existing warnings only.
- `make test-e2e` -> 21 passed.
- `make test-coverage` -> passed, total 99% coverage.
- `make security-audit` -> 0 known vulnerabilities.
- `make docker-build` -> passed, built `lotus-performance:ci`.
- `git diff --check` -> passed with line-ending notices only.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance` -> expected pre-merge drift on `Operations-Runbook.md`; publish after merge.

## Notes
- `make test-pyramid-gate` is not a Makefile target in lotus-performance; `make test-coverage` is the repo-native coverage/test-pyramid gate and passed.
- The observed pytest warnings are pre-existing HTTP 422 deprecation/resource warnings outside this RFC-0108 slice.