### PR TITLE
Document stateful MWR methodology source truth

### DIFF
--- a/docs/methodologies/metrics/master-index.md
+++ b/docs/methodologies/metrics/master-index.md
@@ -7,8 +7,8 @@ This index maps implemented lotus-performance metrics to detailed methodology do
 | TWR Base Return | POST /performance/twr | Stateless + Stateful | [metric-twr-base-return.md](./metric-twr-base-return.md) |
 | TWR Local Return | POST /performance/twr | Stateless + Stateful | [metric-twr-local-return.md](./metric-twr-local-return.md) |
 | TWR FX Return | POST /performance/twr | Stateless + Stateful | [metric-twr-fx-return.md](./metric-twr-fx-return.md) |
-| MWR (XIRR) | POST /performance/mwr | Stateless | [metric-mwr-xirr.md](./metric-mwr-xirr.md) |
-| MWR (Dietz fallback / explicit) | POST /performance/mwr | Stateless | [metric-mwr-dietz.md](./metric-mwr-dietz.md) |
+| MWR (XIRR) | POST /performance/mwr | Stateless + Stateful | [metric-mwr-xirr.md](./metric-mwr-xirr.md) |
+| MWR (Dietz fallback / explicit) | POST /performance/mwr | Stateless + Stateful | [metric-mwr-dietz.md](./metric-mwr-dietz.md) |
 | Position Total Contribution | POST /performance/contribution | Stateless | [metric-contribution-total.md](./metric-contribution-total.md) |
 | Position Local Contribution | POST /performance/contribution | Stateless | [metric-contribution-local.md](./metric-contribution-local.md) |
 | Position FX Contribution | POST /performance/contribution | Stateless | [metric-contribution-fx.md](./metric-contribution-fx.md) |
@@ -27,7 +27,10 @@ This index maps implemented lotus-performance metrics to detailed methodology do
 
 ## Notes
 - simulation mode is not exposed on lotus-performance public analytics contracts in this slice.
-- Stateful execution currently applies to the returns-series integration endpoint; core performance analytics endpoints remain request-data driven.
+- Stateful execution currently applies to the returns-series integration endpoint and to
+  `POST /performance/mwr`. Stateful MWR resolves lotus-core portfolio timeseries into canonical
+  MWR inputs and preserves source-owned capital-flow supportability instead of making downstream
+  consumers reconstruct investor cash-flow schedules.
 - In current engine behavior, `mwr_method=MODIFIED_DIETZ` is mapped to the same Dietz computation path as `DIETZ`.
 
 

--- a/docs/methodologies/metrics/metric-mwr-dietz.md
+++ b/docs/methodologies/metrics/metric-mwr-dietz.md
@@ -3,7 +3,10 @@ Money-Weighted Return via Dietz (`money_weighted_return` when method resolves to
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/mwr`
-- Request mode: stateless payload
+- Request modes:
+  - stateless payload (`stateless_input.begin_mv`, `stateless_input.end_mv`, `stateless_input.cash_flows[]`)
+  - legacy stateless top-level `begin_mv`, `end_mv`, and `cash_flows[]`
+  - stateful payload (`stateful_input.window_start_date`) resolved from lotus-core portfolio timeseries
 - Path coverage:
   - explicit request `mwr_method="DIETZ"` or `"MODIFIED_DIETZ"`
   - fallback when `mwr_method="XIRR"` fails sign/convergence checks
@@ -13,12 +16,21 @@ Money-Weighted Return via Dietz (`money_weighted_return` when method resolves to
 - `begin_mv`
 - `end_mv`
 - `cash_flows[]` (`amount`, `date`)
+- `start_date` when supplied directly or resolved from stateful normalization
 - `as_of`
 - `annualization.enabled`
 - `annualization.basis` (`ACT/ACT` or other -> 365.0)
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; all required values are supplied by the caller.
+- Stateful mode resolves source input from `lotus-core`
+  `POST /integration/portfolios/{portfolio_id}/analytics/portfolio-timeseries` through
+  `CORE_CONTROL_PLANE_BASE_URL`.
+- Stateful normalization uses first and last valid source observations for beginning and ending
+  market value, includes explicit external or missing-classified source cash-flow rows, adds
+  cross-observation carry-forward capital adjustments where beginning market value differs from the
+  prior valid ending market value, and excludes operational fee-classified rows from the investor
+  capital-flow schedule.
 
 ## Unit Conventions
 - Amount fields are currency amounts.
@@ -33,6 +45,8 @@ Money-Weighted Return via Dietz (`money_weighted_return` when method resolves to
 - `Num`: Dietz numerator
 - `r_D`: Dietz periodic return (decimal)
 - `r_A`: annualized return (decimal)
+- `S`: resolved start date (`stateful_input.window_start_date`, explicit `start_date`, or the
+  earliest cash-flow date when no start date is supplied)
 - `days`: `(as_of - start_date).days`
 - `ppy`: annualization factor (`365.25` for `ACT/ACT`, else `365.0`)
 
@@ -57,15 +71,23 @@ Money-Weighted Return via Dietz (`money_weighted_return` when method resolves to
 - `mwr_annualized = 100 * r_A` when annualized else null
 
 ## Step-by-Step Computation
-1. Determine `start_date` as min cash-flow date (or `as_of` if none); set `end_date = as_of`.
-2. Compute `CF_sum` from `cash_flows[]`.
-3. Compute `Den`; if zero, return deterministic zero-result branch.
-4. Compute `Num` and periodic Dietz return `r_D`.
-5. If annualization requested and period length positive, compute `r_A`.
-6. Return response with `method="DIETZ"` and notes (including fallback notes if applicable).
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio timeseries and
+   normalize it into `begin_mv`, `end_mv`, signed `cash_flows[]`, and `start_date`.
+2. Determine `start_date` from the resolved request; set `end_date = as_of`.
+3. Compute `CF_sum` from `cash_flows[]`.
+4. Compute `Den`; if zero, return deterministic zero-result branch.
+5. Compute `Num` and periodic Dietz return `r_D`.
+6. If annualization requested and period length positive, compute `r_A`.
+7. Return response with `method="DIETZ"` and notes (including fallback notes if applicable).
 
 ## Validation and Failure Behavior
 - Schema-level validation enforces required inputs.
+- Stateful mode rejects missing `stateful_input`, rejects stateless payloads in stateful mode, and
+  fails through the retrieval or normalization stage when lotus-core source data cannot produce a
+  valid resolved MWR input.
+- Source fee rows are preserved as performance drag by the upstream analytics input and are not
+  included as investor cash flows; unsupported or invalid source cash-flow rows are skipped during
+  normalization rather than guessed.
 - XIRR fallback notes are preserved when entering Dietz path from failed XIRR attempt.
 - Zero denominator is non-fatal; returns `0.0` with explanatory note.
 - If `annualization.enabled=true` and `days<=0`, annualized output remains null.
@@ -84,12 +106,14 @@ Primary fields:
 - `mwr_annualized` (optional)
 - `method`
 - `start_date`, `end_date`, `notes`
+- `calculation_supportability`, `meta`, `diagnostics`, and `audit`
 
 ## Worked Example
 Inputs:
 - `begin_mv = 100`
 - `cash_flows = [{date: 2026-03-01, amount: 10}]`
 - `end_mv = 112`
+- `start_date = 2026-03-01`
 - `as_of = 2026-03-31`
 - `annualization.enabled = true`, `basis = ACT/ACT`
 

--- a/docs/methodologies/metrics/metric-mwr-xirr.md
+++ b/docs/methodologies/metrics/metric-mwr-xirr.md
@@ -3,20 +3,31 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/mwr`
-- Request mode: stateless payload (`begin_mv`, `end_mv`, `cash_flows[]`)
+- Request modes:
+  - stateless payload (`stateless_input.begin_mv`, `stateless_input.end_mv`, `stateless_input.cash_flows[]`)
+  - legacy stateless top-level `begin_mv`, `end_mv`, and `cash_flows[]`
+  - stateful payload (`stateful_input.window_start_date`) resolved from lotus-core portfolio timeseries
 - Path coverage: applies when `mwr_method="XIRR"` and root solve converges
 
 ## Inputs
 - `begin_mv`
 - `end_mv`
 - `cash_flows[]` (`date`, `amount`)
+- `start_date` when supplied directly or resolved from stateful normalization
 - `as_of` (terminal valuation date)
 - `mwr_method` (`XIRR`)
 - Optional controls: `annualization` block, `solver` object (currently informational in API; engine uses fixed Brent bounds)
 
 ## Upstream Data Sources
-- No runtime upstream dependencies.
-- All required data is provided in the request.
+- Stateless mode has no runtime upstream dependency; all required values are supplied by the caller.
+- Stateful mode resolves source input from `lotus-core`
+  `POST /integration/portfolios/{portfolio_id}/analytics/portfolio-timeseries` through
+  `CORE_CONTROL_PLANE_BASE_URL`.
+- Stateful normalization uses the first and last valid source observations for beginning and
+  ending market value, includes explicit external or missing-classified source cash-flow rows,
+  adds cross-observation carry-forward capital adjustments where beginning market value differs
+  from the prior valid ending market value, and excludes operational fee-classified rows from the
+  investor capital-flow schedule.
 
 ## Unit Conventions
 - Cash flow and market values are currency amounts.
@@ -27,17 +38,20 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 - `BV`: `begin_mv`
 - `EV`: `end_mv`
 - `CF_i`: cash flow amount on date `d_i`
-- `t0`: XIRR anchor date `min(cash_flow_dates U {as_of})`
+- `S`: resolved start date (`stateful_input.window_start_date`, explicit `start_date`, or the
+  earliest cash-flow date when no start date is supplied)
 - `T`: terminal valuation date `as_of`
 - `r`: XIRR annualized decimal rate
-- `tau_j`: year fraction from anchor date using ACT/365.25: `(date_j - t0).days / 365.25`
+- `tau_j`: year fraction from resolved start date using ACT/365.25: `(date_j - S).days / 365.25`
 - `V_j`: signed value at position `j` in the solver vector
 - `NPV(r)`: discounted cash-flow sum used for root solving
 
 ## Methodology and Formulas
 1. Cash-flow vector construction (`calculate_money_weighted_return`):
-- `t0 = min(cash_flow_dates U {as_of})` (or `as_of` if no cash flows)
-- `dates = [t0] + [d_i] + [T]`
+- `S` is the resolved measurement start date. In stateful mode it is the requested
+  `stateful_input.window_start_date`; in stateless mode it is explicit `start_date`, the earliest
+  cash-flow date, or `as_of` when no cash flows exist.
+- `dates = [S] + [d_i] + [T]`
 - `values = [-BV] + [-CF_i] + [EV]`
 - This means the engine treats a positive external contribution as a negative solver cash flow, because it is a cash outflow from the investor to the portfolio.
 
@@ -54,15 +68,23 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 - `end_date = T`
 
 ## Step-by-Step Computation
-1. Determine `start_date`/`end_date` from request (`end_date = as_of`).
-2. Build signed cash-flow schedule for XIRR solve (`-begin`, `-cashflows`, `+end`).
-3. Check sign-change condition on `values`.
-4. If sign change exists, solve `NPV(r)=0` with Brent.
-5. On convergence, return XIRR outputs and `convergence.converged=true`.
-6. On non-convergence/failure, append solver note, append `XIRR failed, falling back to Simple Dietz.`, and fall back to the Dietz path.
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio timeseries and
+   normalize it into `begin_mv`, `end_mv`, signed `cash_flows[]`, and `start_date`.
+2. Determine `start_date`/`end_date` from the resolved request (`end_date = as_of`).
+3. Build signed cash-flow schedule for XIRR solve (`-begin`, `-cashflows`, `+end`).
+4. Check sign-change condition on `values`.
+5. If sign change exists, solve `NPV(r)=0` with Brent.
+6. On convergence, return XIRR outputs and `convergence.converged=true`.
+7. On non-convergence/failure, append solver note, append `XIRR failed, falling back to Simple Dietz.`, and fall back to the Dietz path.
 
 ## Validation and Failure Behavior
 - Request schema enforces required fields and types.
+- Stateful mode rejects missing `stateful_input`, rejects stateless payloads in stateful mode, and
+  fails through the retrieval or normalization stage when lotus-core source data cannot produce a
+  valid resolved MWR input.
+- Source fee rows are preserved as performance drag by the upstream analytics input and are not
+  included as investor cash flows; unsupported or invalid source cash-flow rows are skipped during
+  normalization rather than guessed.
 - If XIRR cannot run due to no sign change, engine returns note: `No sign change in cash flows.` and falls back to Dietz.
 - If Brent fails/convergence error, engine note includes failure reason and falls back to Dietz.
 - `convergence.iterations` and `convergence.residual` are currently `null`; the engine only populates `convergence.converged`.
@@ -84,12 +106,14 @@ Primary fields for this metric when XIRR succeeds:
 - `convergence.residual` (`null` in current implementation)
 - `cashflows_used` when `emit_cashflows_used=true`
 - `start_date`, `end_date`, `notes`
+- `calculation_supportability`, `meta`, `diagnostics`, and `audit`
 
 ## Worked Example
 Inputs:
 - `begin_mv = 1000`
 - `cash_flows = [{date: 2026-01-31, amount: 100}]`
 - `end_mv = 1150`
+- `start_date = 2026-01-31`
 - `as_of = 2026-12-31`
 
 Constructed schedule for solver:

--- a/docs/technical/methodology_index.md
+++ b/docs/technical/methodology_index.md
@@ -24,7 +24,8 @@ Canonical metric-level methodology documents live in:
 That set is the authoritative metric-by-metric reference for:
 
 - TWR base, local, and FX return
-- MWR XIRR and Dietz paths
+- MWR XIRR and Dietz paths, including stateless caller-owned inputs and stateful lotus-core
+  source normalization
 - contribution metrics
 - attribution metrics
 - returns-series portfolio, benchmark, and risk-free series
@@ -42,7 +43,10 @@ That set is the authoritative metric-by-metric reference for:
 
 - The current public TWR, contribution, and attribution contracts use `analyses` and do not use the
   older `period_type` plus top-level `frequencies` shape.
-- The current returns-series contract is the only public surface with stateful execution mode.
+- The current returns-series integration contract and `POST /performance/mwr` support stateful
+  execution. Stateful MWR uses lotus-core portfolio timeseries to resolve the investor
+  capital-timing input schedule; downstream callers should use the source-owned response fields and
+  must not reconstruct MWR inputs from TWR, benchmark, or workspace summary payloads.
 - Contribution, attribution, and returns-series may run synchronously or asynchronously depending on
   workload size and executor policy.
 - OpenAPI is the canonical field-level contract source for descriptions and examples.

--- a/tests/unit/docs/test_metric_methodology_docs.py
+++ b/tests/unit/docs/test_metric_methodology_docs.py
@@ -55,6 +55,23 @@ def test_methodology_master_index_covers_all_metric_docs_and_describes_v3_standa
     assert "## Worked Example" in index
 
 
+def test_mwr_methodology_docs_cover_stateful_source_owned_input_resolution():
+    xirr = _read(METRICS_DIR / "metric-mwr-xirr.md")
+    dietz = _read(METRICS_DIR / "metric-mwr-dietz.md")
+    master_index = _read(METRICS_DIR / "master-index.md")
+
+    for content in (xirr, dietz):
+        assert "Stateless + Stateful" in master_index
+        assert "stateful_input.window_start_date" in content
+        assert "CORE_CONTROL_PLANE_BASE_URL" in content
+        assert "cross-observation carry-forward capital adjustments" in content
+        assert "fee-classified rows" in content
+        assert "must not reconstruct" not in content
+
+    assert "resolved start date" in xirr
+    assert "Stateful MWR resolves lotus-core portfolio timeseries" in master_index
+
+
 def test_attribution_metric_docs_describe_top_down_linking_factor_explicitly():
     for name in [
         "metric-attribution-allocation.md",

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -295,10 +295,22 @@ def test_twr_mwr_response_attribute_certification_documents_field_level_checks()
 
 def test_methodology_index_points_to_current_guides():
     index = _read("docs/technical/methodology_index.md")
+    master_index = _read("docs/methodologies/metrics/master-index.md")
+    xirr_methodology = _read("docs/methodologies/metrics/metric-mwr-xirr.md")
+    dietz_methodology = _read("docs/methodologies/metrics/metric-mwr-dietz.md")
+    integrations_wiki = _read("wiki/Integrations.md")
 
     assert "../guides/twr.md" in index
     assert "../guides/api_reference.md" in index
     assert "period_type" in index
+    assert "`POST /performance/mwr` support stateful" in index
+    assert "must not reconstruct MWR inputs from TWR, benchmark, or workspace summary payloads" in index
+    assert "MWR (XIRR) | POST /performance/mwr | Stateless + Stateful" in master_index
+    assert "MWR (Dietz fallback / explicit) | POST /performance/mwr | Stateless + Stateful" in master_index
+    assert "stateful_input.window_start_date" in xirr_methodology
+    assert "stateful_input.window_start_date" in dietz_methodology
+    assert "Stateful MWR source flow" in integrations_wiki
+    assert "Gateway and Workbench should consume the emitted MWR response" in integrations_wiki
 
 
 def test_standalone_guide_uses_current_engine_api():

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -42,6 +42,11 @@ Cross-service and downstream-facing routes:
 - `GET /integration/returns/series/results/{calculation_id}`
 - `POST /integration/benchmarks/exposure-context`
 
+`POST /performance/mwr` supports both stateless caller-owned inputs and stateful lotus-core
+timeseries sourcing. In stateful mode it is the source-owned investor capital-timing methodology
+surface for downstream product experiences; clients should consume its emitted MWR response and
+supportability block rather than rebuilding cash-flow schedules locally.
+
 ## Operator and platform surfaces
 
 Runtime and supportability routes:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -37,6 +37,24 @@ Governed base-URL examples:
 - operator surfaces:
   execution polling, lineage, runtime status, work items, recoveries, drills, retention
 
+## Stateful MWR source flow
+
+Stateful MWR is a source-owned performance methodology path. `lotus-performance` retrieves
+portfolio analytics timeseries from `lotus-core`, normalizes the investor capital-flow schedule,
+and emits MWR plus supportability metadata for downstream consumers.
+Gateway and Workbench should consume the emitted MWR response as source-owned performance truth;
+they must not reconstruct cash flows from TWR, benchmark, or workspace summary payloads.
+
+```mermaid
+flowchart LR
+    A[lotus-core portfolio timeseries] --> B[lotus-performance stateful MWR normalization]
+    B --> C[begin_mv / end_mv / cashflows_used / start_date]
+    C --> D[XIRR or Dietz engine path]
+    D --> E[MWR response + calculation_supportability]
+    E --> F[lotus-gateway performance contract]
+    F --> G[Workbench investor capital-timing lens]
+```
+
 ## References
 
 - [docs/technical/RFC-0082-upstream-contract-family-map.md](../docs/technical/RFC-0082-upstream-contract-family-map.md)


### PR DESCRIPTION
## Summary
- Promotes stateful MWR source resolution into the v3 methodology docs and methodology index.
- Documents lotus-core timeseries sourcing, carry-forward capital adjustments, fee exclusion, supportability outputs, and downstream no-reconstruction boundaries.
- Adds wiki source-flow documentation and regression tests for MWR methodology truth.

## Local Proof
- `python -m pytest tests/unit/docs/test_metric_methodology_docs.py tests/unit/docs/test_public_docs_contract.py -q` -> 43 passed
- `python -m pytest tests/unit/engine/test_mwr.py tests/unit/services/test_mwr_mode_service.py tests/unit/services/test_workspace_summary_service.py tests/integration/test_mwr_api.py tests/integration/test_response_attribute_certification.py -q` -> 41 passed
- `python -m ruff check tests/unit/docs/test_metric_methodology_docs.py tests/unit/docs/test_public_docs_contract.py` -> passed
- `git diff --check` -> passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance` -> expected pre-merge drift: `API-Surface.md`, `Integrations.md`