### PR TITLE
Document stateful contribution methodology source truth

### DIFF
--- a/docs/methodologies/metrics/master-index.md
+++ b/docs/methodologies/metrics/master-index.md
@@ -9,9 +9,9 @@ This index maps implemented lotus-performance metrics to detailed methodology do
 | TWR FX Return | POST /performance/twr | Stateless + Stateful | [metric-twr-fx-return.md](./metric-twr-fx-return.md) |
 | MWR (XIRR) | POST /performance/mwr | Stateless + Stateful | [metric-mwr-xirr.md](./metric-mwr-xirr.md) |
 | MWR (Dietz fallback / explicit) | POST /performance/mwr | Stateless + Stateful | [metric-mwr-dietz.md](./metric-mwr-dietz.md) |
-| Position Total Contribution | POST /performance/contribution | Stateless | [metric-contribution-total.md](./metric-contribution-total.md) |
-| Position Local Contribution | POST /performance/contribution | Stateless | [metric-contribution-local.md](./metric-contribution-local.md) |
-| Position FX Contribution | POST /performance/contribution | Stateless | [metric-contribution-fx.md](./metric-contribution-fx.md) |
+| Position Total Contribution | POST /performance/contribution | Stateless + Stateful | [metric-contribution-total.md](./metric-contribution-total.md) |
+| Position Local Contribution | POST /performance/contribution | Stateless + Stateful | [metric-contribution-local.md](./metric-contribution-local.md) |
+| Position FX Contribution | POST /performance/contribution | Stateless + Stateful | [metric-contribution-fx.md](./metric-contribution-fx.md) |
 | Attribution Allocation Effect | POST /performance/attribution | Stateless | [metric-attribution-allocation.md](./metric-attribution-allocation.md) |
 | Attribution Selection Effect | POST /performance/attribution | Stateless | [metric-attribution-selection.md](./metric-attribution-selection.md) |
 | Attribution Interaction Effect | POST /performance/attribution | Stateless | [metric-attribution-interaction.md](./metric-attribution-interaction.md) |
@@ -31,6 +31,10 @@ This index maps implemented lotus-performance metrics to detailed methodology do
   `POST /performance/mwr`. Stateful MWR resolves lotus-core portfolio timeseries into canonical
   MWR inputs and preserves source-owned capital-flow supportability instead of making downstream
   consumers reconstruct investor cash-flow schedules.
+- `POST /performance/contribution` also supports stateful execution. Stateful contribution resolves
+  lotus-core portfolio and position timeseries into canonical contribution inputs while keeping
+  contribution methodology, smoothing, hierarchy aggregation, and response supportability owned by
+  `lotus-performance`.
 - In current engine behavior, `mwr_method=MODIFIED_DIETZ` is mapped to the same Dietz computation path as `DIETZ`.
 
 

--- a/docs/methodologies/metrics/metric-contribution-fx.md
+++ b/docs/methodologies/metrics/metric-contribution-fx.md
@@ -3,17 +3,28 @@ Position FX Contribution (`position_contributions[].fx_contribution`)
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/contribution`
-- Mode: stateless request
+- Request modes:
+  - stateless payload (`stateless_input.portfolio_data`, `stateless_input.positions_data[]`)
+  - legacy stateless top-level `portfolio_data` and `positions_data[]`
+  - stateful payload (`stateful_input`) resolved from lotus-core portfolio and position timeseries
 - FX contribution is decomposition residual between total and local contribution in period aggregation.
 
 ## Inputs
 - Position daily total contribution components
 - Position daily local contribution components
+- `stateful_input.metric_basis`, `stateful_input.dimensions`, `stateful_input.include_cash_flows`,
+  and `stateful_input.filters` when source-resolved
 - `currency_mode`, `fx`, `hedging`, `report_ccy`
 - `smoothing.method`
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; all required values are supplied by the caller.
+- Stateful mode resolves lotus-core portfolio and position timeseries and normalizes source rows
+  into the same contribution engine request shape. Position source rows can include local,
+  portfolio, and reporting-currency values plus FX conversion metadata used to support
+  `currency_mode=BOTH`.
+- `lotus-performance` owns FX contribution decomposition; lotus-core supplies analytics inputs and
+  source currency evidence.
 
 ## Unit Conventions
 - Internal contribution values are decimals.
@@ -26,6 +37,7 @@ Position FX Contribution (`position_contributions[].fx_contribution`)
 - `c_s_i,t`: smoothed daily total contribution
 - `lc_s_i,t`: smoothed daily local contribution
 - `fx_s_i,t`: smoothed daily FX contribution
+- `basis`: source-resolved contribution metric basis (`NET` or `GROSS`)
 
 ## Methodology and Formulas
 1. Daily construction in engine:
@@ -46,14 +58,21 @@ Position FX Contribution (`position_contributions[].fx_contribution`)
 - Aggregate position-level `fx_contribution` sums into summary/levels (scaled to pp).
 
 ## Step-by-Step Computation
-1. Compute daily position weights and return components.
-2. Build daily total/local/FX contribution components.
-3. Apply smoothing path and NIP/reset zeroing.
-4. Aggregate by position for period.
-5. Derive period FX contribution as `total - local` and map to response (`*100`).
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio and position
+   timeseries, convert source rows into normalized valuation points, and preserve source currency
+   and FX metadata.
+2. Compute daily position weights and return components.
+3. Build daily total/local/FX contribution components.
+4. Apply smoothing path and NIP/reset zeroing.
+5. Aggregate by position for period.
+6. Derive period FX contribution as `total - local` and map to response (`*100`).
 
 ## Validation and Failure Behavior
 - Same endpoint validation/failure semantics as contribution calculation.
+- Stateful retrieval or normalization failures block the request rather than falling back to local
+  fabricated inputs.
+- Stateful `currency_mode=BOTH` requires reporting currency, position currency, and FX rates when
+  source position currency differs from the reporting currency.
 - If local component is missing/zero, FX contribution absorbs the difference from total.
 - In non-FX setups, FX contributions can be zero by construction.
 
@@ -61,10 +80,14 @@ Position FX Contribution (`position_contributions[].fx_contribution`)
 - `currency_mode`, `fx`, `hedging`, `report_ccy`
 - `smoothing.method`
 - `weighting_scheme`
+- `stateful_input.metric_basis`, `stateful_input.dimensions`, `stateful_input.include_cash_flows`,
+  and `stateful_input.filters` when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.position_contributions[].fx_contribution`
 - Hierarchical: `results_by_period.<period>.summary.fx_contribution` and `levels[].rows[].fx_contribution` (when `currency_mode=BOTH`)
+- `input_mode`
+- `calculation_supportability`, `meta`, `diagnostics`, and `audit`
 
 ## Worked Example
 Period aggregates for one position:

--- a/docs/methodologies/metrics/metric-contribution-local.md
+++ b/docs/methodologies/metrics/metric-contribution-local.md
@@ -3,16 +3,27 @@ Position Local Contribution (`position_contributions[].local_contribution`)
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/contribution`
-- Mode: stateless request
+- Request modes:
+  - stateless payload (`stateless_input.portfolio_data`, `stateless_input.positions_data[]`)
+  - legacy stateless top-level `portfolio_data` and `positions_data[]`
+  - stateful payload (`stateful_input`) resolved from lotus-core portfolio and position timeseries
 - Local contribution is meaningful when position daily `local_ror` exists (multi-currency path). If absent, local contribution defaults to zero.
 
 ## Inputs
 - Position/portfolio valuation points
+- `stateful_input.metric_basis`, `stateful_input.dimensions`, `stateful_input.include_cash_flows`,
+  and `stateful_input.filters` when source-resolved
 - `currency_mode`, `fx`, `hedging`, `report_ccy` (to produce `local_ror` in engine)
 - `weighting_scheme`, `smoothing.method`
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; all required values are supplied by the caller.
+- Stateful mode resolves lotus-core portfolio and position timeseries and normalizes source rows
+  into the same contribution engine request shape. Position source fields can include local,
+  portfolio, and reporting-currency market values, `cash_flow_currency`, FX conversion metadata,
+  and requested dimensions.
+- `lotus-performance` owns local contribution methodology; lotus-core supplies analytics inputs and
+  source currency evidence.
 
 ## Unit Conventions
 - Daily local contribution computed in decimal.
@@ -24,6 +35,7 @@ Position Local Contribution (`position_contributions[].local_contribution`)
 - `lc_raw_i,t`: raw local daily contribution
 - `lc_s_i,t`: smoothed local daily contribution used for aggregation
 - `LC_i`: aggregated position local contribution for period
+- `basis`: source-resolved contribution metric basis (`NET` or `GROSS`)
 
 ## Methodology and Formulas
 1. Daily local contribution:
@@ -43,24 +55,35 @@ Position Local Contribution (`position_contributions[].local_contribution`)
 - Response field: `local_contribution_pp = 100 * LC_i`
 
 ## Step-by-Step Computation
-1. Produce daily position returns (including `local_ror` when FX path active).
-2. Compute daily weights from position vs portfolio BOD capital.
-3. Compute `raw_local_contribution` and set `smoothed_local_contribution`.
-4. Zero local contributions on NIP/reset dates.
-5. Sum per position and map to response (`*100`).
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio and position
+   timeseries, convert source rows into normalized valuation points, and preserve source currency
+   and dimension metadata.
+2. Produce daily position returns (including `local_ror` when FX path active).
+3. Compute daily weights from position vs portfolio BOD capital.
+4. Compute `raw_local_contribution` and set `smoothed_local_contribution`.
+5. Zero local contributions on NIP/reset dates.
+6. Sum per position and map to response (`*100`).
 
 ## Validation and Failure Behavior
 - Same endpoint validation/failure semantics as total contribution.
+- Stateful retrieval or normalization failures block the request rather than falling back to local
+  fabricated inputs.
+- Stateful `currency_mode=BOTH` requires reporting currency, position currency, and FX rates when
+  source position currency differs from the reporting currency.
 - If `local_ror` is unavailable, local contribution deterministically evaluates to zero.
 
 ## Configuration Options
 - `currency_mode`, `fx`, `hedging`, `report_ccy`
 - `weighting_scheme`
 - `smoothing.method`
+- `stateful_input.metric_basis`, `stateful_input.dimensions`, `stateful_input.include_cash_flows`,
+  and `stateful_input.filters` when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.position_contributions[].local_contribution`
 - Hierarchical: `results_by_period.<period>.summary.local_contribution` and `levels[].rows[].local_contribution` (when `currency_mode=BOTH`)
+- `input_mode`
+- `calculation_supportability`, `meta`, `diagnostics`, and `audit`
 
 ## Worked Example
 Two-day example with `w=0.50` and local returns `1.00%`, `0.50%`:

--- a/docs/methodologies/metrics/metric-contribution-total.md
+++ b/docs/methodologies/metrics/metric-contribution-total.md
@@ -3,7 +3,10 @@ Position Total Contribution (`position_contributions[].total_contribution`)
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/contribution`
-- Mode: stateless request payload (`portfolio_data`, `positions_data`)
+- Request modes:
+  - stateless payload (`stateless_input.portfolio_data`, `stateless_input.positions_data[]`)
+  - legacy stateless top-level `portfolio_data` and `positions_data[]`
+  - stateful payload (`stateful_input`) resolved from lotus-core portfolio and position timeseries
 - Output shapes:
   - flat position output when `hierarchy` is null
   - hierarchical output when `hierarchy` is provided
@@ -14,13 +17,22 @@ Position Total Contribution (`position_contributions[].total_contribution`)
 ## Inputs
 - `portfolio_data.valuation_points[]`
 - `positions_data[].valuation_points[]`
+- `stateful_input.metric_basis` (`NET` or `GROSS`) when source-resolved
+- `stateful_input.dimensions[]`, `stateful_input.include_cash_flows`, and `stateful_input.filters`
+  when source-resolved
 - `analyses[]` (period resolution)
 - `weighting_scheme` (implemented branch: `BOD`)
 - `smoothing.method` (`CARINO` or `NONE`)
 - Optional FX controls influencing underlying returns: `currency_mode`, `fx`, `hedging`, `report_ccy`
 
 ## Upstream Data Sources
-- No runtime upstream dependency; all inputs are request-supplied.
+- Stateless mode has no runtime upstream dependency; all required values are supplied by the caller.
+- Stateful mode resolves source input from lotus-core portfolio and position timeseries through the
+  stateful input service. The resolver retrieves portfolio observations, position rows,
+  dimensions, optional cash-flow rows, filters, retrieval metadata, and source currency fields,
+  then normalizes them into the same `ContributionRequest` shape used by stateless execution.
+- `lotus-performance` remains the contribution methodology owner; lotus-core supplies analytics
+  inputs and source metadata, not contribution conclusions.
 
 ## Unit Conventions
 - Daily contribution math in engine uses decimal form.
@@ -39,6 +51,9 @@ Position Total Contribution (`position_contributions[].total_contribution`)
 - `R_P`: linked portfolio period return (decimal)
 - `K_t`: Carino daily factor
 - `K`: Carino total factor
+- `basis`: source-resolved contribution metric basis (`NET` or `GROSS`)
+- `M_i`: source metadata attached to position `i`, including dimensions and selected currency
+  evidence where available
 
 ## Methodology and Formulas
 1. Daily weight (`BOD` branch):
@@ -73,18 +88,28 @@ Position Total Contribution (`position_contributions[].total_contribution`)
   - emit one hierarchy summary per resolved period, not one master-window hierarchy
 
 ## Step-by-Step Computation
-1. Resolve requested periods.
-2. Run TWR engine for portfolio and each position to obtain daily returns.
-3. Merge position rows with portfolio capital columns by date.
-4. Compute daily weights and raw daily contributions.
-5. Apply smoothing method (`CARINO` or `NONE`).
-6. Zero contribution rows on NIP/reset dates.
-7. Slice both contribution rows and portfolio daily-return rows by each resolved period.
-8. Aggregate by position or hierarchy within that period slice and apply residual reconciliation when applicable.
-9. Convert decimal contributions to pp in response (`*100`).
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio and position
+   timeseries, normalize source rows into `portfolio_data` and `positions_data`, preserve source
+   dimensions in position metadata, and convert source cash-flow rows into BOD, EOD, and fee fields.
+2. Resolve requested periods.
+3. Run TWR engine for portfolio and each position to obtain daily returns.
+4. Merge position rows with portfolio capital columns by date.
+5. Compute daily weights and raw daily contributions.
+6. Apply smoothing method (`CARINO` or `NONE`).
+7. Zero contribution rows on NIP/reset dates.
+8. Slice both contribution rows and portfolio daily-return rows by each resolved period.
+9. Aggregate by position or hierarchy within that period slice and apply residual reconciliation when applicable.
+10. Convert decimal contributions to pp in response (`*100`).
 
 ## Validation and Failure Behavior
 - Empty `analyses` is request validation error.
+- Stateful mode rejects missing `stateful_input`, rejects stateless payloads in stateful mode, and
+  fails through the retrieval or normalization stage when lotus-core source data cannot produce
+  usable portfolio or position inputs.
+- Stateful `currency_mode=BOTH` requires reporting currency, position currency, and FX rates when
+  source position currency differs from the reporting currency.
+- Source rows without usable dates or market values are skipped during normalization rather than
+  guessed.
 - No resolved periods: HTTP 400.
 - Empty period slice: period omitted from `results_by_period`.
 - Division by zero in weights is tolerated and mapped to zero weight.
@@ -95,12 +120,16 @@ Position Total Contribution (`position_contributions[].total_contribution`)
 - `smoothing.method` (`CARINO` enables smoothing + residual allocation)
 - `hierarchy` (changes response shape and aggregation path)
 - `currency_mode`/`fx`/`hedging`/`report_ccy` (changes underlying return decomposition)
+- `stateful_input.metric_basis`, `stateful_input.dimensions`, `stateful_input.include_cash_flows`,
+  and `stateful_input.filters` when `input_mode=stateful`
 
 ## Outputs
 Primary fields:
 - `results_by_period.<period>.position_contributions[].total_contribution`
 - `results_by_period.<period>.total_contribution`
 - `results_by_period.<period>.total_portfolio_return`
+- `input_mode`
+- `calculation_supportability`, `meta`, `diagnostics`, and `audit`
 
 Hierarchical path fields:
 - `results_by_period.<period>.summary.portfolio_contribution`

--- a/docs/technical/methodology_index.md
+++ b/docs/technical/methodology_index.md
@@ -26,7 +26,8 @@ That set is the authoritative metric-by-metric reference for:
 - TWR base, local, and FX return
 - MWR XIRR and Dietz paths, including stateless caller-owned inputs and stateful lotus-core
   source normalization
-- contribution metrics
+- contribution metrics, including stateless caller-owned inputs and stateful lotus-core portfolio
+  and position timeseries normalization
 - attribution metrics
 - returns-series portfolio, benchmark, and risk-free series
 
@@ -47,6 +48,10 @@ That set is the authoritative metric-by-metric reference for:
   execution. Stateful MWR uses lotus-core portfolio timeseries to resolve the investor
   capital-timing input schedule; downstream callers should use the source-owned response fields and
   must not reconstruct MWR inputs from TWR, benchmark, or workspace summary payloads.
+- `POST /performance/contribution` also supports stateful execution. Stateful contribution resolves
+  lotus-core portfolio and position timeseries into source-normalized contribution inputs; callers
+  should consume emitted contribution results and supportability rather than reconstructing
+  position contribution from TWR, MWR, attribution, or raw source rows downstream.
 - Contribution, attribution, and returns-series may run synchronously or asynchronously depending on
   workload size and executor policy.
 - OpenAPI is the canonical field-level contract source for descriptions and examples.

--- a/tests/unit/docs/test_metric_methodology_docs.py
+++ b/tests/unit/docs/test_metric_methodology_docs.py
@@ -72,6 +72,23 @@ def test_mwr_methodology_docs_cover_stateful_source_owned_input_resolution():
     assert "Stateful MWR resolves lotus-core portfolio timeseries" in master_index
 
 
+def test_contribution_methodology_docs_cover_stateful_source_owned_input_resolution():
+    total = _read(METRICS_DIR / "metric-contribution-total.md")
+    local = _read(METRICS_DIR / "metric-contribution-local.md")
+    fx = _read(METRICS_DIR / "metric-contribution-fx.md")
+    master_index = _read(METRICS_DIR / "master-index.md")
+
+    for content in (total, local, fx):
+        assert "stateful payload (`stateful_input`)" in content
+        assert "lotus-core portfolio and position timeseries" in content
+        assert "stateful_input.metric_basis" in content
+        assert "stateful_input.include_cash_flows" in content
+        assert "calculation_supportability" in content
+
+    assert "Position Total Contribution | POST /performance/contribution | Stateless + Stateful" in master_index
+    assert "Stateful contribution resolves" in master_index
+
+
 def test_attribution_metric_docs_describe_top_down_linking_factor_explicitly():
     for name in [
         "metric-attribution-allocation.md",

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -311,6 +311,9 @@ def test_methodology_index_points_to_current_guides():
     assert "stateful_input.window_start_date" in dietz_methodology
     assert "Stateful MWR source flow" in integrations_wiki
     assert "Gateway and Workbench should consume the emitted MWR response" in integrations_wiki
+    assert "stateful lotus-core portfolio" in index
+    assert "Stateful contribution source flow" in integrations_wiki
+    assert "they must not reconstruct position contribution" in integrations_wiki
 
 
 def test_standalone_guide_uses_current_engine_api():

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -47,6 +47,11 @@ timeseries sourcing. In stateful mode it is the source-owned investor capital-ti
 surface for downstream product experiences; clients should consume its emitted MWR response and
 supportability block rather than rebuilding cash-flow schedules locally.
 
+`POST /performance/contribution` supports both stateless caller-owned inputs and stateful lotus-core
+portfolio/position timeseries sourcing. In stateful mode it is the source-owned contribution
+methodology surface for downstream product experiences; clients should consume emitted total,
+local, and FX contribution results rather than reconstructing contribution downstream.
+
 ## Operator and platform surfaces
 
 Runtime and supportability routes:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -55,6 +55,25 @@ flowchart LR
     F --> G[Workbench investor capital-timing lens]
 ```
 
+## Stateful contribution source flow
+
+Stateful contribution is a source-normalized performance methodology path. `lotus-performance`
+retrieves portfolio and position timeseries from `lotus-core`, normalizes source rows into the
+contribution engine request shape, and emits total, local, and FX contribution with bounded
+supportability metadata. Gateway, Workbench, risk, and reporting consumers should consume the
+emitted contribution response; they must not reconstruct position contribution from TWR, MWR,
+attribution, or raw source rows.
+
+```mermaid
+flowchart LR
+    A[lotus-core portfolio timeseries] --> C[lotus-performance stateful contribution normalization]
+    B[lotus-core position timeseries] --> C
+    C --> D[portfolio_data / positions_data / dimensions / source currency metadata]
+    D --> E[Contribution engine: total / local / FX]
+    E --> F[Contribution response + calculation_supportability]
+    F --> G[Gateway, Workbench, risk, and reporting consumers]
+```
+
 ## References
 
 - [docs/technical/RFC-0082-upstream-contract-family-map.md](../docs/technical/RFC-0082-upstream-contract-family-map.md)


### PR DESCRIPTION
## Summary
- Documents stateful contribution source resolution for total, local, and FX contribution methodology.
- Updates methodology indexes and wiki source with lotus-core portfolio/position timeseries flow and downstream no-reconstruction boundaries.
- Adds documentation contract tests for the stateful contribution source-owned path.

## Local proof
- python -m pytest tests/unit/docs/test_metric_methodology_docs.py tests/unit/docs/test_public_docs_contract.py -q: 44 passed
- python -m pytest tests/unit/services/test_stateful_contribution_input_service.py tests/integration/test_contribution_api.py -q: 48 passed
- git diff --check: passed with normal CRLF warnings
- wiki check-only: expected drift for wiki/API-Surface.md and wiki/Integrations.md until merge and publication