### PR TITLE
Document stateful attribution methodology source truth

### DIFF
--- a/docs/methodologies/metrics/master-index.md
+++ b/docs/methodologies/metrics/master-index.md
@@ -12,14 +12,14 @@ This index maps implemented lotus-performance metrics to detailed methodology do
 | Position Total Contribution | POST /performance/contribution | Stateless + Stateful | [metric-contribution-total.md](./metric-contribution-total.md) |
 | Position Local Contribution | POST /performance/contribution | Stateless + Stateful | [metric-contribution-local.md](./metric-contribution-local.md) |
 | Position FX Contribution | POST /performance/contribution | Stateless + Stateful | [metric-contribution-fx.md](./metric-contribution-fx.md) |
-| Attribution Allocation Effect | POST /performance/attribution | Stateless | [metric-attribution-allocation.md](./metric-attribution-allocation.md) |
-| Attribution Selection Effect | POST /performance/attribution | Stateless | [metric-attribution-selection.md](./metric-attribution-selection.md) |
-| Attribution Interaction Effect | POST /performance/attribution | Stateless | [metric-attribution-interaction.md](./metric-attribution-interaction.md) |
-| Attribution Total Active Return | POST /performance/attribution | Stateless | [metric-attribution-active-return.md](./metric-attribution-active-return.md) |
-| Currency Local Allocation | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-local-allocation.md](./metric-currency-local-allocation.md) |
-| Currency Local Selection | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-local-selection.md](./metric-currency-local-selection.md) |
-| Currency Allocation | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-allocation.md](./metric-currency-allocation.md) |
-| Currency Selection | POST /performance/attribution | Stateless (multi-currency path) | [metric-currency-selection.md](./metric-currency-selection.md) |
+| Attribution Allocation Effect | POST /performance/attribution | Stateless + Stateful | [metric-attribution-allocation.md](./metric-attribution-allocation.md) |
+| Attribution Selection Effect | POST /performance/attribution | Stateless + Stateful | [metric-attribution-selection.md](./metric-attribution-selection.md) |
+| Attribution Interaction Effect | POST /performance/attribution | Stateless + Stateful | [metric-attribution-interaction.md](./metric-attribution-interaction.md) |
+| Attribution Total Active Return | POST /performance/attribution | Stateless + Stateful | [metric-attribution-active-return.md](./metric-attribution-active-return.md) |
+| Currency Local Allocation | POST /performance/attribution | Stateless + Stateful (multi-currency path) | [metric-currency-local-allocation.md](./metric-currency-local-allocation.md) |
+| Currency Local Selection | POST /performance/attribution | Stateless + Stateful (multi-currency path) | [metric-currency-local-selection.md](./metric-currency-local-selection.md) |
+| Currency Allocation | POST /performance/attribution | Stateless + Stateful (multi-currency path) | [metric-currency-allocation.md](./metric-currency-allocation.md) |
+| Currency Selection | POST /performance/attribution | Stateless + Stateful (multi-currency path) | [metric-currency-selection.md](./metric-currency-selection.md) |
 | Portfolio Return Series | POST /integration/returns/series | Stateless + Stateful | [metric-returns-series-portfolio.md](./metric-returns-series-portfolio.md) |
 | Benchmark Return Series | POST /integration/returns/series | Stateless + Stateful | [metric-returns-series-benchmark.md](./metric-returns-series-benchmark.md) |
 | Active Return Series | POST /integration/returns/series | Stateless + Stateful | [metric-returns-series-active.md](./metric-returns-series-active.md) |
@@ -34,6 +34,11 @@ This index maps implemented lotus-performance metrics to detailed methodology do
 - `POST /performance/contribution` also supports stateful execution. Stateful contribution resolves
   lotus-core portfolio and position timeseries into canonical contribution inputs while keeping
   contribution methodology, smoothing, hierarchy aggregation, and response supportability owned by
+  `lotus-performance`.
+- `POST /performance/attribution` also supports stateful execution. Stateful attribution resolves
+  lotus-core portfolio and position timeseries, benchmark assignment or explicit benchmark override,
+  benchmark component inputs, and source currency evidence into canonical attribution panel inputs
+  while keeping Brinson, active-return, linking, and Karnosky-Singer methodology owned by
   `lotus-performance`.
 - In current engine behavior, `mwr_method=MODIFIED_DIETZ` is mapped to the same Dietz computation path as `DIETZ`.
 

--- a/docs/methodologies/metrics/metric-attribution-active-return.md
+++ b/docs/methodologies/metrics/metric-attribution-active-return.md
@@ -3,6 +3,11 @@ Attribution Total Active Return (`reconciliation.total_active_return`)
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless payload (`stateless_input`) with caller-owned portfolio, benchmark, and group inputs
+  - legacy stateless top-level attribution inputs
+  - stateful payload (`stateful_input`) resolved from lotus-core portfolio, position, benchmark
+    assignment, and benchmark component sources
 - Modes:
   - `mode=BY_GROUP` (pre-aggregated portfolio groups provided)
   - `mode=BY_INSTRUMENT` (engine builds grouped portfolio panel from instrument valuation series)
@@ -13,10 +18,20 @@ Attribution Total Active Return (`reconciliation.total_active_return`)
 - Portfolio side from either:
   - `portfolio_groups_data[]` (`BY_GROUP`), or
   - `portfolio_data` + `instruments_data[]` (`BY_INSTRUMENT`)
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`,
+  `stateful_input.dimensions[]`, and source window fields when source-resolved
 - `group_by[]`, `frequency`, `model`, `linking`
 
 ## Upstream Data Sources
-- Request payload only; no runtime upstream service dependency.
+- Stateless mode has no runtime upstream dependency; all required attribution inputs are supplied
+  by the caller.
+- Stateful mode resolves source input from lotus-core through `CORE_CONTROL_PLANE_BASE_URL`.
+  The resolver retrieves portfolio analytics timeseries, position timeseries, benchmark assignment
+  when a benchmark override is not supplied, and benchmark component inputs through the shared
+  benchmark engine sourcing path. `lotus-performance` then normalizes those source rows into the
+  same attribution engine request shape used by stateless execution.
+- `lotus-performance` remains the attribution methodology owner; lotus-core supplies portfolio,
+  position, benchmark, and source currency inputs, not attribution conclusions.
 
 ## Unit Conventions
 - Engine computations are decimal returns.
@@ -32,6 +47,8 @@ Attribution Total Active Return (`reconciliation.total_active_return`)
 - `R_b,t`: benchmark aggregate return per period `t`
 - `AR_t`: active return per period `t`
 - `AR`: total active return across linked horizon
+- `M_g`: source metadata for group `g`, including source dimensions, benchmark context, and
+  currency evidence where available
 
 ## Methodology and Formulas
 1. Per-period aggregate returns:
@@ -49,16 +66,24 @@ Attribution Total Active Return (`reconciliation.total_active_return`)
 - `residual = total_active_return - sum_of_effects`
 
 ## Step-by-Step Computation
-1. Resolve requested periods and create master request window.
-2. Build aligned portfolio/benchmark panel at requested frequency.
-3. Compute single-period effects, then aggregate by period slice.
-4. Compute portfolio and benchmark per-period aggregate returns.
-5. Compute total active return according to `linking` mode.
-6. Populate reconciliation fields in response.
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio and position
+   timeseries, resolve benchmark assignment or explicit benchmark override, resolve benchmark
+   component inputs, and normalize source rows into attribution panel inputs with source metadata.
+2. Resolve requested periods and create master request window.
+3. Build aligned portfolio/benchmark panel at requested frequency.
+4. Compute single-period effects, then aggregate by period slice.
+5. Compute portfolio and benchmark per-period aggregate returns.
+6. Compute total active return according to `linking` mode.
+7. Populate reconciliation fields in response.
 
 ## Validation and Failure Behavior
 - No resolved periods: HTTP 400.
 - Invalid attribution mode: HTTP 400.
+- Stateful mode rejects missing or conflicting source/stateless envelopes and fails closed when
+  lotus-core portfolio, position, benchmark, or FX/source-currency inputs cannot produce usable
+  attribution inputs.
+- Source rows without usable dates, weights, market values, group keys, or return fields are not
+  guessed into attribution facts.
 - Empty aligned panel or empty period slice: period omitted from output.
 - Engine/input errors surface as HTTP 400/500 depending on exception type.
 
@@ -66,12 +91,16 @@ Attribution Total Active Return (`reconciliation.total_active_return`)
 - `linking` (`NONE` vs non-`NONE` geometric active return path)
 - `frequency` (daily/monthly/quarterly/yearly resampling)
 - `mode`, `group_by`, `model`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, source dimensions, and
+  source window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.reconciliation.total_active_return`
 - `results_by_period.<period>.reconciliation.sum_of_effects`
 - `results_by_period.<period>.reconciliation.residual`
 - Top-level response context remains on `model` and `linking`; those fields are not repeated inside each period result.
+- `benchmark_context`, `calculation_supportability`, `meta`, `diagnostics`, and `audit` when
+  source resolution emits those supportability blocks.
 
 ## Worked Example
 Assume two sub-periods:

--- a/docs/methodologies/metrics/metric-attribution-allocation.md
+++ b/docs/methodologies/metrics/metric-attribution-allocation.md
@@ -3,6 +3,11 @@ Attribution Allocation Effect (`levels[].groups[].allocation`)
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless payload (`stateless_input`) with caller-owned attribution inputs
+  - legacy stateless top-level attribution inputs
+  - stateful payload (`stateful_input`) resolved from lotus-core portfolio, position, benchmark
+    assignment, and benchmark component sources
 - Modes: `BY_GROUP` and `BY_INSTRUMENT`
 - Computed per group, then aggregated to level totals for each resolved period.
 
@@ -14,9 +19,17 @@ Attribution Allocation Effect (`levels[].groups[].allocation`)
   - benchmark total return `r_b_total`
 - `model` (`BRINSON_FACHLER` or `BRINSON_HOOD_BEEBOWER`)
 - `linking`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, dimensions, and source
+  window fields when source-resolved
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; all aligned portfolio and benchmark group
+  facts are supplied by the caller.
+- Stateful mode resolves lotus-core portfolio and position timeseries, resolves benchmark
+  assignment when needed, and resolves benchmark component inputs through the shared benchmark
+  engine sourcing path before normalizing the source rows into the aligned attribution panel.
+- `lotus-performance` owns allocation methodology and active-return linking; lotus-core supplies
+  source inputs and benchmark/source currency evidence, not allocation conclusions.
 
 ## Unit Conventions
 - Effect calculations are decimal in engine.
@@ -32,6 +45,7 @@ Attribution Allocation Effect (`levels[].groups[].allocation`)
 - `AR_geo`: geometric active return across the requested period
 - `AR_arith`: arithmetic active return across the requested period
 - `scale`: top-down linking factor `AR_geo / AR_arith`
+- `M_g`: source metadata for group `g`, including dimensions and benchmark context where available
 
 ## Methodology and Formulas
 1. Single-period allocation by model:
@@ -49,16 +63,21 @@ Attribution Allocation Effect (`levels[].groups[].allocation`)
   - `A_g = scale * sum_t A_g,t`
 
 ## Step-by-Step Computation
-1. Build aligned portfolio/benchmark panel by date and group.
-2. Resample to requested `frequency`, using first `weight_bop` in each bucket and geometric linking for returns.
-3. Compute benchmark total return per period bucket `r_b,t`.
-4. Compute single-period `allocation` using selected model.
-5. If linking enabled, compute `scale` from portfolio and benchmark active return and multiply allocation effects by that factor.
-6. Aggregate by hierarchy levels and scale to pp for response.
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio and position
+   timeseries, benchmark assignment or explicit benchmark override, and benchmark component inputs,
+   then normalize source rows into attribution panel fields.
+2. Build aligned portfolio/benchmark panel by date and group.
+3. Resample to requested `frequency`, using first `weight_bop` in each bucket and geometric linking for returns.
+4. Compute benchmark total return per period bucket `r_b,t`.
+5. Compute single-period `allocation` using selected model.
+6. If linking enabled, compute `scale` from portfolio and benchmark active return and multiply allocation effects by that factor.
+7. Aggregate by hierarchy levels and scale to pp for response.
 
 ## Validation and Failure Behavior
 - Empty aligned panel produces no period results.
 - Invalid model/mode paths return HTTP 400.
+- Stateful source resolution fails closed when lotus-core portfolio, position, benchmark, or
+  source-currency inputs cannot produce usable attribution panel rows.
 - If arithmetic active return is zero in linking path, scaling is skipped (effects unchanged).
 
 ## Configuration Options
@@ -66,11 +85,15 @@ Attribution Allocation Effect (`levels[].groups[].allocation`)
 - `linking`
 - `group_by`
 - `frequency`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, dimensions, and source
+  window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.levels[].groups[].allocation`
 - `results_by_period.<period>.levels[].totals.allocation`
 - `results_by_period.<period>.levels[].groups[].total_effect` includes allocation plus selection and interaction
+- `benchmark_context` and `calculation_supportability` when source resolution emits bounded
+  supportability metadata.
 
 ## Worked Example
 Brinson-Fachler example:

--- a/docs/methodologies/metrics/metric-attribution-interaction.md
+++ b/docs/methodologies/metrics/metric-attribution-interaction.md
@@ -3,6 +3,11 @@ Attribution Interaction Effect (`levels[].groups[].interaction`)
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless payload (`stateless_input`) with caller-owned attribution inputs
+  - legacy stateless top-level attribution inputs
+  - stateful payload (`stateful_input`) resolved from lotus-core portfolio, position, benchmark
+    assignment, and benchmark component sources
 - Modes: `BY_GROUP` and `BY_INSTRUMENT`
 - Interaction is computed for both Brinson models using the same formula.
 
@@ -10,9 +15,17 @@ Attribution Interaction Effect (`levels[].groups[].interaction`)
 - Group weights: `w_p`, `w_b`
 - Group returns: `r_base_p`, `r_base_b`
 - `linking`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, dimensions, and source
+  window fields when source-resolved
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; all portfolio and benchmark weights and
+  returns are supplied by the caller.
+- Stateful mode resolves lotus-core portfolio and position timeseries, benchmark assignment or
+  explicit benchmark override, and benchmark component inputs through the shared benchmark engine
+  sourcing path before normalizing them into aligned attribution panel inputs.
+- `lotus-performance` owns interaction methodology and linking; lotus-core supplies source inputs,
+  benchmark inputs, and source currency evidence, not interaction conclusions.
 
 ## Unit Conventions
 - Engine computes interaction in decimal.
@@ -24,6 +37,8 @@ Attribution Interaction Effect (`levels[].groups[].interaction`)
 - `I_g,t`: single-period interaction effect (decimal)
 - `I_g`: aggregated interaction effect for group `g`
 - `AR_geo`, `AR_arith`, `scale`: top-down linking definitions used when `linking != NONE`
+- `M_g`: source metadata for group `g`, including dimensions, benchmark context, and currency
+  evidence where available
 
 ## Methodology and Formulas
 1. Single-period interaction (both models):
@@ -34,25 +49,34 @@ Attribution Interaction Effect (`levels[].groups[].interaction`)
 - non-`NONE`: `I_g = scale * sum_t I_g,t`, where `scale = AR_geo / AR_arith`
 
 ## Step-by-Step Computation
-1. Build aligned panel and compute single-period effects.
-2. Extract interaction per group-date row.
-3. If linking is enabled, compute `scale` from geometric and arithmetic active return and multiply interaction sums by that factor.
-4. Aggregate by requested hierarchy levels.
-5. Convert to pp in response objects.
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio and position
+   timeseries, resolve benchmark assignment or explicit benchmark override, resolve benchmark
+   component inputs, and normalize source rows into attribution panel fields.
+2. Build aligned panel and compute single-period effects.
+3. Extract interaction per group-date row.
+4. If linking is enabled, compute `scale` from geometric and arithmetic active return and multiply interaction sums by that factor.
+5. Aggregate by requested hierarchy levels.
+6. Convert to pp in response objects.
 
 ## Validation and Failure Behavior
 - Empty aligned inputs lead to no period output.
 - Invalid mode/model paths return HTTP 400.
+- Stateful source resolution fails closed when lotus-core portfolio, position, benchmark, or
+  source-currency inputs cannot produce usable attribution panel rows.
 - If arithmetic active return is zero, no top-down scaling is applied.
 
 ## Configuration Options
 - `linking`
 - `group_by`, `frequency`
 - `model` (does not change interaction formula but affects other effects and totals)
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, dimensions, and source
+  window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.levels[].groups[].interaction`
 - `results_by_period.<period>.levels[].totals.interaction`
+- `benchmark_context` and `calculation_supportability` when source resolution emits bounded
+  supportability metadata.
 
 ## Worked Example
 

--- a/docs/methodologies/metrics/metric-attribution-selection.md
+++ b/docs/methodologies/metrics/metric-attribution-selection.md
@@ -3,6 +3,11 @@ Attribution Selection Effect (`levels[].groups[].selection`)
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless payload (`stateless_input`) with caller-owned attribution inputs
+  - legacy stateless top-level attribution inputs
+  - stateful payload (`stateful_input`) resolved from lotus-core portfolio, position, benchmark
+    assignment, and benchmark component sources
 - Modes: `BY_GROUP` and `BY_INSTRUMENT`
 - Computed at group-period level then aggregated by hierarchy and period.
 
@@ -12,9 +17,17 @@ Attribution Selection Effect (`levels[].groups[].selection`)
   - benchmark base return `r_base_b`
 - Group-level weights (`w_p`, `w_b`)
 - `model`, `linking`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, dimensions, and source
+  window fields when source-resolved
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; all portfolio and benchmark returns and
+  weights are supplied by the caller.
+- Stateful mode resolves lotus-core portfolio and position timeseries, benchmark assignment or
+  explicit benchmark override, and benchmark component inputs through the shared benchmark engine
+  sourcing path before normalizing them into aligned attribution panel inputs.
+- `lotus-performance` owns selection methodology and linking; lotus-core supplies analytics and
+  benchmark inputs, not selection conclusions.
 
 ## Unit Conventions
 - Selection effect is computed in decimal and returned in pp (`*100`).
@@ -26,6 +39,8 @@ Attribution Selection Effect (`levels[].groups[].selection`)
 - `S_g,t`: single-period selection effect (decimal)
 - `S_g`: aggregated selection effect for group `g`
 - `AR_geo`, `AR_arith`, `scale`: same linking definitions used by allocation and interaction docs
+- `M_g`: source metadata for group `g`, including dimensions, benchmark context, and currency
+  evidence where available
 
 ## Methodology and Formulas
 1. Single-period selection by model:
@@ -39,25 +54,34 @@ Attribution Selection Effect (`levels[].groups[].selection`)
 - non-`NONE`: `S_g = scale * sum_t S_g,t`, where `scale = AR_geo / AR_arith`
 
 ## Step-by-Step Computation
-1. Align portfolio and benchmark panels by group and resample to requested `frequency`.
-2. Compute single-period selection per group from the chosen model.
-3. If linking is enabled, compute `scale` from geometric and arithmetic active return and multiply the arithmetic selection sums by that factor.
-4. Aggregate by requested levels.
-5. Convert to pp for response.
+1. Resolve mode-specific inputs. In stateful mode retrieve lotus-core portfolio and position
+   timeseries, resolve benchmark assignment or explicit benchmark override, resolve benchmark
+   component inputs, and normalize source rows into attribution panel fields.
+2. Align portfolio and benchmark panels by group and resample to requested `frequency`.
+3. Compute single-period selection per group from the chosen model.
+4. If linking is enabled, compute `scale` from geometric and arithmetic active return and multiply the arithmetic selection sums by that factor.
+5. Aggregate by requested levels.
+6. Convert to pp for response.
 
 ## Validation and Failure Behavior
 - Empty aligned panel yields no period output.
 - Invalid request mode/model handled as HTTP 400.
+- Stateful source resolution fails closed when lotus-core portfolio, position, benchmark, or
+  source-currency inputs cannot produce usable attribution panel rows.
 - If arithmetic active return is zero, linking scaler is not applied.
 
 ## Configuration Options
 - `model`
 - `linking`
 - `group_by`, `frequency`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, dimensions, and source
+  window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.levels[].groups[].selection`
 - `results_by_period.<period>.levels[].totals.selection`
+- `benchmark_context` and `calculation_supportability` when source resolution emits bounded
+  supportability metadata.
 
 ## Worked Example
 Brinson-Fachler example:

--- a/docs/methodologies/metrics/metric-currency-allocation.md
+++ b/docs/methodologies/metrics/metric-currency-allocation.md
@@ -3,6 +3,10 @@ Currency Attribution Currency Allocation (`currency_attribution[].effects.curren
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless attribution inputs with caller-owned local and FX return columns
+  - stateful attribution inputs resolved from lotus-core portfolio, position, benchmark, and FX
+    source rows when those rows can produce local and FX return fields
 - Available only in currency attribution path:
   - `currency_mode=BOTH`
   - required local/FX columns are present in the aligned effects panel
@@ -12,9 +16,16 @@ Currency Attribution Currency Allocation (`currency_attribution[].effects.curren
 - `w_p`, `w_b`
 - `r_local_b`
 - `r_fx_b` (benchmark FX return by currency)
+- source currency metadata and FX/local-return fields when `input_mode=stateful`
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; required local and FX fields are supplied by
+  the caller.
+- Stateful mode uses lotus-core portfolio and position timeseries, benchmark assignment/component
+  inputs, and FX/source currency evidence normalized by the attribution resolver. The currency
+  attribution branch runs only after those source rows produce the required local and FX columns.
+- `lotus-performance` owns Karnosky-Singer currency allocation methodology; lotus-core supplies
+  source rows and currency evidence, not currency-attribution conclusions.
 
 ## Unit Conventions
 - Engine computes decimal effect.
@@ -38,23 +49,30 @@ Aggregation:
 - `TE_c = LA_c + LS_c + CA_c + CS_c`
 
 ## Step-by-Step Computation
-1. Build currency-level panel by date.
-2. Compute weight active term `(w_p - w_b)`.
-3. Compute local-growth term `(1 + r_local_b)`.
-4. Multiply with benchmark FX return to get `CA_c,t`.
-5. Sum over dates and scale to pp.
+1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core
+   portfolio, position, benchmark, and FX/source currency rows.
+2. Build currency-level panel by date.
+3. Compute weight active term `(w_p - w_b)`.
+4. Compute local-growth term `(1 + r_local_b)`.
+5. Multiply with benchmark FX return to get `CA_c,t`.
+6. Sum over dates and scale to pp.
 
 ## Validation and Failure Behavior
 - If currency effects cannot be computed (missing required columns), field is absent with entire currency-attribution block.
+- Stateful source rows without usable source currency, reporting currency, local return, or FX
+  return evidence do not produce currency-attribution facts.
 - Endpoint handles invalid requests/errors as HTTP 400/500.
 
 ## Configuration Options
 - `currency_mode=BOTH`
 - `frequency`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, source dimensions, and
+  source window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.currency_attribution[].effects.currency_allocation`
 - contributes to `results_by_period.<period>.currency_attribution[].effects.total_effect`
+- `calculation_supportability` when source resolution emits bounded supportability metadata.
 
 ## Worked Example
 

--- a/docs/methodologies/metrics/metric-currency-local-allocation.md
+++ b/docs/methodologies/metrics/metric-currency-local-allocation.md
@@ -3,6 +3,10 @@ Currency Attribution Local Allocation (`currency_attribution[].effects.local_all
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless attribution inputs with caller-owned local and FX return columns
+  - stateful attribution inputs resolved from lotus-core portfolio, position, benchmark, and FX
+    source rows when those rows can produce local and FX return fields
 - Availability conditions:
   - `currency_mode="BOTH"`
   - aligned effects contain required local/FX columns
@@ -13,9 +17,16 @@ Currency Attribution Local Allocation (`currency_attribution[].effects.local_all
   - `w_p` (portfolio weight)
   - `w_b` (benchmark weight)
   - `r_local_b` (benchmark local return)
+- source currency metadata and FX/local-return fields when `input_mode=stateful`
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; required local and FX fields are supplied by
+  the caller.
+- Stateful mode uses lotus-core portfolio and position timeseries, benchmark assignment/component
+  inputs, and FX/source currency evidence normalized by the attribution resolver. The currency
+  attribution branch runs only after those source rows produce the required local and FX columns.
+- `lotus-performance` owns Karnosky-Singer local allocation methodology; lotus-core supplies source
+  rows and currency evidence, not currency-attribution conclusions.
 
 ## Unit Conventions
 - Engine computes in decimal.
@@ -39,22 +50,29 @@ Period/currency aggregation in response:
 - `TE_c = LA_c + LS_c + CA_c + CS_c`
 
 ## Step-by-Step Computation
-1. Build daily attribution panel and aggregate by (`date`, `currency`).
-2. Compute `LA_c,t` for each currency/date row.
-3. Sum across dates per currency.
-4. Convert to pp and populate `currency_attribution[].effects.local_allocation`.
+1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core
+   portfolio, position, benchmark, and FX/source currency rows.
+2. Build daily attribution panel and aggregate by (`date`, `currency`).
+3. Compute `LA_c,t` for each currency/date row.
+4. Sum across dates per currency.
+5. Convert to pp and populate `currency_attribution[].effects.local_allocation`.
 
 ## Validation and Failure Behavior
 - If currency attribution prerequisites are missing (required columns or currency key), `currency_attribution` block is omitted.
+- Stateful source rows without usable source currency, reporting currency, local return, or FX
+  return evidence do not produce currency-attribution facts.
 - Invalid attribution request/mode handling follows endpoint-level HTTP 400/500 behavior.
 
 ## Configuration Options
 - `currency_mode` must be `BOTH`.
 - `frequency` controls period bucketing before currency-effect aggregation.
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, source dimensions, and
+  source window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.currency_attribution[].effects.local_allocation`
 - contributes to `results_by_period.<period>.currency_attribution[].effects.total_effect`
+- `calculation_supportability` when source resolution emits bounded supportability metadata.
 
 ## Worked Example
 

--- a/docs/methodologies/metrics/metric-currency-local-selection.md
+++ b/docs/methodologies/metrics/metric-currency-local-selection.md
@@ -3,6 +3,10 @@ Currency Attribution Local Selection (`currency_attribution[].effects.local_sele
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless attribution inputs with caller-owned local and FX return columns
+  - stateful attribution inputs resolved from lotus-core portfolio, position, benchmark, and FX
+    source rows when those rows can produce local and FX return fields
 - Availability requires currency attribution path to be active:
   - `currency_mode=BOTH`
   - required columns are present in the aligned effects panel
@@ -12,9 +16,16 @@ Currency Attribution Local Selection (`currency_attribution[].effects.local_sele
 - `w_b` (benchmark currency weight)
 - `r_local_p` (portfolio local return by currency)
 - `r_local_b` (benchmark local return by currency)
+- source currency metadata and FX/local-return fields when `input_mode=stateful`
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; required local and FX fields are supplied by
+  the caller.
+- Stateful mode uses lotus-core portfolio and position timeseries, benchmark assignment/component
+  inputs, and FX/source currency evidence normalized by the attribution resolver. The currency
+  attribution branch runs only after those source rows produce the required local and FX columns.
+- `lotus-performance` owns Karnosky-Singer local selection methodology; lotus-core supplies source
+  rows and currency evidence, not currency-attribution conclusions.
 
 ## Unit Conventions
 - Formula computed in decimal.
@@ -38,22 +49,29 @@ Aggregation:
 - `TE_c = LA_c + LS_c + CA_c + CS_c`
 
 ## Step-by-Step Computation
-1. Aggregate aligned panel by (`date`, `currency`).
-2. Compute local return spread per row.
-3. Multiply by benchmark weight to get `LS_c,t`.
-4. Sum across dates and convert to pp in response.
+1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core
+   portfolio, position, benchmark, and FX/source currency rows.
+2. Aggregate aligned panel by (`date`, `currency`).
+3. Compute local return spread per row.
+4. Multiply by benchmark weight to get `LS_c,t`.
+5. Sum across dates and convert to pp in response.
 
 ## Validation and Failure Behavior
 - Currency-attribution block is omitted when prerequisites are not met.
+- Stateful source rows without usable source currency, reporting currency, local return, or FX
+  return evidence do not produce currency-attribution facts.
 - Endpoint-level invalid input errors map to HTTP 400/500 paths.
 
 ## Configuration Options
 - `currency_mode=BOTH`
 - `frequency` (controls aggregation horizon)
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, source dimensions, and
+  source window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.currency_attribution[].effects.local_selection`
 - contributes to `results_by_period.<period>.currency_attribution[].effects.total_effect`
+- `calculation_supportability` when source resolution emits bounded supportability metadata.
 
 ## Worked Example
 

--- a/docs/methodologies/metrics/metric-currency-selection.md
+++ b/docs/methodologies/metrics/metric-currency-selection.md
@@ -3,6 +3,10 @@ Currency Attribution Currency Selection (`currency_attribution[].effects.currenc
 
 ## Endpoint and Mode Coverage
 - Endpoint: `POST /performance/attribution`
+- Request modes:
+  - stateless attribution inputs with caller-owned local and FX return columns
+  - stateful attribution inputs resolved from lotus-core portfolio, position, benchmark, and FX
+    source rows when those rows can produce local and FX return fields
 - Available only when currency-attribution branch is active:
   - `currency_mode=BOTH`
   - required local/FX columns are present in the aligned effects panel
@@ -12,9 +16,16 @@ Currency Attribution Currency Selection (`currency_attribution[].effects.currenc
 - `w_b`
 - `r_local_p`, `r_local_b`
 - `r_fx_b`
+- source currency metadata and FX/local-return fields when `input_mode=stateful`
 
 ## Upstream Data Sources
-- Request payload only.
+- Stateless mode has no runtime upstream dependency; required local and FX fields are supplied by
+  the caller.
+- Stateful mode uses lotus-core portfolio and position timeseries, benchmark assignment/component
+  inputs, and FX/source currency evidence normalized by the attribution resolver. The currency
+  attribution branch runs only after those source rows produce the required local and FX columns.
+- `lotus-performance` owns Karnosky-Singer currency selection methodology; lotus-core supplies
+  source rows and currency evidence, not currency-attribution conclusions.
 
 ## Unit Conventions
 - Computed in decimal, emitted as percentage points (`*100`).
@@ -39,23 +50,30 @@ Aggregation and total effect:
   - `TE_c = LA_c + LS_c + CA_c + CS_c`
 
 ## Step-by-Step Computation
-1. Compute local return spread per currency-date.
-2. Multiply by benchmark weight.
-3. Multiply by benchmark FX return.
-4. Sum across dates and convert to pp.
-5. Add into per-currency total effect.
+1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core
+   portfolio, position, benchmark, and FX/source currency rows.
+2. Compute local return spread per currency-date.
+3. Multiply by benchmark weight.
+4. Multiply by benchmark FX return.
+5. Sum across dates and convert to pp.
+6. Add into per-currency total effect.
 
 ## Validation and Failure Behavior
 - Currency attribution omitted if prerequisites are not met.
+- Stateful source rows without usable source currency, reporting currency, local return, or FX
+  return evidence do not produce currency-attribution facts.
 - Standard endpoint error behavior applies for invalid inputs/exceptions.
 
 ## Configuration Options
 - `currency_mode=BOTH`
 - `frequency`
+- `stateful_input.portfolio_id`, optional `stateful_input.benchmark_id`, source dimensions, and
+  source window fields when `input_mode=stateful`
 
 ## Outputs
 - `results_by_period.<period>.currency_attribution[].effects.currency_selection`
 - contributes to `results_by_period.<period>.currency_attribution[].effects.total_effect`
+- `calculation_supportability` when source resolution emits bounded supportability metadata.
 
 ## Worked Example
 

--- a/docs/technical/methodology_index.md
+++ b/docs/technical/methodology_index.md
@@ -28,7 +28,8 @@ That set is the authoritative metric-by-metric reference for:
   source normalization
 - contribution metrics, including stateless caller-owned inputs and stateful lotus-core portfolio
   and position timeseries normalization
-- attribution metrics
+- attribution metrics, including stateless caller-owned inputs and stateful lotus-core portfolio,
+  position, benchmark, and source currency normalization
 - returns-series portfolio, benchmark, and risk-free series
 
 ## Technical references
@@ -52,6 +53,12 @@ That set is the authoritative metric-by-metric reference for:
   lotus-core portfolio and position timeseries into source-normalized contribution inputs; callers
   should consume emitted contribution results and supportability rather than reconstructing
   position contribution from TWR, MWR, attribution, or raw source rows downstream.
+- `POST /performance/attribution` also supports stateful execution. Stateful attribution resolves
+  lotus-core portfolio and position timeseries, benchmark assignment or explicit benchmark override,
+  benchmark component inputs, and source currency evidence into source-normalized attribution
+  inputs; callers should consume emitted allocation, selection, interaction, active-return, and
+  currency-attribution results instead of reconstructing attribution from contribution, TWR, MWR,
+  benchmark, or raw source rows downstream.
 - Contribution, attribution, and returns-series may run synchronously or asynchronously depending on
   workload size and executor policy.
 - OpenAPI is the canonical field-level contract source for descriptions and examples.

--- a/tests/unit/docs/test_metric_methodology_docs.py
+++ b/tests/unit/docs/test_metric_methodology_docs.py
@@ -101,6 +101,41 @@ def test_attribution_metric_docs_describe_top_down_linking_factor_explicitly():
         assert "scale" in content
 
 
+def test_attribution_methodology_docs_cover_stateful_source_owned_input_resolution():
+    attribution_docs = [
+        "metric-attribution-active-return.md",
+        "metric-attribution-allocation.md",
+        "metric-attribution-selection.md",
+        "metric-attribution-interaction.md",
+    ]
+    currency_docs = [
+        "metric-currency-local-allocation.md",
+        "metric-currency-local-selection.md",
+        "metric-currency-allocation.md",
+        "metric-currency-selection.md",
+    ]
+    master_index = _read(METRICS_DIR / "master-index.md")
+
+    for name in attribution_docs:
+        content = _read(METRICS_DIR / name)
+        assert "stateful payload (`stateful_input`)" in content
+        assert "lotus-core portfolio" in content
+        assert "position timeseries" in content
+        assert "benchmark assignment" in content
+        assert "benchmark component inputs" in content
+        assert "calculation_supportability" in content
+
+    for name in currency_docs:
+        content = _read(METRICS_DIR / name)
+        assert "stateful attribution inputs" in content
+        assert "FX/source currency evidence" in content
+        assert "calculation_supportability" in content
+
+    assert "Attribution Allocation Effect | POST /performance/attribution | Stateless + Stateful" in master_index
+    assert "Currency Allocation | POST /performance/attribution | Stateless + Stateful" in master_index
+    assert "Stateful attribution resolves" in master_index
+
+
 def test_currency_attribution_metric_docs_describe_total_effect_relationship():
     for name in [
         "metric-currency-local-allocation.md",

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -314,6 +314,10 @@ def test_methodology_index_points_to_current_guides():
     assert "stateful lotus-core portfolio" in index
     assert "Stateful contribution source flow" in integrations_wiki
     assert "they must not reconstruct position contribution" in integrations_wiki
+    assert "Stateful attribution source flow" in integrations_wiki
+    assert "reconstruct allocation, selection, interaction" in integrations_wiki
+    assert "source-normalized attribution" in index
+    assert "inputs; callers should consume emitted allocation" in index
 
 
 def test_standalone_guide_uses_current_engine_api():

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -52,6 +52,12 @@ portfolio/position timeseries sourcing. In stateful mode it is the source-owned 
 methodology surface for downstream product experiences; clients should consume emitted total,
 local, and FX contribution results rather than reconstructing contribution downstream.
 
+`POST /performance/attribution` supports both stateless caller-owned inputs and stateful lotus-core
+portfolio/position, benchmark, and source currency sourcing. In stateful mode it is the source-owned
+attribution methodology surface for downstream product experiences; clients should consume emitted
+allocation, selection, interaction, active-return, and currency-attribution results rather than
+reconstructing attribution downstream.
+
 ## Operator and platform surfaces
 
 Runtime and supportability routes:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -74,6 +74,27 @@ flowchart LR
     F --> G[Gateway, Workbench, risk, and reporting consumers]
 ```
 
+## Stateful attribution source flow
+
+Stateful attribution is a source-normalized performance methodology path. `lotus-performance`
+retrieves portfolio and position timeseries from `lotus-core`, resolves benchmark assignment or an
+explicit benchmark override, sources benchmark component inputs through the shared benchmark engine
+path, and normalizes source currency evidence for the multi-currency branch. Gateway, Workbench,
+risk, and reporting consumers should consume the emitted attribution response; they must not
+reconstruct allocation, selection, interaction, active return, or currency attribution from
+contribution, TWR, MWR, benchmark, or raw source rows.
+
+```mermaid
+flowchart LR
+    A[lotus-core portfolio timeseries] --> D[lotus-performance stateful attribution normalization]
+    B[lotus-core position timeseries] --> D
+    C[lotus-core benchmark assignment / component inputs / FX evidence] --> D
+    D --> E[portfolio groups / benchmark groups / source currency metadata]
+    E --> F[Attribution engine: allocation / selection / interaction / active return / currency effects]
+    F --> G[Attribution response + calculation_supportability + benchmark_context]
+    G --> H[Gateway, Workbench, risk, and reporting consumers]
+```
+
 ## References
 
 - [docs/technical/RFC-0082-upstream-contract-family-map.md](../docs/technical/RFC-0082-upstream-contract-family-map.md)


### PR DESCRIPTION
## Summary
- Documents stateful attribution source resolution across active return, allocation, selection, interaction, and Karnosky-Singer currency effects.
- Updates methodology indexes and wiki source with lotus-core portfolio/position, benchmark, and FX/source-currency attribution flow.
- Adds documentation contract tests for the stateful attribution source-owned path.

## Local proof
- python -m pytest tests/unit/docs/test_metric_methodology_docs.py tests/unit/docs/test_public_docs_contract.py -q: 45 passed
- python -m pytest tests/unit/services/test_stateful_attribution_input_service.py tests/unit/services/test_attribution_mode_service.py tests/integration/test_attribution_api.py -q: 46 passed, 10 existing HTTP 422 deprecation warnings
- python -m ruff format --check tests/unit/docs/test_metric_methodology_docs.py tests/unit/docs/test_public_docs_contract.py: passed
- python -m ruff check tests/unit/docs/test_metric_methodology_docs.py tests/unit/docs/test_public_docs_contract.py: passed
- git diff --check: passed with normal CRLF warnings
- wiki check-only: expected drift for wiki/API-Surface.md and wiki/Integrations.md until merge and publication