### PR TITLE
Add MWR solver outcome metrics

### DIFF
--- a/app/api/endpoints/performance.py
+++ b/app/api/endpoints/performance.py
@@ -16,6 +16,7 @@ from app.models.responses import PerformanceResponse, TWRAcceptedResponse
 from app.models.twr_requests import TWRAnalyticsRequest, TWRInputMode, TWRResolvedExecutionRequest
 from app.models.workspace_summary_requests import WorkspaceSummaryRequest
 from app.models.workspace_summary_responses import WorkspaceSummaryAcceptedResponse, WorkspaceSummaryResponse
+from app.observability import record_mwr_solver_outcome
 from app.services.async_result_service import resolve_async_result
 from app.services.attribution_mode_service import resolve_attribution_request
 from app.services.attribution_service import calculate_attribution
@@ -644,6 +645,13 @@ async def calculate_mwr_endpoint(request: MoneyWeightedReturnAnalyticsRequest):
         minimum_input_row_count=2,
     )
     record_supportability_metric(operation="mwr", supportability=calculation_supportability)
+    record_mwr_solver_outcome(
+        input_mode=request.input_mode.value,
+        method=mwr_result.method,
+        status=mwr_result.status,
+        reason_codes=mwr_result.reason_codes,
+        fallback_used=mwr_result.fallback_from is not None or mwr_result.is_approximation,
+    )
 
     response_payload = {
         "calculation_id": request.calculation_id,

--- a/app/observability.py
+++ b/app/observability.py
@@ -13,6 +13,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from app.observability_contracts import (
     PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS,
     PERFORMANCE_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
+    PERFORMANCE_MWR_SOLVER_OUTCOME_METRIC_LABELS,
 )
 from app.services.queue_metrics_service import DurableQueueCollector
 
@@ -29,6 +30,27 @@ ANALYTICS_FRESHNESS_BUCKET_TOTAL = Counter(
     "lotus_analytics_freshness_bucket_total",
     "Backend analytics freshness and supportability posture by service, operation, and bounded freshness bucket.",
     PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS,
+)
+MWR_SOLVER_OUTCOME_TOTAL = Counter(
+    "lotus_performance_mwr_solver_outcome_total",
+    "MWR solver outcomes by bounded input mode, method, status, reason code, and fallback flag.",
+    PERFORMANCE_MWR_SOLVER_OUTCOME_METRIC_LABELS,
+)
+
+_MWR_ALLOWED_INPUT_MODES = frozenset({"stateless", "stateful"})
+_MWR_ALLOWED_METHODS = frozenset({"XIRR", "DIETZ"})
+_MWR_ALLOWED_STATUSES = frozenset({"CALCULATED", "FALLBACK_USED", "NOT_APPLICABLE", "NOT_CALCULABLE"})
+_MWR_ALLOWED_REASON_CODES = frozenset(
+    {
+        "NONE",
+        "DIETZ_FALLBACK_USED",
+        "MULTIPLE_IRR_ROOTS_DETECTED",
+        "NO_ECONOMIC_CONTENT",
+        "NO_POSITIVE_AND_NEGATIVE_CASH_FLOW",
+        "NO_ROOT_FOUND",
+        "SOLVER_DID_NOT_CONVERGE",
+        "ZERO_DENOMINATOR",
+    }
 )
 
 
@@ -117,6 +139,30 @@ def record_analytics_freshness_bucket(
         freshness_bucket=freshness_bucket,
         supportability_state=supportability_state,
     ).inc()
+
+
+def record_mwr_solver_outcome(
+    *,
+    input_mode: str,
+    method: str,
+    status: str,
+    reason_codes: list[str] | tuple[str, ...],
+    fallback_used: bool,
+) -> None:
+    bounded_input_mode = input_mode if input_mode in _MWR_ALLOWED_INPUT_MODES else "other"
+    bounded_method = method if method in _MWR_ALLOWED_METHODS else "OTHER"
+    bounded_status = status if status in _MWR_ALLOWED_STATUSES else "OTHER"
+    emitted_reason_codes = tuple(reason_codes) if reason_codes else ("NONE",)
+
+    for reason_code in emitted_reason_codes:
+        bounded_reason_code = reason_code if reason_code in _MWR_ALLOWED_REASON_CODES else "OTHER"
+        MWR_SOLVER_OUTCOME_TOTAL.labels(
+            input_mode=bounded_input_mode,
+            method=bounded_method,
+            status=bounded_status,
+            reason_code=bounded_reason_code,
+            fallback_used=str(fallback_used).lower(),
+        ).inc()
 
 
 def build_access_log_fields(*, request: Request, duration_ms: float) -> dict[str, str | float]:

--- a/app/observability_contracts.py
+++ b/app/observability_contracts.py
@@ -13,3 +13,11 @@ PERFORMANCE_ANALYTICS_FRESHNESS_METRIC_LABELS: tuple[str, ...] = (
     "freshness_bucket",
     "supportability_state",
 )
+
+PERFORMANCE_MWR_SOLVER_OUTCOME_METRIC_LABELS: tuple[str, ...] = (
+    "input_mode",
+    "method",
+    "status",
+    "reason_code",
+    "fallback_used",
+)

--- a/docs/guides/mwr-lotus-production-controls.md
+++ b/docs/guides/mwr-lotus-production-controls.md
@@ -88,6 +88,9 @@ not reinterpret solver status, collapse reason codes, or relabel approximation m
 - Reproducibility: deterministic cash-flow normalization and solver metadata make calculation output
   explainable across reruns.
 - Supportability: every non-OK calculation path carries status and reason-code evidence.
+- Operational metrics: `/metrics` exposes
+  `lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}`
+  so operators can track fallback, no-root, and multiple-root rates with bounded labels.
 - Domain correctness: XIRR and Dietz are not presented as interchangeable; Dietz is exposed only as a
   labeled approximation path.
 - Consumer compatibility: downstream Lotus consumers receive the expanded response contract without
@@ -100,6 +103,6 @@ The current implementation is backed by:
 - unit tests for XIRR, short-period annualization, same-day netting, no-root, multiple-root, no
   economic-content, and fallback paths;
 - integration tests for `/performance/mwr` response status, reason codes, warning propagation,
-  holding-period return, and convergence metadata;
+  holding-period return, convergence metadata, and solver-outcome metric emission;
 - documentation contract tests that keep public docs, wiki links, and response certification aligned;
 - `make check`, `make domain-product-validate`, OpenAPI quality, and API vocabulary validation.

--- a/docs/guides/mwr.md
+++ b/docs/guides/mwr.md
@@ -217,3 +217,7 @@ documentation rather than retained as generic reference text:
 - [MWR industry review findings](../technical/mwr-industry-review-findings.md) records what was
   adopted, what Lotus already handled more strongly, and which candidate enhancements remain outside
   the current implementation-backed contract.
+
+Operational trend visibility is exposed through
+`lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}` for
+fallback, no-root, and multiple-root rate monitoring.

--- a/docs/operations/mwr-production-support-playbook.md
+++ b/docs/operations/mwr-production-support-playbook.md
@@ -16,6 +16,9 @@ not be used to infer unsupported calculation behavior.
    flow count.
 6. For stateful requests, review `calculation_supportability` and source lineage before escalating
    to `lotus-core` data owners.
+7. Check `/metrics` for
+   `lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}`
+   when triaging repeated fallback, no-root, or multiple-root patterns.
 
 ## Reason-Code Triage
 
@@ -47,6 +50,8 @@ Escalate to `lotus-performance` engineering when:
 - `lotus-gateway` or another consumer drops status, reason codes, warnings, or approximation flags;
 - a documented reason code is missing from OpenAPI or API vocabulary artifacts;
 - repeated stateful requests show inconsistent supportability metadata for the same input evidence.
+- `lotus_performance_mwr_solver_outcome_total` stops emitting bounded `reason_code`, `status`, or
+  `fallback_used` labels for completed MWR responses.
 
 Escalate to upstream data ownership when:
 

--- a/docs/technical/mwr-endpoint-certification.md
+++ b/docs/technical/mwr-endpoint-certification.md
@@ -82,10 +82,16 @@ and `freshness_bucket` values plus input-row and resolved-period counts. The ser
 
 `lotus_performance_calculation_supportability_total{operation="mwr",supportability_state,reason,freshness_bucket}`
 
+MWR-specific solver outcomes are also counted for operational trend analysis:
+
+`lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}`
+
 Use this block as the source-owned freshness and degraded-state signal for front-office MWR panels.
 The response publishes `calculation_supportability.metric_labels` with the same bounded label keys
 used by the metric. The metric labels must not include portfolio, tenant, account, benchmark,
 calculation, trace, correlation, request body, response body, or security identifiers.
+The solver-outcome metric follows the same support-safety rule: label values are bounded to input
+mode, calculation method, outcome status, reason code, and fallback flag.
 
 Calculation-quality metadata is part of the product contract:
 

--- a/docs/technical/mwr-industry-review-findings.md
+++ b/docs/technical/mwr-industry-review-findings.md
@@ -14,6 +14,7 @@ was used as a review input; the durable documentation is now Lotus-authored and 
 | Distinguish annualized and holding-period returns. | `money_weighted_return` remains the primary annualized value and `holding_period_return` is emitted separately. |
 | Net same-day cash flows deterministically. | Cash flows are normalized and netted by date before solving; tests prove order independence. |
 | Make support behavior operationally usable. | The MWR support playbook maps reason codes to support actions and client-safe explanations. |
+| Track fallback and solver ambiguity rates operationally. | `/metrics` emits `lotus_performance_mwr_solver_outcome_total` with bounded labels for input mode, method, status, reason code, and fallback use. |
 
 ## Areas Where Lotus Is Stronger
 
@@ -34,7 +35,7 @@ consumer propagation, and documentation are completed:
 - multi-currency per-flow FX conversion inside MWR;
 - component or attribution-level MWR decomposition;
 - private-market since-inception IRR workflows with capital-call/distribution schedules;
-- operational SLO dashboards for MWR reason-code frequency and fallback rate.
+- operational SLO dashboards and alert thresholds for MWR reason-code frequency and fallback rate.
 
 ## Backlog Candidates
 
@@ -42,8 +43,8 @@ Candidate enhancements should be implemented as governed slices:
 
 1. Add an independently certified Modified Dietz method if business reporting requires it separately
    from the current labeled fallback path.
-2. Add MWR operational metrics for fallback rate, no-root rate, multiple-root rate, and stateful
-   source-data rejection rate.
+2. Add alert thresholds and dashboards for the emitted MWR solver-outcome metric, including fallback
+   rate, no-root rate, multiple-root rate, and stateful source-data rejection rate.
 3. Add FX-aware MWR only after the cross-repository currency contract is explicit and consumer
    surfaces can show currency provenance.
 4. Extend demo/wiki material when front-office surfaces expose reason-code drill-downs directly.
@@ -56,5 +57,6 @@ Implementation-backed proof currently lives in:
 - `app/models/mwr_responses.py` for the response contract;
 - `tests/unit/engine/test_mwr.py` and `tests/integration/test_mwr_api.py` for calculation behavior;
 - `tests/integration/test_response_attribute_certification.py` for emitted response fields;
+- `tests/unit/test_observability.py` for bounded MWR metric labels;
 - `docs/guides/mwr-lotus-production-controls.md` and
   `docs/operations/mwr-production-support-playbook.md` for product and support documentation.

--- a/tests/integration/test_mwr_api.py
+++ b/tests/integration/test_mwr_api.py
@@ -65,6 +65,39 @@ def test_calculate_mwr_endpoint_xirr_happy_path(client):
     }
 
 
+def test_calculate_mwr_endpoint_emits_solver_outcome_metric(client):
+    payload = {
+        "calculation_id": str(uuid4()),
+        "portfolio_id": "MWR_METRIC_MULTIPLE_ROOT",
+        "begin_mv": 100.0,
+        "end_mv": -132.0,
+        "as_of": "2028-01-01",
+        "start_date": "2026-01-01",
+        "cash_flows": [{"amount": -230.0, "date": "2027-01-01"}],
+        "mwr_method": "XIRR",
+        "annualization": {"enabled": False, "basis": "ACT/365"},
+    }
+
+    response = client.post("/performance/mwr", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "FALLBACK_USED"
+    assert body["fallback_reason"] == "MULTIPLE_IRR_ROOTS_DETECTED"
+
+    metrics = client.get("/metrics")
+
+    assert metrics.status_code == 200
+    assert (
+        'lotus_performance_mwr_solver_outcome_total{fallback_used="true",input_mode="stateless",'
+        'method="DIETZ",reason_code="MULTIPLE_IRR_ROOTS_DETECTED",status="FALLBACK_USED"}' in metrics.text
+    )
+    assert (
+        'lotus_performance_mwr_solver_outcome_total{fallback_used="true",input_mode="stateless",'
+        'method="DIETZ",reason_code="DIETZ_FALLBACK_USED",status="FALLBACK_USED"}' in metrics.text
+    )
+
+
 def test_calculate_mwr_endpoint_supports_stateful_mode(client, monkeypatch):
     async def _mock_get_portfolio_timeseries(self, **kwargs):  # noqa: ARG001
         return (

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -263,11 +263,13 @@ def test_mwr_guide_matches_current_method_reality():
     assert "holding_period_return" in guide
     assert "fallback_reason" in guide
     assert "root_count_detected" in guide
+    assert "lotus_performance_mwr_solver_outcome_total" in guide
     assert "mwr-lotus-production-controls.md" in guide
     assert "mwr-production-support-playbook.md" in guide
     assert "mwr-industry-review-findings.md" in guide
     assert "investor capital-timing lens" in certification
     assert "No-root and multiple-root cases are not silently interpreted" in certification
+    assert "lotus_performance_mwr_solver_outcome_total" in certification
     assert 'status="FALLBACK_USED"' in certification
     assert "CORE_CONTROL_PLANE_BASE_URL" in certification
     assert "lotus-gateway" in certification
@@ -295,6 +297,7 @@ def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     assert "lotus-gateway" in controls
     assert "data mesh" in controls.lower()
     assert "calculation_supportability" in playbook
+    assert "lotus_performance_mwr_solver_outcome_total" in playbook
     assert "NO_ECONOMIC_CONTENT" in playbook
     assert "Adopted Into The Current Contract" in findings
     assert "Areas Where Lotus Is Stronger" in findings

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -2,12 +2,14 @@ import json
 import logging
 
 from fastapi import Request
+from prometheus_client import REGISTRY, generate_latest
 
 from app.observability import (
     JsonFormatter,
     build_access_log_fields,
     correlation_id_var,
     propagation_headers,
+    record_mwr_solver_outcome,
     request_id_var,
     resolve_correlation_id,
     resolve_request_id,
@@ -99,3 +101,31 @@ def test_build_access_log_fields_contains_platform_duration_and_legacy_latency()
     assert fields["endpoint"] == "/health"
     assert fields["duration_ms"] == 10.5
     assert fields["latency_ms"] == 10.5
+
+
+def test_record_mwr_solver_outcome_uses_bounded_support_safe_labels():
+    record_mwr_solver_outcome(
+        input_mode="stateful",
+        method="XIRR",
+        status="FALLBACK_USED",
+        reason_codes=["MULTIPLE_IRR_ROOTS_DETECTED"],
+        fallback_used=True,
+    )
+    record_mwr_solver_outcome(
+        input_mode="portfolio-123",
+        method="CUSTOM",
+        status="SURPRISE",
+        reason_codes=["portfolio-123"],
+        fallback_used=False,
+    )
+
+    metrics_text = generate_latest(REGISTRY).decode("utf-8")
+
+    assert (
+        'lotus_performance_mwr_solver_outcome_total{fallback_used="true",input_mode="stateful",'
+        'method="XIRR",reason_code="MULTIPLE_IRR_ROOTS_DETECTED",status="FALLBACK_USED"}' in metrics_text
+    )
+    assert (
+        'lotus_performance_mwr_solver_outcome_total{fallback_used="false",input_mode="other",'
+        'method="OTHER",reason_code="OTHER",status="OTHER"}' in metrics_text
+    )

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -70,6 +70,7 @@ executor-backed and lineage-backed workflows.
   [docs/runbooks/runtime-retention-cleanup.md](../docs/runbooks/runtime-retention-cleanup.md)
 - MWR support:
   [docs/operations/mwr-production-support-playbook.md](../docs/operations/mwr-production-support-playbook.md)
+  and `lotus_performance_mwr_solver_outcome_total` for fallback, no-root, and multiple-root rates.
 
 ## Runtime thresholds and overlays
 


### PR DESCRIPTION
## Summary

- Adds bounded `lotus_performance_mwr_solver_outcome_total` Prometheus counter for MWR solver outcomes.
- Records input mode, method, status, reason code, and fallback flag without portfolio/client/request identifiers.
- Adds unit and integration coverage for bounded labels and `/metrics` emission on fallback/multiple-root outcomes.
- Updates MWR guide, support playbook, certification, findings, and wiki source with the implementation-backed operator signal.

## Validation

- `python -m pytest tests/unit/test_observability.py tests/integration/test_mwr_api.py tests/unit/docs/test_public_docs_contract.py -q`
- `python -m ruff check app/observability.py app/observability_contracts.py app/api/endpoints/performance.py tests/unit/test_observability.py tests/integration/test_mwr_api.py tests/unit/docs/test_public_docs_contract.py`
- `python -m ruff format --check app/observability.py app/observability_contracts.py app/api/endpoints/performance.py tests/unit/test_observability.py tests/integration/test_mwr_api.py tests/unit/docs/test_public_docs_contract.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance -AllowUnpublishedSourceChanges`
- `make check`
- `python automation\validate_engineering_context_system.py` in `lotus-platform`
- `python automation\validate_lotus_skill_alignment.py` in `lotus-platform`
- `powershell -ExecutionPolicy Bypass -File automation\Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget -CheckOnly` in `lotus-platform`

## Wiki

Repo-local wiki source changed. Publish after merge with:

`powershell -ExecutionPolicy Bypass -File lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-performance`