### PR TITLE
Add MWR alerting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ The runtime is intentionally durable:
 Key operator and certification references:
 
 - [docs/runbooks/runtime-alerts.md](docs/runbooks/runtime-alerts.md)
+- [docs/operations/mwr-alert-rule-templates.md](docs/operations/mwr-alert-rule-templates.md)
 - [docs/runbooks/durable-metadata-recovery.md](docs/runbooks/durable-metadata-recovery.md)
 - [docs/runbooks/runtime-retention-cleanup.md](docs/runbooks/runtime-retention-cleanup.md)
 - [docs/technical/lineage-endpoint-certification.md](docs/technical/lineage-endpoint-certification.md)

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -844,6 +844,7 @@ Return semantics for the workspace surface are now explicit rather than inferred
   - `docs/runbooks/runtime-alerts.md` is the governed first-response guide for queue, storage, and recovery-drill breach gauges
 - alert templates:
   - `docs/operations/runtime-alert-rule-templates.md` provides Prometheus-style expressions for the breach and availability gauges exported here
+  - `docs/operations/mwr-alert-rule-templates.md` provides Prometheus-style expressions and dashboard panels for MWR fallback, no-root, multiple-root, and source-data rejection rates
 - alert policy:
   - `docs/standards/runtime-alert-policy.md` defines the default severity and response class for these breach and availability gauges
 - threshold profiles:
@@ -882,6 +883,9 @@ Return semantics for the workspace surface are now explicit rather than inferred
   - `lotus_performance_lineage_storage_capacity_bytes{segment="total|used|free"}`
   - `lotus_performance_lineage_storage_free_ratio`
   - `lotus_performance_lineage_storage_pressure_threshold{threshold="min_free_bytes|min_free_ratio"}`
+- includes MWR operational posture metrics:
+  - `lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}`
+  - `lotus_performance_calculation_supportability_total{operation="mwr",supportability_state,reason,freshness_bucket}`
 
 ## Runtime Operations
 

--- a/docs/guides/mwr.md
+++ b/docs/guides/mwr.md
@@ -221,3 +221,5 @@ documentation rather than retained as generic reference text:
 Operational trend visibility is exposed through
 `lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}` for
 fallback, no-root, and multiple-root rate monitoring.
+Alert and dashboard templates for this signal live in
+`docs/operations/mwr-alert-rule-templates.md`.

--- a/docs/operations/mwr-alert-rule-templates.md
+++ b/docs/operations/mwr-alert-rule-templates.md
@@ -1,0 +1,175 @@
+# MWR Alert And Dashboard Templates
+
+- Service: `lotus-performance`
+- Scope: Prometheus-style alert rules and dashboard panels for `/performance/mwr` solver ambiguity,
+  fallback, and source-data rejection posture
+- Related references:
+  - `docs/operations/mwr-production-support-playbook.md`
+  - `docs/guides/mwr.md`
+  - `docs/technical/mwr-endpoint-certification.md`
+  - `docs/technical/mwr-industry-review-findings.md`
+  - `docs/runbooks/runtime-alerts.md`
+  - `docs/standards/runtime-alert-policy.md`
+
+These templates use service-owned, bounded-label metrics. They must not introduce portfolio,
+client, tenant, account, calculation, trace, correlation, request, or response identifiers into
+Prometheus labels.
+
+## Metric Contract
+
+MWR solver outcomes are emitted through:
+
+`lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}`
+
+Source-data supportability posture is read from the shared calculation-supportability metric:
+
+`lotus_performance_calculation_supportability_total{operation,supportability_state,reason,freshness_bucket}`
+
+## Recording Queries
+
+Use a 30-minute observation window for operator dashboards and a 15-minute window only in
+high-volume environments where the sample count is large enough to avoid noisy ratios.
+
+```promql
+sum(increase(lotus_performance_mwr_solver_outcome_total[30m]))
+```
+
+```promql
+sum(increase(lotus_performance_mwr_solver_outcome_total{fallback_used="true"}[30m]))
+/
+clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)
+```
+
+```promql
+sum(increase(lotus_performance_mwr_solver_outcome_total{reason_code="NO_ROOT_FOUND"}[30m]))
+/
+clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)
+```
+
+```promql
+sum(increase(lotus_performance_mwr_solver_outcome_total{reason_code="MULTIPLE_IRR_ROOTS_DETECTED"}[30m]))
+/
+clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)
+```
+
+```promql
+sum(increase(lotus_performance_calculation_supportability_total{
+  operation="mwr",
+  supportability_state=~"empty|stale"
+}[30m]))
+/
+clamp_min(sum(increase(lotus_performance_calculation_supportability_total{operation="mwr"}[30m])), 1)
+```
+
+## Alert Rule Templates
+
+Thresholds below are production defaults for portfolio-advisory operations. Environments with low
+MWR volume should pair each ratio alert with a minimum sample count before paging.
+
+```yaml
+- alert: LotusPerformanceMWRFallbackRateElevated
+  expr: |
+    (
+      sum(increase(lotus_performance_mwr_solver_outcome_total{fallback_used="true"}[30m]))
+      /
+      clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)
+    ) > 0.05
+    and
+    sum(increase(lotus_performance_mwr_solver_outcome_total[30m])) >= 20
+  for: 30m
+  labels:
+    severity: ticket
+    service: lotus-performance
+    product: mwr
+  annotations:
+    summary: "lotus-performance MWR fallback rate elevated"
+    description: "More than 5% of recent MWR calculations used a labeled fallback."
+    runbook: "docs/operations/mwr-production-support-playbook.md"
+```
+
+```yaml
+- alert: LotusPerformanceMWRNoRootRateElevated
+  expr: |
+    (
+      sum(increase(lotus_performance_mwr_solver_outcome_total{reason_code="NO_ROOT_FOUND"}[30m]))
+      /
+      clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)
+    ) > 0.02
+    and
+    sum(increase(lotus_performance_mwr_solver_outcome_total[30m])) >= 20
+  for: 30m
+  labels:
+    severity: ticket
+    service: lotus-performance
+    product: mwr
+  annotations:
+    summary: "lotus-performance MWR no-root rate elevated"
+    description: "More than 2% of recent MWR calculations could not find an XIRR root."
+    runbook: "docs/operations/mwr-production-support-playbook.md"
+```
+
+```yaml
+- alert: LotusPerformanceMWRMultipleRootRateElevated
+  expr: |
+    (
+      sum(increase(lotus_performance_mwr_solver_outcome_total{reason_code="MULTIPLE_IRR_ROOTS_DETECTED"}[30m]))
+      /
+      clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)
+    ) > 0.01
+    and
+    sum(increase(lotus_performance_mwr_solver_outcome_total[30m])) >= 20
+  for: 30m
+  labels:
+    severity: ticket
+    service: lotus-performance
+    product: mwr
+  annotations:
+    summary: "lotus-performance MWR multiple-root rate elevated"
+    description: "More than 1% of recent MWR calculations detected multiple valid IRR roots."
+    runbook: "docs/operations/mwr-production-support-playbook.md"
+```
+
+```yaml
+- alert: LotusPerformanceMWRSourceDataRejectionRateElevated
+  expr: |
+    (
+      sum(increase(lotus_performance_calculation_supportability_total{
+        operation="mwr",
+        supportability_state=~"empty|stale"
+      }[30m]))
+      /
+      clamp_min(sum(increase(lotus_performance_calculation_supportability_total{operation="mwr"}[30m])), 1)
+    ) > 0.03
+    and
+    sum(increase(lotus_performance_calculation_supportability_total{operation="mwr"}[30m])) >= 20
+  for: 30m
+  labels:
+    severity: ticket
+    service: lotus-performance
+    product: mwr
+  annotations:
+    summary: "lotus-performance MWR source-data rejection rate elevated"
+    description: "More than 3% of recent MWR calculations reported empty or stale source supportability."
+    runbook: "docs/operations/mwr-production-support-playbook.md"
+```
+
+## Dashboard Panels
+
+Use these panels for production operations, support review, and client-demo readiness checks:
+
+| Panel | Query | Audience |
+| --- | --- | --- |
+| MWR request volume | `sum(increase(lotus_performance_mwr_solver_outcome_total[30m]))` | operations, engineering |
+| Fallback rate | `sum(increase(lotus_performance_mwr_solver_outcome_total{fallback_used="true"}[30m])) / clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)` | operations, support, business users |
+| No-root rate | `sum(increase(lotus_performance_mwr_solver_outcome_total{reason_code="NO_ROOT_FOUND"}[30m])) / clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)` | operations, engineering |
+| Multiple-root rate | `sum(increase(lotus_performance_mwr_solver_outcome_total{reason_code="MULTIPLE_IRR_ROOTS_DETECTED"}[30m])) / clamp_min(sum(increase(lotus_performance_mwr_solver_outcome_total[30m])), 1)` | support, business users |
+| Source-data rejection rate | `sum(increase(lotus_performance_calculation_supportability_total{operation="mwr",supportability_state=~"empty|stale"}[30m])) / clamp_min(sum(increase(lotus_performance_calculation_supportability_total{operation="mwr"}[30m])), 1)` | operations, upstream data owners |
+
+## Response Guidance
+
+- Treat `MULTIPLE_IRR_ROOTS_DETECTED` as a business-explainability signal, not as a platform outage.
+- Treat `NO_ROOT_FOUND` as a data-shape or economics review signal until a runtime failure is proven.
+- Treat elevated source-data rejection as a data mesh escalation to the `lotus-core` source-data
+  owner when stateful stale or insufficient observations are confirmed.
+- Pair every alert investigation with a sample response review so supportability fields and
+  client-safe explanations stay aligned with `docs/operations/mwr-production-support-playbook.md`.

--- a/docs/operations/mwr-production-support-playbook.md
+++ b/docs/operations/mwr-production-support-playbook.md
@@ -19,6 +19,9 @@ not be used to infer unsupported calculation behavior.
 7. Check `/metrics` for
    `lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}`
    when triaging repeated fallback, no-root, or multiple-root patterns.
+8. Use `docs/operations/mwr-alert-rule-templates.md` for Prometheus alert rules and dashboard
+   panels that track fallback rate, no-root rate, multiple-root rate, and source-data rejection
+   rate.
 
 ## Reason-Code Triage
 
@@ -52,6 +55,11 @@ Escalate to `lotus-performance` engineering when:
 - repeated stateful requests show inconsistent supportability metadata for the same input evidence.
 - `lotus_performance_mwr_solver_outcome_total` stops emitting bounded `reason_code`, `status`, or
   `fallback_used` labels for completed MWR responses.
+- `LotusPerformanceMWRFallbackRateElevated`,
+  `LotusPerformanceMWRNoRootRateElevated`,
+  `LotusPerformanceMWRMultipleRootRateElevated`, or
+  `LotusPerformanceMWRSourceDataRejectionRateElevated` remains active after the first
+  response checks in `docs/operations/mwr-alert-rule-templates.md`.
 
 Escalate to upstream data ownership when:
 

--- a/docs/standards/runtime-alert-policy.md
+++ b/docs/standards/runtime-alert-policy.md
@@ -4,6 +4,7 @@
 - Scope: severity, expected response class, and ownership policy for runtime breach gauges and their availability signals
 - Related references:
   - `docs/operations/runtime-alert-rule-templates.md`
+  - `docs/operations/mwr-alert-rule-templates.md`
   - `docs/runbooks/runtime-alerts.md`
   - `docs/standards/scalability-availability.md`
   - `docs/standards/runtime-threshold-profiles.md`
@@ -36,6 +37,8 @@
 | `lotus_performance_lineage_storage_capacity_availability` == `0` | `page` | Storage-capacity blindness removes early warning before lineage write failure. |
 | `lotus_performance_recovery_drill_availability` == `0` | `page` | Recovery evidence becomes unreadable, so recovery-governance signals are no longer trustworthy. |
 | `lotus_performance_runtime_retention_availability` == `0` | `page` | Retention evidence becomes unreadable, so lifecycle-governance signals are no longer trustworthy. |
+| MWR fallback/no-root/multiple-root rate alerts | `ticket` | These indicate calculation ambiguity or data-shape drift that requires support and engineering review, but does not by itself prove service outage. |
+| MWR source-data rejection rate alert | `ticket` | Empty or stale source supportability is a data mesh quality escalation unless paired with readiness or upstream availability failure. |
 
 ## Response Targets
 

--- a/docs/technical/mwr-endpoint-certification.md
+++ b/docs/technical/mwr-endpoint-certification.md
@@ -93,6 +93,9 @@ calculation, trace, correlation, request body, response body, or security identi
 The solver-outcome metric follows the same support-safety rule: label values are bounded to input
 mode, calculation method, outcome status, reason code, and fallback flag.
 
+Operational alert and dashboard templates for fallback, no-root, multiple-root, and stateful
+source-data rejection rates are governed in `docs/operations/mwr-alert-rule-templates.md`.
+
 Calculation-quality metadata is part of the product contract:
 
 - `status="CALCULATED"` means the emitted method completed without fallback.

--- a/docs/technical/mwr-industry-review-findings.md
+++ b/docs/technical/mwr-industry-review-findings.md
@@ -14,7 +14,7 @@ was used as a review input; the durable documentation is now Lotus-authored and 
 | Distinguish annualized and holding-period returns. | `money_weighted_return` remains the primary annualized value and `holding_period_return` is emitted separately. |
 | Net same-day cash flows deterministically. | Cash flows are normalized and netted by date before solving; tests prove order independence. |
 | Make support behavior operationally usable. | The MWR support playbook maps reason codes to support actions and client-safe explanations. |
-| Track fallback and solver ambiguity rates operationally. | `/metrics` emits `lotus_performance_mwr_solver_outcome_total` with bounded labels for input mode, method, status, reason code, and fallback use. |
+| Track fallback and solver ambiguity rates operationally. | `/metrics` emits `lotus_performance_mwr_solver_outcome_total` with bounded labels for input mode, method, status, reason code, and fallback use; `docs/operations/mwr-alert-rule-templates.md` converts those signals into Lotus alert and dashboard templates. |
 
 ## Areas Where Lotus Is Stronger
 
@@ -43,11 +43,9 @@ Candidate enhancements should be implemented as governed slices:
 
 1. Add an independently certified Modified Dietz method if business reporting requires it separately
    from the current labeled fallback path.
-2. Add alert thresholds and dashboards for the emitted MWR solver-outcome metric, including fallback
-   rate, no-root rate, multiple-root rate, and stateful source-data rejection rate.
-3. Add FX-aware MWR only after the cross-repository currency contract is explicit and consumer
+2. Add FX-aware MWR only after the cross-repository currency contract is explicit and consumer
    surfaces can show currency provenance.
-4. Extend demo/wiki material when front-office surfaces expose reason-code drill-downs directly.
+3. Extend demo/wiki material when front-office surfaces expose reason-code drill-downs directly.
 
 ## Proof Points
 
@@ -59,4 +57,5 @@ Implementation-backed proof currently lives in:
 - `tests/integration/test_response_attribute_certification.py` for emitted response fields;
 - `tests/unit/test_observability.py` for bounded MWR metric labels;
 - `docs/guides/mwr-lotus-production-controls.md` and
-  `docs/operations/mwr-production-support-playbook.md` for product and support documentation.
+  `docs/operations/mwr-production-support-playbook.md` for product and support documentation;
+- `docs/operations/mwr-alert-rule-templates.md` for MWR alert thresholds and dashboard queries.

--- a/docs/technical/runtime_topology.md
+++ b/docs/technical/runtime_topology.md
@@ -113,6 +113,8 @@ Operator first response for these breach gauges is governed in
 [runtime-alerts.md](/C:/Users/Sandeep/projects/lotus-performance/docs/runbooks/runtime-alerts.md).
 Prometheus-style rule templates for the same gauges are governed in
 [runtime-alert-rule-templates.md](/C:/Users/Sandeep/projects/lotus-performance/docs/operations/runtime-alert-rule-templates.md).
+MWR fallback, no-root, multiple-root, and source-data rejection alert templates are governed
+in [mwr-alert-rule-templates.md](/C:/Users/Sandeep/projects/lotus-performance/docs/operations/mwr-alert-rule-templates.md).
 Severity and response defaults for those rules are governed in
 [runtime-alert-policy.md](/C:/Users/Sandeep/projects/lotus-performance/docs/standards/runtime-alert-policy.md).
 Recommended dev, staging, and production threshold values are governed in

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -282,6 +282,7 @@ def test_mwr_guide_matches_current_method_reality():
 def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     controls = _read("docs/guides/mwr-lotus-production-controls.md")
     playbook = _read("docs/operations/mwr-production-support-playbook.md")
+    alert_templates = _read("docs/operations/mwr-alert-rule-templates.md")
     findings = _read("docs/technical/mwr-industry-review-findings.md")
     guide = _read("docs/guides/mwr.md")
     api_wiki = _read("wiki/API-Surface.md")
@@ -298,13 +299,24 @@ def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     assert "data mesh" in controls.lower()
     assert "calculation_supportability" in playbook
     assert "lotus_performance_mwr_solver_outcome_total" in playbook
+    assert "mwr-alert-rule-templates.md" in playbook
     assert "NO_ECONOMIC_CONTENT" in playbook
     assert "Adopted Into The Current Contract" in findings
     assert "Areas Where Lotus Is Stronger" in findings
     assert "Backlog Candidates" in findings
+    assert "mwr-alert-rule-templates.md" in findings
+    assert "LotusPerformanceMWRFallbackRateElevated" in alert_templates
+    assert "LotusPerformanceMWRNoRootRateElevated" in alert_templates
+    assert "LotusPerformanceMWRMultipleRootRateElevated" in alert_templates
+    assert "LotusPerformanceMWRSourceDataRejectionRateElevated" in alert_templates
+    assert "MULTIPLE_IRR_ROOTS_DETECTED" in alert_templates
+    assert "NO_ROOT_FOUND" in alert_templates
+    assert 'supportability_state=~"empty|stale"' in alert_templates
     assert "mwr-lotus-production-controls.md" in guide
+    assert "mwr-alert-rule-templates.md" in guide
     assert "mwr-lotus-production-controls.md" in api_wiki
     assert "mwr-production-support-playbook.md" in ops_wiki
+    assert "mwr-alert-rule-templates.md" in ops_wiki
 
 
 def test_twr_mwr_response_attribute_certification_documents_field_level_checks():
@@ -847,6 +859,7 @@ def test_enterprise_readiness_covers_privileged_operator_reads():
 
 def test_runtime_alert_templates_cover_exported_breach_gauges():
     templates = _read("docs/operations/runtime-alert-rule-templates.md")
+    mwr_templates = _read("docs/operations/mwr-alert-rule-templates.md")
     runbook = _read("docs/runbooks/runtime-alerts.md")
     api_reference = _read("docs/guides/api_reference.md")
     runtime_topology = _read("docs/technical/runtime_topology.md")
@@ -860,9 +873,13 @@ def test_runtime_alert_templates_cover_exported_breach_gauges():
     assert "lotus_performance_lineage_storage_capacity_availability" in templates
     assert "lotus_performance_recovery_drill_availability" in templates
     assert "lotus_performance_runtime_retention_availability" in templates
+    assert "lotus_performance_mwr_solver_outcome_total" in mwr_templates
+    assert "lotus_performance_calculation_supportability_total" in mwr_templates
     assert "docs/operations/runtime-alert-rule-templates.md" in runbook
     assert "runtime-alert-rule-templates.md" in api_reference
+    assert "mwr-alert-rule-templates.md" in api_reference
     assert "runtime-alert-rule-templates.md" in runtime_topology
+    assert "mwr-alert-rule-templates.md" in runtime_topology
 
 
 def test_runtime_alert_policy_governs_severity_defaults():
@@ -879,6 +896,8 @@ def test_runtime_alert_policy_governs_severity_defaults():
     assert "lotus_performance_lineage_storage_pressure_breach" in policy
     assert "lotus_performance_recovery_drill_degradation_breach" in policy
     assert "lotus_performance_runtime_retention_degradation_breach" in policy
+    assert "MWR fallback/no-root/multiple-root rate alerts" in policy
+    assert "MWR source-data rejection rate alert" in policy
     assert "`page`" in policy
     assert "`ticket`" in policy
     assert "docs/standards/runtime-alert-policy.md" in templates

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -71,6 +71,8 @@ executor-backed and lineage-backed workflows.
 - MWR support:
   [docs/operations/mwr-production-support-playbook.md](../docs/operations/mwr-production-support-playbook.md)
   and `lotus_performance_mwr_solver_outcome_total` for fallback, no-root, and multiple-root rates.
+- MWR alert and dashboard templates:
+  [docs/operations/mwr-alert-rule-templates.md](../docs/operations/mwr-alert-rule-templates.md)
 
 ## Runtime thresholds and overlays
 


### PR DESCRIPTION
## Summary

- Adds implementation-backed MWR Prometheus alert and dashboard templates for fallback, no-root, multiple-root, and source-data supportability rates.
- Links the new alert templates from the MWR guide, support playbook, endpoint certification, runtime topology, API reference, README, and repo-local wiki source.
- Updates docs contract tests so the MWR alerting material remains backed by the emitted metric contracts.

## Validation

- `python -m pytest tests/unit/docs/test_public_docs_contract.py -q`
- `python -m ruff check tests/unit/docs/test_public_docs_contract.py`
- `python -m ruff format --check tests/unit/docs/test_public_docs_contract.py`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance -AllowUnpublishedSourceChanges`
- `make check`
- `python automation\validate_engineering_context_system.py` in `lotus-platform`
- `python automation\validate_lotus_skill_alignment.py` in `lotus-platform`
- `powershell -ExecutionPolicy Bypass -File automation\Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget -CheckOnly` in `lotus-platform`

## Wiki

Repo-local wiki source changed. Publish after merge with:

`powershell -ExecutionPolicy Bypass -File lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-performance`