### PR TITLE
Document MWR FX contract gate

### DIFF
--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -40,8 +40,9 @@ Validation posture:
 
 Current coverage boundary:
 
-1. this directory covers the currently governed `ReturnsSeriesBundle` and `BenchmarkExposureContext`
-   products plus the first-wave `lotus-core` dependency declarations already aligned under RFC-0084,
+1. this directory covers the currently governed `MoneyWeightedReturnAnalytics`,
+   `ReturnsSeriesBundle`, and `BenchmarkExposureContext` products plus the first-wave `lotus-core`
+   dependency declarations already aligned under RFC-0084,
 2. benchmark-definition, benchmark-composition, vendor-return, index-catalog, index-price-series, and
    FX operational-read dependencies remain documented in `docs/technical/RFC-0082-upstream-contract-family-map.md`
    but are not yet machine-readable here because the corresponding upstream producer declarations have not

--- a/contracts/domain-data-products/lotus-performance-products.v1.json
+++ b/contracts/domain-data-products/lotus-performance-products.v1.json
@@ -6,6 +6,65 @@
   "authoritative_domain": "performance_analytics",
   "products": [
     {
+      "product_name": "MoneyWeightedReturnAnalytics",
+      "product_version": "v1",
+      "owner_repository": "lotus-performance",
+      "product_family": "analytics_output",
+      "authoritative_domain": "performance_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "valuation_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "generated_at",
+        "as_of_date",
+        "correlation_id",
+        "request_fingerprint",
+        "source_services",
+        "upstream_request_fingerprints",
+        "data_quality_status"
+      ],
+      "current_routes": [
+        "/performance/mwr"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Stateful MWR is recalculated from governed upstream portfolio observations for the requested as-of date and measurement window."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable",
+        "lineage_bundle_class_ref": "customer_lineage_summary"
+      },
+      "security_profile_ref": "system_access:client_confidential:retain_for_client_record:audit_system_access",
+      "approved_consumers": [
+        "lotus-gateway"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "calculation_id",
+        "correlation_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
       "product_name": "ReturnsSeriesBundle",
       "product_version": "v1",
       "owner_repository": "lotus-performance",

--- a/docs/guides/mwr.md
+++ b/docs/guides/mwr.md
@@ -143,6 +143,9 @@ calculation.
 
 MWR is not decomposed into local and FX components on the current public contract. Callers should
 submit `begin_mv`, `end_mv`, and `cash_flows` in one consistent reporting currency.
+`cashflows_used` proves the signed schedule used by the engine; it is not FX conversion provenance.
+The implementation-readiness contract for a future FX-aware MWR extension is documented in
+[MWR FX-aware contract design](../technical/mwr-fx-contract-design.md).
 
 ## Example request
 
@@ -225,6 +228,9 @@ documentation rather than retained as generic reference text:
 - [MWR industry review findings](../technical/mwr-industry-review-findings.md) records what was
   adopted, what Lotus already handled more strongly, and which candidate enhancements remain outside
   the current implementation-backed contract.
+- [MWR FX-aware contract design](../technical/mwr-fx-contract-design.md) defines the upstream,
+  downstream, lineage, and testing gates required before multi-currency per-flow conversion becomes
+  supported MWR behavior.
 
 Operational trend visibility is exposed through
 `lotus_performance_mwr_solver_outcome_total{input_mode,method,status,reason_code,fallback_used}` for

--- a/docs/methodologies/metrics/master-index.md
+++ b/docs/methodologies/metrics/master-index.md
@@ -42,6 +42,9 @@ This index maps implemented lotus-performance metrics to detailed methodology do
   `lotus-performance`.
 - In current engine behavior, `mwr_method=MODIFIED_DIETZ` uses dated cash-flow weights and
   `mwr_method=DIETZ` keeps the midpoint Simple Dietz path.
+- Current MWR methodology documents assume a single reporting-currency schedule. Future FX-aware MWR
+  is governed by `docs/technical/mwr-fx-contract-design.md` and is not implementation-supported
+  until upstream FX evidence, response provenance, consumer propagation, and tests are complete.
 
 
 ## Documentation Standard

--- a/docs/methodologies/metrics/metric-mwr-dietz.md
+++ b/docs/methodologies/metrics/metric-mwr-dietz.md
@@ -36,6 +36,9 @@ or `MODIFIED_DIETZ`)
 
 ## Unit Conventions
 - Amount fields are currency amounts.
+- `begin_mv`, `end_mv`, and `cash_flows[].amount` must be in one reporting currency before the
+  Dietz-family calculation runs; current `cashflows_used` output is schedule evidence, not FX
+  conversion provenance.
 - `money_weighted_return`, `mwr_annualized`, and `holding_period_return` are percentage points.
 - Internal periodic Dietz rate is decimal and multiplied by 100 for output.
 
@@ -104,6 +107,9 @@ or `MODIFIED_DIETZ`)
 - Source fee rows are preserved as performance drag by the upstream analytics input and are not
   included as investor cash flows; unsupported or invalid source cash-flow rows are skipped during
   normalization rather than guessed.
+- Mixed source-currency schedules are not converted by the current Dietz-family path. FX-aware MWR
+  remains gated by `docs/technical/mwr-fx-contract-design.md` and must fail closed in any future
+  implementation when conversion evidence is incomplete.
 - Explicit `MODIFIED_DIETZ` and `DIETZ` requests return `status="CALCULATED"` when the denominator
   is non-zero.
 - XIRR fallback responses return `status="FALLBACK_USED"`, include the XIRR failure reason and

--- a/docs/methodologies/metrics/metric-mwr-xirr.md
+++ b/docs/methodologies/metrics/metric-mwr-xirr.md
@@ -32,6 +32,9 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 
 ## Unit Conventions
 - Cash flow and market values are currency amounts.
+- `begin_mv`, `end_mv`, and `cash_flows[].amount` must be in one reporting currency before the
+  XIRR solver runs; current `cashflows_used` output is schedule evidence, not FX conversion
+  provenance.
 - `money_weighted_return`, `mwr_annualized`, and `holding_period_return` are percentage points.
 - XIRR uses a decimal annual rate internally, then multiplies by 100 for response fields.
 - Successful XIRR returns an annualized primary value; `holding_period_return` gives the measured-period equivalent.
@@ -100,6 +103,9 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 - Source fee rows are preserved as performance drag by the upstream analytics input and are not
   included as investor cash flows; unsupported or invalid source cash-flow rows are skipped during
   normalization rather than guessed.
+- Mixed source-currency schedules are not converted by the current XIRR path. FX-aware MWR remains
+  gated by `docs/technical/mwr-fx-contract-design.md` and must fail closed in any future
+  implementation when conversion evidence is incomplete.
 - `NO_ECONOMIC_CONTENT` returns `status="NOT_APPLICABLE"`.
 - `NO_POSITIVE_AND_NEGATIVE_CASH_FLOW`, `NO_ROOT_FOUND`, `MULTIPLE_IRR_ROOTS_DETECTED`, and
   `INVALID_SOLVER_BOUNDS` enter a labeled Modified Dietz fallback unless no economic content exists.

--- a/docs/technical/methodology_index.md
+++ b/docs/technical/methodology_index.md
@@ -7,6 +7,7 @@ analytics and integration surfaces.
 
 - [guides/twr.md](../guides/twr.md)
 - [guides/mwr.md](../guides/mwr.md)
+- [technical/mwr-fx-contract-design.md](mwr-fx-contract-design.md)
 - [guides/contribution.md](../guides/contribution.md)
 - [guides/attribution.md](../guides/attribution.md)
 - [guides/workspace_summary.md](../guides/workspace_summary.md)
@@ -49,6 +50,9 @@ That set is the authoritative metric-by-metric reference for:
   execution. Stateful MWR uses lotus-core portfolio timeseries to resolve the investor
   capital-timing input schedule; downstream callers should use the source-owned response fields and
   must not reconstruct MWR inputs from TWR, benchmark, or workspace summary payloads.
+- Current MWR methods require a single reporting-currency schedule. FX-aware MWR remains gated by
+  [mwr-fx-contract-design.md](mwr-fx-contract-design.md), including upstream FX evidence,
+  reporting-currency provenance, gateway and Workbench propagation, and fail-closed validation.
 - `POST /performance/contribution` also supports stateful execution. Stateful contribution resolves
   lotus-core portfolio and position timeseries into source-normalized contribution inputs; callers
   should consume emitted contribution results and supportability rather than reconstructing

--- a/docs/technical/mwr-fx-contract-design.md
+++ b/docs/technical/mwr-fx-contract-design.md
@@ -1,0 +1,123 @@
+# MWR FX-Aware Contract Design
+
+This document defines the Lotus readiness contract for adding FX-aware money-weighted return (MWR)
+without weakening the current implementation-backed contract.
+
+## Current Production Contract
+
+`POST /performance/mwr` currently computes MWR from a single reporting-currency input schedule:
+
+- `begin_mv`
+- `end_mv`
+- `cash_flows[].amount`
+- `start_date`
+- `as_of`
+
+The current engine does not convert per-flow source currencies inside MWR. It expects all market
+values and cash flows to already be expressed in one consistent reporting currency before XIRR,
+Modified Dietz, or Simple Dietz execution. This is intentional: today's `cashflows_used` response
+echo proves the signed schedule used by the engine, not FX conversion provenance.
+
+## Design Goal
+
+FX-aware MWR should allow private-bank users to explain investor-experience return when capital
+movements, valuations, or reporting contexts cross currencies. The design must preserve the Lotus
+ownership boundary:
+
+1. `lotus-core` remains the source authority for portfolio observations, source currencies,
+   reporting currency context, and governed FX evidence.
+2. `lotus-performance` remains the methodology authority for MWR normalization, XIRR root solving,
+   Dietz fallback behavior, supportability metadata, and emitted performance product truth.
+3. `lotus-gateway`, Workbench, reporting, and other consumers display the emitted performance
+   product; they must not reconstruct FX conversion, infer missing rate evidence, or recalculate
+   MWR locally.
+
+## Required Input Provenance
+
+Before FX-aware MWR can become an implemented API contract, every converted monetary input must
+carry enough evidence to make the reporting-currency schedule reproducible.
+
+| Input evidence | Required meaning |
+| --- | --- |
+| `source_amount` | Original amount before conversion. |
+| `source_currency` | ISO reporting source currency attached to the original observation or cash flow. |
+| `reporting_amount` | Converted amount used by the MWR engine. |
+| `reporting_currency` | Portfolio or requested reporting currency used for the calculation. |
+| `fx_rate` | Rate used to convert source amount to reporting amount. |
+| `fx_pair` | Canonical currency pair for the conversion. |
+| `fx_rate_date` | Business date for the rate. |
+| `fx_rate_source` | Source system, vendor, or governed Lotus rate set. |
+| `fx_rate_version` | Restatement/version identifier when available. |
+| `conversion_policy` | Policy such as transaction-date spot, valuation-date spot, or source-preconverted. |
+| `conversion_timestamp` | Timestamp at which conversion evidence was assembled. |
+| `conversion_fingerprint` | Stable fingerprint for reproducibility and lineage tie-out. |
+
+For stateful MWR, this evidence must come from governed upstream analytics-input contracts. For
+stateless MWR, the caller must provide complete conversion evidence if the request asks
+`lotus-performance` to treat amounts as FX-aware. Missing or partial evidence must fail closed
+rather than falling back to guessed rates.
+
+## Proposed Response Semantics
+
+When implemented, FX-aware MWR should extend the response only after OpenAPI, gateway, Workbench,
+and documentation consumers are ready. The response should make the following visible:
+
+- `reporting_currency` for the MWR result.
+- `currency_mode` or equivalent posture that distinguishes base-only from FX-aware execution.
+- `cashflows_used[]` entries with both source and reporting-currency evidence when FX conversion is
+  active.
+- `market_values_used` or equivalent evidence for beginning and ending market-value conversion.
+- conversion-policy metadata in `meta`, `diagnostics`, or a governed supportability block.
+- reason codes for missing FX evidence, stale rates, conflicting reporting currency, or unsupported
+  conversion policy.
+
+No downstream consumer may treat the current base-only `cashflows_used[].amount` as enough to
+explain an FX-aware MWR calculation.
+
+## Data Mesh Requirements
+
+FX-aware MWR is a governed data mesh extension, not a local calculation flag. The slice that
+implements it must include:
+
+1. repo-native domain data product declaration updates for any new product version or materially
+   expanded contract;
+2. upstream consumer declarations for the governed FX evidence product once `lotus-core` publishes
+   it as an analytics-input contract;
+3. lineage fingerprints for upstream portfolio, reference, and FX evidence;
+4. data-quality and freshness posture for conversion evidence;
+5. OpenAPI examples covering base-only, source-preconverted, and FX-aware converted schedules;
+6. gateway and Workbench propagation of reporting currency, conversion policy, reason codes, and
+   supportability state;
+7. tests proving deterministic conversion, missing-rate failure, stale-rate failure, restatement
+   fingerprint changes, and downstream response preservation.
+
+## Flow
+
+```mermaid
+flowchart LR
+    A[lotus-core portfolio observations] --> C[lotus-performance MWR input normalization]
+    B[governed FX evidence] --> C
+    C --> D[reporting-currency begin_mv / end_mv / cash_flows]
+    D --> E[XIRR root scan or Dietz-family method]
+    E --> F[MWR response + FX provenance + supportability]
+    F --> G[Gateway and Workbench display source-owned performance truth]
+```
+
+## Definition Of Done For Implementation
+
+FX-aware MWR is not done until all of these are true:
+
+- OpenAPI exposes the new request and response fields with no alias drift.
+- Stateful mode consumes a governed upstream FX analytics-input contract, not an operational-read
+  shortcut with implicit semantics.
+- Stateless mode validates complete FX evidence when FX-aware execution is requested.
+- Engine tests cover XIRR and Dietz-family schedules with mixed source currencies after conversion.
+- API tests cover missing FX evidence, stale FX evidence, conflicting reporting currency, and
+  source-preconverted schedules.
+- Gateway and Workbench tests prove consumers preserve emitted FX provenance and do not recalculate
+  conversion or MWR locally.
+- Methodology, API guide, wiki, and support docs describe the implemented behavior using Lotus
+  reporting-currency and supportability language.
+
+Until those items are complete, Lotus documentation must continue to describe MWR as a
+single-reporting-currency calculation.

--- a/docs/technical/mwr-industry-review-findings.md
+++ b/docs/technical/mwr-industry-review-findings.md
@@ -16,6 +16,7 @@ was used as a review input; the durable documentation is now Lotus-authored and 
 | Make support behavior operationally usable. | The MWR support playbook maps reason codes to support actions and client-safe explanations. |
 | Track fallback and solver ambiguity rates operationally. | `/metrics` emits `lotus_performance_mwr_solver_outcome_total` with bounded labels for input mode, method, status, reason code, and fallback use; `docs/operations/mwr-alert-rule-templates.md` converts those signals into Lotus alert and dashboard templates. |
 | Support Modified Dietz as a distinct method. | `mwr_method="MODIFIED_DIETZ"` uses dated cash-flow weights, while `mwr_method="DIETZ"` keeps midpoint weighting. XIRR fallback now emits `method="MODIFIED_DIETZ"`. |
+| Keep FX-aware MWR behind a reproducible evidence contract. | `docs/technical/mwr-fx-contract-design.md` defines the upstream FX evidence, response provenance, data mesh, consumer, and validation gates required before multi-currency per-flow conversion becomes supported behavior. |
 
 ## Areas Where Lotus Is Stronger
 
@@ -40,8 +41,9 @@ consumer propagation, and documentation are completed:
 
 Candidate enhancements should be implemented as governed slices:
 
-1. Add FX-aware MWR only after the cross-repository currency contract is explicit and consumer
-   surfaces can show currency provenance.
+1. Implement FX-aware MWR only after the contract in `docs/technical/mwr-fx-contract-design.md` is
+   backed by upstream FX analytics-input evidence, OpenAPI changes, gateway and Workbench
+   propagation, and tests.
 2. Extend demo/wiki material when front-office surfaces expose reason-code drill-downs directly.
 
 ## Proof Points
@@ -56,3 +58,5 @@ Implementation-backed proof currently lives in:
 - `docs/guides/mwr-lotus-production-controls.md` and
   `docs/operations/mwr-production-support-playbook.md` for product and support documentation;
 - `docs/operations/mwr-alert-rule-templates.md` for MWR alert thresholds and dashboard queries.
+- `docs/technical/mwr-fx-contract-design.md` for the governed readiness gate before FX-aware MWR
+  can become implementation-supported behavior.

--- a/tests/unit/docs/test_metric_methodology_docs.py
+++ b/tests/unit/docs/test_metric_methodology_docs.py
@@ -66,6 +66,8 @@ def test_mwr_methodology_docs_cover_stateful_source_owned_input_resolution():
         assert "CORE_CONTROL_PLANE_BASE_URL" in content
         assert "cross-observation carry-forward capital adjustments" in content
         assert "fee-classified rows" in content
+        assert "one reporting currency" in content
+        assert "mwr-fx-contract-design.md" in content
         assert "must not reconstruct" not in content
 
     assert "resolved start date" in xirr
@@ -76,6 +78,7 @@ def test_mwr_methodology_docs_cover_stateful_source_owned_input_resolution():
     assert "ZERO_DENOMINATOR" in dietz
     assert 'status="FALLBACK_USED"' in dietz
     assert "Stateful MWR resolves lotus-core portfolio timeseries" in master_index
+    assert "Future FX-aware MWR" in master_index
 
 
 def test_contribution_methodology_docs_cover_stateful_source_owned_input_resolution():

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -265,6 +265,8 @@ def test_mwr_guide_matches_current_method_reality():
     assert "root_count_detected" in guide
     assert "lotus_performance_mwr_solver_outcome_total" in guide
     assert "mwr-lotus-production-controls.md" in guide
+    assert "mwr-fx-contract-design.md" in guide
+    assert "cashflows_used` proves the signed schedule" in guide
     assert "mwr-production-support-playbook.md" in guide
     assert "mwr-industry-review-findings.md" in guide
     assert "investor capital-timing lens" in certification
@@ -284,9 +286,12 @@ def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     playbook = _read("docs/operations/mwr-production-support-playbook.md")
     alert_templates = _read("docs/operations/mwr-alert-rule-templates.md")
     findings = _read("docs/technical/mwr-industry-review-findings.md")
+    fx_design = _read("docs/technical/mwr-fx-contract-design.md")
     guide = _read("docs/guides/mwr.md")
     api_wiki = _read("wiki/API-Surface.md")
     ops_wiki = _read("wiki/Operations-Runbook.md")
+    integrations_wiki = _read("wiki/Integrations.md")
+    mesh_wiki = _read("wiki/Mesh-Data-Products.md")
 
     assert not (REPO_ROOT / "docs/reference/mwrr-industry-pack").exists()
 
@@ -305,6 +310,12 @@ def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     assert "Areas Where Lotus Is Stronger" in findings
     assert "Backlog Candidates" in findings
     assert "mwr-alert-rule-templates.md" in findings
+    assert "mwr-fx-contract-design.md" in findings
+    assert "Required Input Provenance" in fx_design
+    assert "source_amount" in fx_design
+    assert "conversion_fingerprint" in fx_design
+    assert "must not reconstruct FX conversion" in fx_design
+    assert "fail closed" in fx_design
     assert "LotusPerformanceMWRFallbackRateElevated" in alert_templates
     assert "LotusPerformanceMWRNoRootRateElevated" in alert_templates
     assert "LotusPerformanceMWRMultipleRootRateElevated" in alert_templates
@@ -315,8 +326,11 @@ def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     assert "mwr-lotus-production-controls.md" in guide
     assert "mwr-alert-rule-templates.md" in guide
     assert "mwr-lotus-production-controls.md" in api_wiki
+    assert "mwr-fx-contract-design.md" in api_wiki
     assert "mwr-production-support-playbook.md" in ops_wiki
     assert "mwr-alert-rule-templates.md" in ops_wiki
+    assert "must not infer FX rates" in integrations_wiki
+    assert "MoneyWeightedReturnAnalytics" in mesh_wiki
 
 
 def test_twr_mwr_response_attribute_certification_documents_field_level_checks():
@@ -363,6 +377,7 @@ def test_methodology_index_points_to_current_guides():
     assert "stateful_input.window_start_date" in dietz_methodology
     assert "Stateful MWR source flow" in integrations_wiki
     assert "Gateway and Workbench should consume the emitted MWR response" in integrations_wiki
+    assert "FX-aware MWR remains gated" in index
     assert "stateful lotus-core portfolio" in index
     assert "Stateful contribution source flow" in integrations_wiki
     assert "they must not reconstruct position contribution" in integrations_wiki

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -47,16 +47,20 @@ def test_repo_native_validation_script_stages_upstream_core_products() -> None:
     assert [path.name for path in upstream_paths] == ["lotus-core-products.v1.json"]
 
 
-def test_repo_native_producer_declarations_cover_only_the_governed_first_wave_products() -> None:
+def test_repo_native_producer_declarations_cover_governed_first_wave_products_and_mwr() -> None:
     payload = _load_declaration("lotus-performance-products.v1.json")
 
     assert payload["producer_repository"] == "lotus-performance"
     assert [product["product_name"] for product in payload["products"]] == [
+        "MoneyWeightedReturnAnalytics",
         "ReturnsSeriesBundle",
         "BenchmarkExposureContext",
     ]
-    assert payload["products"][0]["approved_consumers"] == ["lotus-risk"]
+    assert payload["products"][0]["approved_consumers"] == ["lotus-gateway"]
+    assert payload["products"][0]["current_routes"] == ["/performance/mwr"]
+    assert "upstream_request_fingerprints" in payload["products"][0]["required_trust_metadata"]
     assert payload["products"][1]["approved_consumers"] == ["lotus-risk"]
+    assert payload["products"][2]["approved_consumers"] == ["lotus-risk"]
 
 
 def test_repo_native_consumer_declarations_keep_watchlist_dependencies_docs_only() -> None:

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -50,6 +50,10 @@ calculation-quality metadata (`status`, `reason_codes`, `warnings`, `fallback_re
 `is_approximation`) plus `holding_period_return` and XIRR convergence diagnostics so demos,
 support workflows, and downstream UI panels can explain whether the value is an annualized XIRR, a
 Modified Dietz fallback, Simple Dietz result, or not calculable.
+Current MWR inputs must be in one reporting currency; `cashflows_used` is calculation-schedule
+evidence, not FX conversion provenance. FX-aware MWR is contract-gated by
+[docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md), and
+downstream consumers must not infer missing FX rates or conversion policy from the current response.
 
 `POST /performance/contribution` supports both stateless caller-owned inputs and stateful lotus-core
 portfolio/position timeseries sourcing. In stateful mode it is the source-owned contribution
@@ -86,7 +90,8 @@ Runtime and supportability routes:
   [docs/guides/complete_service_reference.md](../docs/guides/complete_service_reference.md)
 - Lotus MWR production controls and review findings:
   [docs/guides/mwr-lotus-production-controls.md](../docs/guides/mwr-lotus-production-controls.md),
-  [docs/technical/mwr-industry-review-findings.md](../docs/technical/mwr-industry-review-findings.md)
+  [docs/technical/mwr-industry-review-findings.md](../docs/technical/mwr-industry-review-findings.md),
+  [docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md)
 - runtime behavior and readiness:
   [Operations Runbook](Operations-Runbook)
 - upstream contract boundary:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -44,17 +44,22 @@ portfolio analytics timeseries from `lotus-core`, normalizes the investor capita
 and emits MWR plus supportability metadata for downstream consumers.
 Gateway and Workbench should consume the emitted MWR response as source-owned performance truth;
 they must not reconstruct cash flows from TWR, benchmark, or workspace summary payloads.
+Current MWR inputs are a single reporting-currency schedule. Gateway, Workbench, reporting, and
+support tooling must not infer FX rates, conversion policy, or source-currency provenance from
+today's `cashflows_used` echo.
 Gateway should preserve calculation-quality fields (`status`, `reason_codes`, `warnings`,
 `fallback_reason`, `is_approximation`, and `holding_period_return`) because they explain whether the
 client-facing number is annualized XIRR, a labeled Modified Dietz fallback, a Simple Dietz result,
 or not calculable.
 The implementation-backed Lotus production control guide is maintained at
 [docs/guides/mwr-lotus-production-controls.md](../docs/guides/mwr-lotus-production-controls.md).
+The future FX-aware MWR gate is maintained at
+[docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md).
 
 ```mermaid
 flowchart LR
     A[lotus-core portfolio timeseries] --> B[lotus-performance stateful MWR normalization]
-    B --> C[begin_mv / end_mv / cashflows_used / start_date]
+    B --> C[reporting-currency begin_mv / end_mv / cashflows_used / start_date]
     C --> D[XIRR root scan or Modified Dietz / Simple Dietz engine path]
     D --> E[MWR response + status + fallback metadata + calculation_supportability]
     E --> F[lotus-gateway performance contract preserves metadata]

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -4,8 +4,11 @@
 
 `lotus-performance` is a maturity-wave producer in the Lotus enterprise data mesh.
 
-## Governed product
+## Governed products
 
+- Product ID: `lotus-performance:MoneyWeightedReturnAnalytics:v1`
+- Product role: governed investor capital-timing return product consumed by gateway and Workbench
+  experiences
 - Product ID: `lotus-performance:ReturnsSeriesBundle:v1`
 - Product role: governed return-series and performance evidence consumed by risk, advisory, reporting, gateway, and Workbench discovery flows
 - Source declaration: `contracts/domain-data-products/`
@@ -15,6 +18,10 @@
   `convergence`, `calculation_supportability`, lineage, metadata, diagnostics, and audit fields.
   Downstream products may display or summarize those fields, but must not reinterpret ambiguous
   XIRR roots or rebuild investor cash-flow schedules outside the producer.
+  It is now declared as `MoneyWeightedReturnAnalytics` in
+  `contracts/domain-data-products/lotus-performance-products.v1.json`. Current MWR is a single
+  reporting-currency product; future FX-aware MWR remains gated by
+  [docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md).
   Production controls and review findings are maintained in
   [docs/guides/mwr-lotus-production-controls.md](../docs/guides/mwr-lotus-production-controls.md)
   and


### PR DESCRIPTION
## Summary
- add a Lotus-authored FX-aware MWR readiness contract covering upstream FX evidence, response provenance, data mesh requirements, consumer obligations, and validation gates
- declare `MoneyWeightedReturnAnalytics` as a repo-native domain data product for the existing `/performance/mwr` product surface
- update MWR guide, methodology docs, industry review findings, wiki pages, and documentation tests so the current single-reporting-currency boundary is implementation-backed

## Proof
- `python -m pytest tests/unit/docs/test_public_docs_contract.py tests/unit/docs/test_metric_methodology_docs.py tests/unit/test_domain_data_product_contracts.py -q`
- `python scripts/validate_domain_data_product_contracts.py`
- `python -m ruff check tests/unit/docs/test_public_docs_contract.py tests/unit/docs/test_metric_methodology_docs.py tests/unit/test_domain_data_product_contracts.py`
- `python -m ruff format --check tests/unit/docs/test_public_docs_contract.py tests/unit/docs/test_metric_methodology_docs.py tests/unit/test_domain_data_product_contracts.py`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance -AllowUnpublishedSourceChanges`
- `python automation\validate_engineering_context_system.py` in `lotus-platform`
- `python automation\validate_lotus_skill_alignment.py` in `lotus-platform`
- `powershell -ExecutionPolicy Bypass -File automation\Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget -CheckOnly` in `lotus-platform`
- `make check`

## Stranded Truth
- Reconciled before implementation and before PR: only `origin/feat/api-contract-hardening` remains unmerged; classified as active separate API-contract work.