### PR TITLE
Refresh performance live certification evidence

### DIFF
--- a/docs/technical/twr-endpoint-certification.md
+++ b/docs/technical/twr-endpoint-certification.md
@@ -113,17 +113,31 @@ Performance improvement opportunities:
 
 ## Domain Certification Result
 
-For canonical portfolio `PB_SG_GLOBAL_BAL_001` as of `2026-04-10`, the following windows are
-domain-safe for UI integration based on current evidence:
+For canonical portfolio `PB_SG_GLOBAL_BAL_001`, the following windows are domain-safe for UI
+integration based on current live evidence.
 
 | Window | Result |
 | --- | --- |
-| `YTD`, NET | `1.2152137301822075%`, daily/monthly breakdowns, max daily absolute move about `0.030546%` |
-| `YTD`, GROSS | `1.2359023665067692%`, gross exceeds net as expected from fee drag |
+| `YTD`, NET as of `2026-04-10` | `-0.6917915976265676%`, `100` daily rows, `4` monthly rows, supportability `ready` / `calculation_complete` |
+| `YTD`, GROSS as of current Workbench canonical evidence window | `-0.671493%`, gross exceeds net as expected from fee drag |
 | `MTD` | `0.10506363961935161%` |
 | `QTD` | `0.10506363961935161%` |
 | `EXPLICIT 2026-03-01..2026-04-10` | `0.3874271363699222%` |
-| `YTD` with benchmark | portfolio `1.2152137301822075%`, benchmark `5.095680231948784%`, active `-3.880466501766577%` |
+| `YTD` with benchmark as of `2026-04-10` | portfolio `-0.6917915976265676%`, benchmark `5.095680231948784%`, active `-5.7874718295753524%`, benchmark calendar posture `partial_overlap` with `BENCHMARK_CALENDAR_GAP` |
+
+Live audit note - 2026-05-10:
+
+- the prior certification figures in this document reflected an older canonical seed snapshot and
+  are no longer the current implementation-backed truth;
+- `POST /performance/twr` returned calculation id `9c448568-f2a7-4a3f-8570-f7189d3390b0` for the
+  audited `PB_SG_GLOBAL_BAL_001` `YTD` stateful TWR request as of `2026-04-10`;
+- `calculation_supportability.state` was `ready`, `reason` was `calculation_complete`, and
+  `freshness_bucket` was `current`;
+- canonical TWR inspection for calculation `63826edc-1ef6-433b-9398-ac0cb13836d0` returned
+  `supportable_with_warnings` with only the allowed canonical warning codes
+  `WEEKEND_OBSERVATIONS_PRESENT` and `MONTHLY_RETURN_DAY_DOMINANCE_DETECTED`;
+- log review for `performance-analytics` and `lotus-gateway` over the live-audit window found no
+  `ERROR`, `CRITICAL`, traceback, or `5xx` entries.
 
 The same endpoint mechanically supports `1Y` and `ITD`, but long-window results are not front-office
 safe for this canonical portfolio yet. Current source history produces nonpositive capital-base days

--- a/docs/technical/workspace-summary-endpoint-certification.md
+++ b/docs/technical/workspace-summary-endpoint-certification.md
@@ -153,10 +153,28 @@ Observed response:
 - diagnostics note: `Benchmark summary uses stateful benchmark input with calculated returns.`;
 - audit counts: `input_rows=100`, `periods_resolved=2`, `portfolio_chunk_count=2`,
   `portfolio_page_count=2`;
-- YTD net TWR `0.1227054514533199`, gross TWR `0.14317077642345133`, benchmark
-  `5.095680231948784`, active net `-4.9729747804954645`, MWR `-3.613903477849731`;
-- 1M net TWR `0.28230078105095924`, gross TWR `0.30279872769536365`, benchmark
-  `2.428296633866729`, active net `-2.1459958528157697`, MWR `3.748202939315167`.
+- current canonical Gateway-backed evidence for `PB_SG_GLOBAL_BAL_001`, `YTD`, `NET`,
+  `BMK_PB_GLOBAL_BALANCED_60_40`, and report end `2026-05-08` returns net TWR
+  `-0.691792`, gross TWR `-0.671493`, benchmark `6.997327`, active net `-7.689119`, and MWR
+  `-1.926818`;
+- contribution total ties to the workspace TWR at `-0.691791`; contribution smoothing evidence is
+  `APPLIED` with `CARINO_FACTOR_APPLIED`, `RAW_CONTRIBUTION_DIFFERS_FROM_LINKED_RETURN`, and
+  `RESIDUAL_ALLOCATED_TO_RECONCILE_PERIOD`;
+- attribution returns `active_return_pct=-7.016227`, `sum_of_effects_pct=-7.016227`, and
+  `residual_pct=0.0`;
+- evidence view is `supported`, source service is `lotus-performance`, and calculation artifacts
+  include request/response JSON plus workspace-summary portfolio daily result CSVs.
+
+Live audit note - 2026-05-10:
+
+- the earlier numerical certification bullets reflected a prior canonical seed snapshot and were
+  stale against the currently running front-office stack;
+- Gateway summary and details endpoints both returned HTTP `200` when called with required caller
+  context headers;
+- `input_freshness` reported `performance=stale` and `benchmark=stale` because the canonical
+  Workbench as-of date is `2026-05-10` while the latest performance and benchmark evidence is
+  `2026-05-08`; this is surfaced explicitly rather than hidden;
+- live validation with `npm run live:validate` was rerun as part of the audit.
 
 ## Certification Commands
 


### PR DESCRIPTION
## Summary
- correct stale canonical TWR and workspace-summary certification figures against current live stack evidence
- record current TWR calculation id, supportability posture, benchmark warning posture, Gateway evidence, and log review

## Validation
- python -m pytest tests/unit/docs/test_public_docs_contract.py tests/unit/app/test_twr_openapi_contract.py tests/unit/app/test_workspace_summary_openapi_contract.py -q
- python scripts/validate_canonical_twr_inspection.py --performance-base-url http://127.0.0.1:8002 --core-control-plane-base-url http://127.0.0.1:8202
- npm run live:validate (lotus-workbench)
- git diff --check