### PR TITLE
feat: support issuer benchmark exposure context

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Current request-model highlights:
 - returns-series outputs include `active_returns` and `cumulative_active_returns`
 - attribution emits source-owned `currency_attribution_totals` for portfolio-level
   Karnosky-Singer FX attribution when `currency_mode=BOTH` is source-ready
-- benchmark exposure context is currently certified at `frequency=DAILY`; `ISSUER` remains gated
+- benchmark exposure context is certified at `frequency=DAILY` for `POSITION`, `SECTOR`,
+  `ASSET_CLASS`, and `ISSUER`; issuer groups use lotus-core index-catalog issuer labels
 - Older examples using `period_type` are not current
 - Older examples using `daily_data` are not current
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -13,6 +13,10 @@ For platform-wide truth, read:
 `lotus-performance` is the authoritative performance analytics service in Lotus.
 
 It owns benchmark-aware performance calculations, contribution, attribution, returns series, execution tracking, and lineage capture for performance workflows.
+Its benchmark exposure context integration surface supports `POSITION`, `SECTOR`, `ASSET_CLASS`,
+and `ISSUER` grouping dimensions at `frequency=DAILY`; issuer grouping is a performance-owned
+derived view over lotus-core index-catalog `classification_labels.issuer_id` and `issuer_name`
+source labels.
 
 ## Business And Domain Responsibility
 

--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -187,8 +187,8 @@ INTEGRATION_CAPABILITIES_RESPONSE_EXAMPLES = [
                 "result_path_template": None,
                 "stateful_restrictions": [
                     "lotus-core remains the benchmark composition system of record",
-                    "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported",
-                    "ISSUER remains gated until benchmark issuer exposure semantics are approved",
+                    "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported",
+                    "ISSUER groups use lotus-core index-catalog issuer_id and issuer_name classification labels",
                 ],
                 "contract_notes": [
                     "returns a lineage-backed benchmark exposure view aligned to benchmark performance context",
@@ -386,8 +386,8 @@ class AnalyticsSurfaceCapability(BaseModel):
     stateful_restrictions: list[str] = Field(
         default_factory=list,
         description="Current stateful-mode fences or restrictions for this analytics surface.",
-        examples=[["POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported"]],
-        json_schema_extra={"example": ["POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported"]},
+        examples=[["POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported"]],
+        json_schema_extra={"example": ["POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported"]},
     )
     contract_notes: list[str] = Field(
         default_factory=list,
@@ -756,8 +756,8 @@ async def get_integration_capabilities(
             stateful_restrictions=(
                 [
                     "lotus-core remains the benchmark composition system of record",
-                    "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported",
-                    "ISSUER remains gated until benchmark issuer exposure semantics are approved",
+                    "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported",
+                    "ISSUER groups use lotus-core index-catalog issuer_id and issuer_name classification labels",
                 ]
                 if benchmark_enabled and stateful_mode_enabled
                 else []

--- a/app/models/benchmark_exposure_context.py
+++ b/app/models/benchmark_exposure_context.py
@@ -59,7 +59,7 @@ class BenchmarkExposureContextRequest(BaseModel):
                     "window": {"start_date": "2026-01-01", "end_date": "2026-04-10"},
                     "frequency": "DAILY",
                     "reporting_currency": "USD",
-                    "grouping_dimensions": ["POSITION", "SECTOR", "ASSET_CLASS"],
+                    "grouping_dimensions": ["POSITION", "SECTOR", "ASSET_CLASS", "ISSUER"],
                     "page": {"page_size": 1000, "page_token": None},
                 }
             ]
@@ -96,9 +96,9 @@ class BenchmarkExposureContextRequest(BaseModel):
     )
     grouping_dimensions: list[BenchmarkExposureGroupingDimension] = Field(
         default_factory=lambda: [BenchmarkExposureGroupingDimension.POSITION],
-        description="Benchmark exposure grouping dimensions to return. v1 supports POSITION, SECTOR, and ASSET_CLASS. ISSUER remains gated until issuer benchmark semantics are approved.",
-        examples=[["POSITION", "SECTOR", "ASSET_CLASS"]],
-        json_schema_extra={"example": ["POSITION", "SECTOR", "ASSET_CLASS"]},
+        description="Benchmark exposure grouping dimensions to return. v1 supports POSITION, SECTOR, ASSET_CLASS, and ISSUER. ISSUER groups are sourced from lotus-core index-catalog classification labels.",
+        examples=[["POSITION", "SECTOR", "ASSET_CLASS", "ISSUER"]],
+        json_schema_extra={"example": ["POSITION", "SECTOR", "ASSET_CLASS", "ISSUER"]},
     )
     page: BenchmarkExposurePageRequest = Field(default_factory=BenchmarkExposurePageRequest)
 
@@ -108,17 +108,6 @@ class BenchmarkExposureContextRequest(BaseModel):
             raise ValueError("benchmark exposure context v1 supports frequency=DAILY only")
         if not self.grouping_dimensions:
             raise ValueError("grouping_dimensions must contain at least one value")
-        unsupported = sorted(
-            {
-                dimension.value
-                for dimension in self.grouping_dimensions
-                if dimension == BenchmarkExposureGroupingDimension.ISSUER
-            }
-        )
-        if unsupported:
-            raise ValueError(
-                "benchmark exposure context does not yet support grouping_dimensions=" + ", ".join(unsupported)
-            )
         return self
 
 

--- a/app/services/benchmark_exposure_context_service.py
+++ b/app/services/benchmark_exposure_context_service.py
@@ -141,10 +141,7 @@ async def _classification_map_for_request(
     stateful_input_service: StatefulInputService,
     component_series: list[dict[str, Any]],
 ) -> dict[str, dict[str, str]]:
-    if not any(
-        dimension in {BenchmarkExposureGroupingDimension.SECTOR, BenchmarkExposureGroupingDimension.ASSET_CLASS}
-        for dimension in request.grouping_dimensions
-    ):
+    if not any(dimension != BenchmarkExposureGroupingDimension.POSITION for dimension in request.grouping_dimensions):
         return {}
     index_ids = sorted(
         {
@@ -258,6 +255,11 @@ def _group_identity(
     if grouping_dimension == BenchmarkExposureGroupingDimension.ASSET_CLASS:
         label = classification_map.get(index_id, {}).get("asset_class") or "UNKNOWN"
         return f"ASSET_CLASS_{label}", label, None
+    if grouping_dimension == BenchmarkExposureGroupingDimension.ISSUER:
+        labels = classification_map.get(index_id, {})
+        issuer_id = labels.get("issuer_id") or "UNKNOWN"
+        issuer_name = labels.get("issuer_name") or issuer_id
+        return f"ISSUER_{issuer_id}", issuer_name, None
     raise HTTPException(
         status_code=HTTP_422_UNPROCESSABLE,
         detail=f"benchmark exposure context does not yet support grouping_dimension={grouping_dimension.value}",

--- a/docs/examples/integration_capabilities_response.json
+++ b/docs/examples/integration_capabilities_response.json
@@ -185,8 +185,8 @@
       "result_path_template": null,
       "stateful_restrictions": [
         "lotus-core remains the benchmark composition system of record",
-        "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported",
-        "ISSUER remains gated until benchmark issuer exposure semantics are approved"
+        "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported",
+        "ISSUER groups use lotus-core index-catalog issuer_id and issuer_name classification labels"
       ],
       "supported_input_modes": [
         "stateful"

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -827,15 +827,15 @@ Return semantics for the workspace surface are now explicit rather than inferred
   - `POSITION`
   - `SECTOR`
   - `ASSET_CLASS`
-- gated grouping dimensions:
-  - `ISSUER` remains unsupported until benchmark issuer exposure semantics are defined
+  - `ISSUER`
 - contract notes:
   - if `benchmark_id` is omitted, lotus-performance resolves benchmark assignment through lotus-core
   - benchmark market-series is requested with `series_fields=["component_weight"]`
   - `frequency=DAILY` is the only supported v1 frequency; monthly or weekly benchmark exposure history is intentionally rejected rather than silently resampled
   - response rows use decimal weights, not percentages
   - row weights are returned as decimal fractions where `0.60` means a 60% benchmark exposure
-  - `POSITION` rows carry `component_id`; aggregate `SECTOR` and `ASSET_CLASS` rows omit `component_id`
+  - `ISSUER` grouping uses `classification_labels.issuer_id` and `issuer_name` from lotus-core index catalog records
+  - `POSITION` rows carry `component_id`; aggregate `SECTOR`, `ASSET_CLASS`, and `ISSUER` rows omit `component_id`
   - pagination uses `page.page_size` and opaque `page.next_page_token` values returned by the endpoint
   - lineage metadata includes `source_system="lotus-core"` and `served_by="lotus-performance"`
   - downstream certification and consumer posture are recorded in

--- a/docs/guides/complete_service_reference.md
+++ b/docs/guides/complete_service_reference.md
@@ -994,8 +994,8 @@ Purpose:
 Contract notes:
 
 - v1 supports `frequency=DAILY` only
-- supported grouping dimensions are `POSITION`, `SECTOR`, and `ASSET_CLASS`
-- `ISSUER` is rejected until issuer benchmark exposure semantics are approved
+- supported grouping dimensions are `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`
+- `ISSUER` grouping uses `classification_labels.issuer_id` and `issuer_name` from lotus-core index catalog records
 - row weights are decimal fractions, not percentages
 - pagination uses `page.page_size` and `page.next_page_token`
 - certification evidence lives in

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-12T04:05:46.724618+00:00",
+  "generatedAt": "2026-05-16T00:34:59.570177+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -189,7 +189,7 @@
           "poll_path_template": "/performance/executions/{calculation_id}",
           "result_path_template": "/performance/workspace-summary/results/{calculation_id}",
           "stateful_restrictions": [
-            "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported"
+            "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported"
           ],
           "contract_notes": [
             "returns a lineage-backed benchmark exposure view aligned to benchmark performance context"
@@ -2390,11 +2390,12 @@
       "semanticId": "lotus.grouping_dimensions",
       "canonicalTerm": "grouping_dimensions",
       "preferredName": "grouping_dimensions",
-      "description": "Benchmark exposure grouping dimensions to return. v1 supports POSITION, SECTOR, and ASSET_CLASS. ISSUER remains gated until issuer benchmark semantics are approved.",
+      "description": "Benchmark exposure grouping dimensions to return. v1 supports POSITION, SECTOR, ASSET_CLASS, and ISSUER. ISSUER groups are sourced from lotus-core index-catalog classification labels.",
       "example": [
         "POSITION",
         "SECTOR",
-        "ASSET_CLASS"
+        "ASSET_CLASS",
+        "ISSUER"
       ],
       "type": "array",
       "locations": [
@@ -6090,7 +6091,7 @@
       "preferredName": "stateful_restrictions",
       "description": "Current stateful-mode fences or restrictions for this analytics surface.",
       "example": [
-        "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported"
+        "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported"
       ],
       "type": "array",
       "locations": [

--- a/docs/technical/benchmark-exposure-context-endpoint-certification.md
+++ b/docs/technical/benchmark-exposure-context-endpoint-certification.md
@@ -38,9 +38,9 @@ The certified v1 request contract covers:
 - `window.start_date` and `window.end_date`;
 - `frequency=DAILY`;
 - optional `reporting_currency`;
-- supported grouping dimensions `POSITION`, `SECTOR`, and `ASSET_CLASS`;
-- gated grouping dimension `ISSUER`, rejected until issuer benchmark exposure semantics are
-  approved;
+- supported grouping dimensions `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`;
+- issuer grouping sourced from `classification_labels.issuer_id` and `issuer_name` in lotus-core
+  index catalog records;
 - pagination through `page.page_size` and `page.page_token`.
 
 `WEEKLY` and `MONTHLY` frequencies are intentionally rejected in v1. Downstream callers should not
@@ -57,8 +57,8 @@ The certification suite checks every output family:
   `reporting_currency`;
 - retrieval counters for benchmark market-series and index catalog calls;
 - `POSITION` rows carry `component_id`, `group_key`, `group_label`, and decimal `weight`;
-- aggregate `SECTOR` and `ASSET_CLASS` rows omit `component_id` and sum component weights by date
-  and group;
+- aggregate `SECTOR`, `ASSET_CLASS`, and `ISSUER` rows omit `component_id` and sum component
+  weights by date and group;
 - for a fully covered date, weights by grouping dimension sum to `1.0`;
 - pagination returns a deterministic next-page token and no token on the final page.
 
@@ -84,10 +84,10 @@ Current strategic downstream consumer:
   - client: `src/app/integrations/lotus_performance_client.py`
   - adapter: `src/app/services/benchmark_exposure_history.py`
   - usage: stateful active-risk attribution fetches benchmark exposure context with
-    `frequency=DAILY`, `page_size=1000`, and supported grouping dimensions.
+    `frequency=DAILY`, `page_size=1000`, and supported grouping dimensions including issuer.
 
 `lotus-gateway` and `lotus-workbench` do not call this endpoint directly. They surface user-facing
-issuer-gating copy when active-risk issuer benchmark exposure semantics are unavailable.
+active-risk issuer attribution only through governed risk and gateway contracts.
 
 No duplicate downstream endpoint use was found. This endpoint remains the strategic integration
 surface for performance-aligned benchmark exposure history.

--- a/tests/integration/test_benchmark_exposure_context_api.py
+++ b/tests/integration/test_benchmark_exposure_context_api.py
@@ -21,11 +21,21 @@ class _RecordingStatefulInputService:
                 "records": [
                     {
                         "index_id": "IDX_GLOBAL_EQUITY",
-                        "classification_labels": {"sector": "Global Equity", "asset_class": "Equity"},
+                        "classification_labels": {
+                            "sector": "Global Equity",
+                            "asset_class": "Equity",
+                            "issuer_id": "ISSUER_GLOBAL_EQUITY",
+                            "issuer_name": "Global Equity Issuer Basket",
+                        },
                     },
                     {
                         "index_id": "IDX_GLOBAL_BONDS",
-                        "classification_labels": {"sector": "Global Bonds", "asset_class": "Fixed Income"},
+                        "classification_labels": {
+                            "sector": "Global Bonds",
+                            "asset_class": "Fixed Income",
+                            "issuer_id": "ISSUER_GLOBAL_BONDS",
+                            "issuer_name": "Global Bond Issuer Basket",
+                        },
                     },
                 ]
             },
@@ -64,7 +74,7 @@ def test_benchmark_exposure_context_api_returns_performance_aligned_view(monkeyp
         "window": {"start_date": "2026-01-02", "end_date": "2026-01-02"},
         "frequency": "DAILY",
         "reporting_currency": "USD",
-        "grouping_dimensions": ["POSITION", "SECTOR", "ASSET_CLASS"],
+        "grouping_dimensions": ["POSITION", "SECTOR", "ASSET_CLASS", "ISSUER"],
         "page": {"page_size": 2, "page_token": None},
     }
 
@@ -104,6 +114,8 @@ def test_benchmark_exposure_context_api_returns_performance_aligned_view(monkeyp
     assert {(row["grouping_dimension"], row["group_key"], row["weight"]) for row in next_body["rows"]} == {
         ("POSITION", "IDX_GLOBAL_EQUITY", "0.60"),
         ("POSITION", "IDX_GLOBAL_BONDS", "0.40"),
+        ("ISSUER", "ISSUER_ISSUER_GLOBAL_EQUITY", "0.60"),
+        ("ISSUER", "ISSUER_ISSUER_GLOBAL_BONDS", "0.40"),
         ("SECTOR", "SECTOR_Global Equity", "0.60"),
         ("SECTOR", "SECTOR_Global Bonds", "0.40"),
     }
@@ -119,13 +131,19 @@ def test_benchmark_exposure_context_api_returns_performance_aligned_view(monkeyp
         ("2026-01-02", "POSITION"): 1.0,
         ("2026-01-02", "SECTOR"): 1.0,
         ("2026-01-02", "ASSET_CLASS"): 1.0,
+        ("2026-01-02", "ISSUER"): 1.0,
     }
     assert stateful_service.assignment_calls[0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
     assert stateful_service.market_series_calls[0]["series_fields"] == ["component_weight"]
     assert stateful_service.market_series_calls[0]["target_currency"] == "USD"
 
 
-def test_benchmark_exposure_context_api_rejects_issuer_until_contract_exists() -> None:
+def test_benchmark_exposure_context_api_returns_issuer_groups(monkeypatch) -> None:
+    stateful_service = _RecordingStatefulInputService()
+    monkeypatch.setattr(
+        "app.api.endpoints.benchmark_exposure_context.build_stateful_input_service",
+        lambda *, settings: stateful_service,
+    )
     payload = {
         "portfolio_id": "PB_SG_GLOBAL_BAL_001",
         "as_of_date": "2026-01-02",
@@ -136,8 +154,12 @@ def test_benchmark_exposure_context_api_rejects_issuer_until_contract_exists() -
     with TestClient(app) as client:
         response = client.post("/integration/benchmarks/exposure-context", json=payload)
 
-    assert response.status_code == 422
-    assert "does not yet support" in response.text
+    assert response.status_code == 200
+    body = response.json()
+    assert {(row["group_key"], row["group_label"], row["weight"]) for row in body["rows"]} == {
+        ("ISSUER_ISSUER_GLOBAL_EQUITY", "Global Equity Issuer Basket", "0.60"),
+        ("ISSUER_ISSUER_GLOBAL_BONDS", "Global Bond Issuer Basket", "0.40"),
+    }
 
 
 def test_benchmark_exposure_context_api_rejects_non_daily_frequency() -> None:

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -113,8 +113,8 @@ def test_integration_capabilities_default_contract():
     assert surfaces["benchmark_exposure_context"]["supports_async"] is False
     assert surfaces["benchmark_exposure_context"]["stateful_restrictions"] == [
         "lotus-core remains the benchmark composition system of record",
-        "POSITION, SECTOR, and ASSET_CLASS grouping dimensions are supported",
-        "ISSUER remains gated until benchmark issuer exposure semantics are approved",
+        "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported",
+        "ISSUER groups use lotus-core index-catalog issuer_id and issuer_name classification labels",
     ]
     features = {item["key"]: item for item in body["features"]}
     assert "performance.analytics.benchmark" in features

--- a/tests/unit/app/test_benchmark_exposure_context_openapi_contract.py
+++ b/tests/unit/app/test_benchmark_exposure_context_openapi_contract.py
@@ -30,7 +30,7 @@ def test_benchmark_exposure_context_openapi_documents_usage_and_fields() -> None
         assert request_schema["properties"][field_name]["description"]
 
     assert "DAILY only" in request_schema["properties"]["frequency"]["description"]
-    assert request_schema["examples"][0]["grouping_dimensions"] == ["POSITION", "SECTOR", "ASSET_CLASS"]
+    assert request_schema["examples"][0]["grouping_dimensions"] == ["POSITION", "SECTOR", "ASSET_CLASS", "ISSUER"]
 
     for field_name in [
         "valuation_date",

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -689,7 +689,7 @@ def test_benchmark_exposure_context_docs_reflect_certified_contract():
     assert "POST /integration/benchmarks/exposure-context" in readme
     assert "Benchmark Exposure Context Endpoint Certification" in readme
     assert "frequency=DAILY" in readme
-    assert "ISSUER` remains gated" in readme
+    assert "`ASSET_CLASS`, and `ISSUER`" in readme
     assert "`frequency=DAILY` is the only supported v1 frequency" in api_reference
     assert "row weights are returned as decimal fractions" in api_reference
     assert "`POSITION` rows carry `component_id`" in api_reference

--- a/tests/unit/services/test_benchmark_exposure_context_service.py
+++ b/tests/unit/services/test_benchmark_exposure_context_service.py
@@ -38,15 +38,30 @@ class _StatefulInputServiceStub:
                 "records": [
                     {
                         "index_id": "IDX_TECH_A",
-                        "classification_labels": {"sector": "Technology", "asset_class": "Equity"},
+                        "classification_labels": {
+                            "sector": "Technology",
+                            "asset_class": "Equity",
+                            "issuer_id": "ISSUER_TECH",
+                            "issuer_name": "Technology Issuer Basket",
+                        },
                     },
                     {
                         "index_id": "IDX_TECH_B",
-                        "classification_labels": {"sector": "Technology", "asset_class": "Equity"},
+                        "classification_labels": {
+                            "sector": "Technology",
+                            "asset_class": "Equity",
+                            "issuer_id": "ISSUER_TECH",
+                            "issuer_name": "Technology Issuer Basket",
+                        },
                     },
                     {
                         "index_id": "IDX_BOND",
-                        "classification_labels": {"sector": "Government Bonds", "asset_class": "Fixed Income"},
+                        "classification_labels": {
+                            "sector": "Government Bonds",
+                            "asset_class": "Fixed Income",
+                            "issuer_id": "ISSUER_GOVT",
+                            "issuer_name": "Government Bond Issuer Basket",
+                        },
                     },
                 ]
             },
@@ -96,6 +111,7 @@ def _request(**overrides) -> BenchmarkExposureContextRequest:
             BenchmarkExposureGroupingDimension.POSITION,
             BenchmarkExposureGroupingDimension.SECTOR,
             BenchmarkExposureGroupingDimension.ASSET_CLASS,
+            BenchmarkExposureGroupingDimension.ISSUER,
         ],
     }
     payload.update(overrides)
@@ -129,6 +145,7 @@ async def test_build_benchmark_exposure_context_groups_and_aligns_weights() -> N
     }
     assert weights[("2026-01-02", "SECTOR", "SECTOR_Technology")] == Decimal("0.60")
     assert weights[("2026-01-02", "ASSET_CLASS", "ASSET_CLASS_Equity")] == Decimal("0.60")
+    assert weights[("2026-01-02", "ISSUER", "ISSUER_ISSUER_TECH")] == Decimal("0.60")
     assert weights[("2026-01-02", "POSITION", "IDX_TECH_A")] == Decimal("0.35")
     assert service.assignment_calls[0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
     assert service.market_series_calls[0]["series_fields"] == ["component_weight"]
@@ -179,9 +196,10 @@ async def test_build_benchmark_exposure_context_rejects_bad_upstream_shapes() ->
         )
 
 
-def test_benchmark_exposure_context_rejects_issuer_until_semantics_exist() -> None:
-    with pytest.raises(ValueError, match="does not yet support"):
-        _request(grouping_dimensions=[BenchmarkExposureGroupingDimension.ISSUER])
+def test_benchmark_exposure_context_accepts_issuer_grouping() -> None:
+    request = _request(grouping_dimensions=[BenchmarkExposureGroupingDimension.ISSUER])
+
+    assert request.grouping_dimensions == [BenchmarkExposureGroupingDimension.ISSUER]
 
 
 @pytest.mark.asyncio
@@ -313,7 +331,7 @@ def test_build_exposure_rows_skips_invalid_component_shapes_and_rejects_invalid_
         )
 
 
-def test_group_identity_uses_unknown_defaults_and_rejects_unsupported_dimension() -> None:
+def test_group_identity_uses_unknown_defaults_for_classification_groups() -> None:
     assert _group_identity(
         index_id="IDX",
         grouping_dimension=BenchmarkExposureGroupingDimension.SECTOR,
@@ -325,12 +343,17 @@ def test_group_identity_uses_unknown_defaults_and_rejects_unsupported_dimension(
         classification_map={},
     ) == ("ASSET_CLASS_UNKNOWN", "UNKNOWN", None)
 
-    with pytest.raises(HTTPException, match="does not yet support grouping_dimension=ISSUER"):
-        _group_identity(
-            index_id="IDX",
-            grouping_dimension=BenchmarkExposureGroupingDimension.ISSUER,
-            classification_map={},
-        )
+    assert _group_identity(
+        index_id="IDX",
+        grouping_dimension=BenchmarkExposureGroupingDimension.ISSUER,
+        classification_map={},
+    ) == ("ISSUER_UNKNOWN", "UNKNOWN", None)
+
+    assert _group_identity(
+        index_id="IDX",
+        grouping_dimension=BenchmarkExposureGroupingDimension.ISSUER,
+        classification_map={"IDX": {"issuer_id": "ISSUER_A", "issuer_name": "Issuer A"}},
+    ) == ("ISSUER_ISSUER_A", "Issuer A", None)
 
 
 def test_page_rows_rejects_invalid_page_token_inputs() -> None:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -37,6 +37,12 @@ Governed base-URL examples:
 - operator surfaces:
   execution polling, lineage, runtime status, work items, recoveries, drills, retention
 
+Benchmark exposure context is the performance-owned derived integration view for downstream risk
+attribution. It resolves benchmark assignment and component weights through `lotus-core`, then
+serves `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER` rows at `frequency=DAILY`. Issuer rows use
+lotus-core index-catalog `classification_labels.issuer_id` and `issuer_name`; `POSITION` is the only
+grouping that carries `component_id`.
+
 ## Stateful TWR source flow
 
 Stateful TWR is the source-normalized portfolio performance path. `lotus-performance` retrieves


### PR DESCRIPTION
## Summary
- ungates `ISSUER` for `POST /integration/benchmarks/exposure-context`
- maps issuer rows from lotus-core index-catalog `classification_labels.issuer_id` and `issuer_name`
- updates integration capability copy, API vocabulary inventory, README/docs/context, and wiki source

## Validation
- `python -m ruff format --check app\models\benchmark_exposure_context.py app\services\benchmark_exposure_context_service.py app\api\endpoints\integration_capabilities.py tests\unit\services\test_benchmark_exposure_context_service.py tests\integration\test_benchmark_exposure_context_api.py tests\integration\test_integration_capabilities_api.py tests\unit\app\test_benchmark_exposure_context_openapi_contract.py tests\unit\docs\test_public_docs_contract.py`
- `python -m ruff check app\models\benchmark_exposure_context.py app\services\benchmark_exposure_context_service.py app\api\endpoints\integration_capabilities.py tests\unit\services\test_benchmark_exposure_context_service.py tests\integration\test_benchmark_exposure_context_api.py tests\integration\test_integration_capabilities_api.py tests\unit\app\test_benchmark_exposure_context_openapi_contract.py tests\unit\docs\test_public_docs_contract.py`
- `python -m pytest tests\unit\services\test_benchmark_exposure_context_service.py tests\integration\test_benchmark_exposure_context_api.py tests\unit\app\test_benchmark_exposure_context_models.py tests\unit\app\test_benchmark_exposure_context_openapi_contract.py tests\integration\test_integration_capabilities_api.py tests\unit\docs\test_public_docs_contract.py -q` -> 88 passed
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make domain-product-validate`
- `make no-alias-gate`
- `make test-unit` -> 1270 passed
- `pwsh -NoProfile -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance` -> expected drift: `Integrations.md` pending post-merge wiki publish

## Wiki
Repo-local wiki source changed in `wiki/Integrations.md`; publish after merge.