### PR TITLE
Fail closed currency attribution evidence

### DIFF
--- a/docs/guides/attribution.md
+++ b/docs/guides/attribution.md
@@ -158,7 +158,8 @@ Use `status`, `reason_codes`, `reasons`, and `supportability_evidence` as the au
 front-office degraded-state contract for a period. A period can be mathematically calculated but
 still be `partial` when there is off-benchmark exposure, benchmark-only exposure, unclassified
 segments, missing benchmark evidence, skipped linking, an invalid multi-period return chain,
-currency-attribution gaps, or a material residual. `reconciliation.residual_materiality` classifies
+currency-attribution gaps, including absent currency grouping or missing local/FX evidence, or a
+material residual. `reconciliation.residual_materiality` classifies
 the active-return residual against the governed warning and material thresholds. When linked
 attribution is requested and any portfolio or benchmark period return is less than or equal to
 `-100%`, `supportability_evidence.linking_status` is `invalid_return_chain` and

--- a/docs/technical/attribution-endpoint-certification.md
+++ b/docs/technical/attribution-endpoint-certification.md
@@ -131,7 +131,8 @@ preserve these fields when displaying partial, warning, or degraded attribution 
 not collapse a partial period into a green state simply because allocation, selection, and
 interaction totals are present. Current controlled reason codes include off-benchmark exposure,
 benchmark-only exposure, unclassified segment, missing benchmark data or returns, negative weights,
-zero exposure rows, currency-attribution gaps, skipped linking, invalid linked return chains,
+zero exposure rows, currency-attribution gaps including absent currency grouping or missing local/FX
+evidence, skipped linking, invalid linked return chains,
 material residuals, and residual-watch posture.
 
 ## Canonical Live Findings

--- a/engine/attribution.py
+++ b/engine/attribution.py
@@ -398,6 +398,17 @@ def _calculate_currency_attribution_effects(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def _currency_attribution_requirements_met(effects_df: pd.DataFrame, request: AttributionRequest) -> bool:
+    required_cols = {"r_local_p", "r_local_b", "r_fx_b", "w_p", "w_b"}
+    if request.currency_mode != "BOTH":
+        return False
+    if "currency" not in request.group_by:
+        return False
+    if not required_cols.issubset(effects_df.columns):
+        return False
+    return "currency" in effects_df.reset_index().columns
+
+
 def _link_effects_top_down(
     effects_df: pd.DataFrame, geometric_total_ar: float, arithmetic_total_ar: float
 ) -> pd.DataFrame:
@@ -478,8 +489,9 @@ def aggregate_attribution_results(
 
     currency_attribution_status = "not_requested"
     if request.currency_mode == "BOTH":
-        required_cols = {"r_local_p", "r_local_b", "r_fx_b", "w_p", "w_b"}
-        currency_attribution_status = "complete" if required_cols.issubset(effects_df.columns) else "unavailable"
+        currency_attribution_status = (
+            "complete" if _currency_attribution_requirements_met(effects_df, request) else "unavailable"
+        )
 
     status, reason_codes, reasons, supportability_evidence, supportability_lineage = (
         build_attribution_supportability_evidence(
@@ -507,9 +519,8 @@ def aggregate_attribution_results(
     )
 
     if request.currency_mode == "BOTH":
-        required_cols = {"r_local_p", "r_local_b", "r_fx_b", "w_p", "w_b"}
-        effects_df_reset = effects_df.reset_index()
-        if required_cols.issubset(effects_df.columns) and "currency" in effects_df_reset.columns:
+        if _currency_attribution_requirements_met(effects_df, request):
+            effects_df_reset = effects_df.reset_index()
             currency_df = effects_df_reset.groupby(["date", "currency"]).sum(numeric_only=True)
             fx_effects_df = _calculate_currency_attribution_effects(currency_df)
             aggregation_lineage["currency_attribution_effects.csv"] = fx_effects_df.reset_index()

--- a/engine/attribution_supportability.py
+++ b/engine/attribution_supportability.py
@@ -144,7 +144,7 @@ def build_attribution_supportability_evidence(
             _build_attribution_reason(
                 "currency_attribution_unavailable",
                 "warning",
-                "Currency attribution was requested but required local or FX return evidence was unavailable.",
+                "Currency attribution was requested but required currency grouping or local/FX return evidence was unavailable.",
                 0,
             )
         )

--- a/tests/unit/engine/test_attribution.py
+++ b/tests/unit/engine/test_attribution.py
@@ -724,6 +724,61 @@ def test_attribution_supportability_evidence_flags_currency_and_linking_gaps():
     assert result.supportability_evidence.linking_status == "scaling_skipped"
 
 
+def test_currency_attribution_fails_closed_when_currency_grouping_is_absent():
+    request = AttributionRequest.model_validate(
+        {
+            "portfolio_id": "ATTR_CCY_GROUP_REQUIRED",
+            "mode": "by_group",
+            "group_by": ["sector"],
+            "linking": "none",
+            "frequency": "daily",
+            "currency_mode": "BOTH",
+            "report_ccy": "USD",
+            "report_start_date": "2025-01-01",
+            "report_end_date": "2025-01-01",
+            "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
+            "portfolio_groups_data": [
+                {
+                    "key": {"sector": "Global Equity"},
+                    "observations": [
+                        {
+                            "date": "2025-01-01",
+                            "return_base": 0.031,
+                            "return_local": 0.025,
+                            "return_fx": 0.006,
+                            "weight_bop": 0.55,
+                        }
+                    ],
+                }
+            ],
+            "benchmark_groups_data": [
+                {
+                    "key": {"sector": "Global Equity"},
+                    "observations": [
+                        {
+                            "date": "2025-01-01",
+                            "return_base": 0.029,
+                            "return_local": 0.020,
+                            "return_fx": 0.009,
+                            "weight_bop": 0.50,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    effects_df, _ = run_attribution_calculations(request)
+    result, lineage = aggregate_attribution_results(effects_df, request)
+
+    assert result.status == "partial"
+    assert "currency_attribution_unavailable" in result.reason_codes
+    assert result.supportability_evidence.currency_attribution_status == "unavailable"
+    assert result.currency_attribution is None
+    assert result.currency_attribution_totals is None
+    assert "currency_attribution_effects.csv" not in lineage
+
+
 def test_attribution_linking_flags_invalid_return_chain_from_regression_pack():
     request = AttributionRequest.model_validate(
         {

--- a/wiki/Attribution-Analytics.md
+++ b/wiki/Attribution-Analytics.md
@@ -131,7 +131,7 @@ Common current reasons:
 | `benchmark_only_exposure` | Benchmark group is absent from portfolio. | Confirm whether the active underweight is expected. |
 | `unclassified_segment` | One or more rows mapped to the governed unknown/unclassified bucket. | Review source classification completeness. |
 | `missing_benchmark_return` | Benchmark exposure exists without benchmark return evidence. | Review benchmark source coverage. |
-| `currency_attribution_unavailable` | Currency attribution was requested without required local/FX evidence. | Review `currency_mode`, `report_ccy`, and FX inputs. |
+| `currency_attribution_unavailable` | Currency attribution was requested without required currency grouping or local/FX evidence. | Review `currency_mode`, `group_by`, `report_ccy`, and FX inputs. |
 | `linking_invalid_return_chain` | Linked attribution was requested but a period return is `<= -100%`. | Treat linked attribution as partial and inspect reset/source events. |
 | `material_residual` | Residual exceeds the governed materiality threshold. | Investigate input alignment, linking, and source-data gaps. |
 


### PR DESCRIPTION
## Summary
- fail closed Karnosky-Singer currency-attribution evidence unless the request is `currency_mode=BOTH`, has required local/FX columns, and includes the `currency` grouping key
- reuse the same prerequisite check for evidence status and emitted `currency_attribution`/`currency_attribution_totals`
- update attribution docs and wiki source so operators understand `currency_attribution_unavailable` covers absent currency grouping as well as missing local/FX evidence

## Validation
- `python -m pytest tests/unit/engine/test_attribution.py -q` -> 30 passed
- `python -m pytest tests/unit/engine/test_attribution.py tests/unit/docs/test_public_docs_contract.py -q` -> 74 passed
- `make lint` -> passed
- `make typecheck` -> passed
- `make openapi-gate` -> passed
- `make api-vocabulary-gate` -> passed
- `make no-alias-gate` -> passed
- `make domain-product-validate` -> passed
- `make test-unit` -> 1271 passed
- `make test-integration` -> 288 passed
- `make test-e2e` -> 21 passed after isolated rerun; concurrent e2e+integration run produced transient shared runtime-store interference, then e2e passed in isolation
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` -> passed
- `make migration-smoke` -> passed
- `make security-audit` -> known vulnerabilities: 0
- `make coverage-gate` -> 99% total coverage
- `make docker-build` -> passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance` -> expected pre-merge drift: `Attribution-Analytics.md`

## Governance
- Stranded truth before implementation: no unmerged `lotus-performance` remote branches.
- Stranded truth before PR: no unmerged `lotus-performance` remote branches.
- API schema shape did not change; OpenAPI and vocabulary gates were still run.
- Wiki source changed and must be published after merge.