### PR TITLE
Fix currency attribution totals aggregation

### DIFF
--- a/docs/methodologies/metrics/metric-currency-allocation.md
+++ b/docs/methodologies/metrics/metric-currency-allocation.md
@@ -47,6 +47,10 @@ Aggregation:
 - `CA_c = sum_t CA_c,t`
 - response field = `100 * CA_c`
 - `TE_c = LA_c + LS_c + CA_c + CS_c`
+- If the request groups by `currency` plus additional dimensions, the engine first recomputes a
+  date/currency panel by summing portfolio and benchmark weights and calculating benchmark local
+  and FX returns as weight-averaged returns. It does not sum granular local or FX returns across
+  sectors or other visible rows.
 
 ## Step-by-Step Computation
 1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core

--- a/docs/methodologies/metrics/metric-currency-local-allocation.md
+++ b/docs/methodologies/metrics/metric-currency-local-allocation.md
@@ -48,6 +48,10 @@ Period/currency aggregation in response:
 - `LA_c = sum_t LA_c,t`
 - Response field value: `100 * LA_c`
 - `TE_c = LA_c + LS_c + CA_c + CS_c`
+- If the request groups by `currency` plus additional dimensions, the engine first recomputes a
+  date/currency panel by summing portfolio and benchmark weights and calculating local returns as
+  weight-averaged returns. It does not sum granular local returns across sectors or other visible
+  rows.
 
 ## Step-by-Step Computation
 1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core

--- a/docs/methodologies/metrics/metric-currency-local-selection.md
+++ b/docs/methodologies/metrics/metric-currency-local-selection.md
@@ -47,6 +47,10 @@ Aggregation:
 - `LS_c = sum_t LS_c,t`
 - response field = `100 * LS_c`
 - `TE_c = LA_c + LS_c + CA_c + CS_c`
+- If the request groups by `currency` plus additional dimensions, the engine first recomputes a
+  date/currency panel by summing portfolio and benchmark weights and calculating portfolio and
+  benchmark local returns as weight-averaged returns. It does not sum granular local returns across
+  sectors or other visible rows.
 
 ## Step-by-Step Computation
 1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core

--- a/docs/methodologies/metrics/metric-currency-selection.md
+++ b/docs/methodologies/metrics/metric-currency-selection.md
@@ -48,6 +48,10 @@ Aggregation and total effect:
 - response field = `100 * CS_c`
 - per-currency `total_effect` is sum of four currency effects:
   - `TE_c = LA_c + LS_c + CA_c + CS_c`
+- If the request groups by `currency` plus additional dimensions, the engine first recomputes a
+  date/currency panel by summing portfolio and benchmark weights and calculating local and FX
+  returns as weight-averaged returns. It does not sum granular local or FX returns across sectors
+  or other visible rows.
 
 ## Step-by-Step Computation
 1. Resolve mode-specific attribution inputs. In stateful mode retrieve and normalize lotus-core

--- a/docs/technical/attribution-endpoint-certification.md
+++ b/docs/technical/attribution-endpoint-certification.md
@@ -82,8 +82,11 @@ supported attribution claims.
 When `currency_mode="BOTH"` is source-ready, the response emits both per-currency
 `currency_attribution[]` rows and portfolio-level `currency_attribution_totals`. The totals are the
 source-owned Karnosky-Singer sum of local allocation, local selection, currency allocation, currency
-selection, total effect, and currency bucket count across the emitted rows. Gateway, Workbench,
-reporting, and manage consumers should consume these totals rather than reconstructing
+selection, total effect, and currency bucket count across the emitted rows. If the request groups
+by `currency` plus another dimension, `lotus-performance` first recomputes a date/currency panel
+using summed weights and weight-averaged local/FX returns; it does not sum granular sector or other
+visible-row returns into the FX methodology. Gateway, Workbench, reporting, and manage consumers
+should consume these totals rather than reconstructing
 portfolio-level FX attribution by summing displayed rows.
 
 ## Downstream Consumers

--- a/engine/attribution.py
+++ b/engine/attribution.py
@@ -398,6 +398,34 @@ def _calculate_currency_attribution_effects(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def _build_currency_attribution_panel(effects_df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregates granular attribution rows into a date/currency panel.
+
+    Currency attribution is portfolio-level evidence. If callers request a more granular grouping,
+    such as currency plus sector, returns must be recomputed as currency-weighted returns rather
+    than summed across the visible groups.
+    """
+    currency_input = effects_df.reset_index()
+
+    def aggregate_currency_row(group: pd.DataFrame) -> pd.Series:
+        w_p = pd.to_numeric(group["w_p"], errors="coerce").fillna(0.0)
+        w_b = pd.to_numeric(group["w_b"], errors="coerce").fillna(0.0)
+        return pd.Series(
+            {
+                "w_p": float(w_p.sum()),
+                "w_b": float(w_b.sum()),
+                "r_local_p": _calculate_weighted_average_return(w_p, group["r_local_p"]),
+                "r_local_b": _calculate_weighted_average_return(w_b, group["r_local_b"]),
+                "r_fx_b": _calculate_weighted_average_return(w_b, group["r_fx_b"]),
+            }
+        )
+
+    return currency_input.groupby(["date", "currency"], dropna=False).apply(
+        aggregate_currency_row,
+        include_groups=False,
+    )
+
+
 def _currency_attribution_requirements_met(effects_df: pd.DataFrame, request: AttributionRequest) -> bool:
     required_cols = {"r_local_p", "r_local_b", "r_fx_b", "w_p", "w_b"}
     if request.currency_mode != "BOTH":
@@ -520,8 +548,7 @@ def aggregate_attribution_results(
 
     if request.currency_mode == "BOTH":
         if _currency_attribution_requirements_met(effects_df, request):
-            effects_df_reset = effects_df.reset_index()
-            currency_df = effects_df_reset.groupby(["date", "currency"]).sum(numeric_only=True)
+            currency_df = _build_currency_attribution_panel(effects_df)
             fx_effects_df = _calculate_currency_attribution_effects(currency_df)
             aggregation_lineage["currency_attribution_effects.csv"] = fx_effects_df.reset_index()
             total_fx_effects = fx_effects_df.groupby("currency").sum(numeric_only=True)

--- a/tests/unit/docs/test_metric_methodology_docs.py
+++ b/tests/unit/docs/test_metric_methodology_docs.py
@@ -138,6 +138,8 @@ def test_attribution_methodology_docs_cover_stateful_source_owned_input_resoluti
         content = _read(METRICS_DIR / name)
         assert "stateful attribution inputs" in content
         assert "FX/source currency evidence" in content
+        assert "weight-averaged returns" in content
+        assert "does not sum granular" in content
         assert "calculation_supportability" in content
 
     assert "Attribution Allocation Effect | POST /performance/attribution | Stateless + Stateful" in master_index

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -286,8 +286,10 @@ def test_attribution_documentation_map_and_wiki_navigation_are_present():
     assert "material residual classification" in wiki_page
     assert "currency_attribution_totals" in wiki_page
     assert "portfolio-level Karnosky-Singer total" in wiki_page
+    assert "weight-averaged local/FX" in wiki_page
     assert "portfolio-level FX attribution" in certification
     assert "should consume these totals rather than reconstructing" in certification
+    assert "does not sum granular sector" in certification
     assert "[Attribution Analytics](Attribution-Analytics)" in wiki_sidebar
     assert "[Attribution Analytics](Attribution-Analytics)" in wiki_home
     assert "docs/technical/attribution-documentation-map.md" in wiki_api_surface

--- a/tests/unit/engine/test_attribution.py
+++ b/tests/unit/engine/test_attribution.py
@@ -578,6 +578,107 @@ def test_calculate_currency_attribution_effects_matches_exact_formulas():
     assert row["currency_selection"] == pytest.approx(0.50 * (0.025 - 0.020) * 0.010)
 
 
+def test_currency_attribution_totals_are_invariant_to_extra_grouping_dimensions():
+    request = AttributionRequest.model_validate(
+        {
+            "portfolio_id": "ATTR_CCY_TOTALS_GRANULAR",
+            "mode": "by_group",
+            "group_by": ["currency", "sector"],
+            "linking": "none",
+            "frequency": "daily",
+            "currency_mode": "BOTH",
+            "report_ccy": "USD",
+            "report_start_date": "2025-01-01",
+            "report_end_date": "2025-01-01",
+            "analyses": [{"period": "ITD", "frequencies": ["daily"]}],
+            "portfolio_groups_data": [
+                {
+                    "key": {"currency": "EUR", "sector": "Equity"},
+                    "observations": [
+                        {
+                            "date": "2025-01-01",
+                            "return_base": 0.041,
+                            "return_local": 0.030,
+                            "return_fx": 0.011,
+                            "weight_bop": 0.30,
+                        }
+                    ],
+                },
+                {
+                    "key": {"currency": "EUR", "sector": "Bonds"},
+                    "observations": [
+                        {
+                            "date": "2025-01-01",
+                            "return_base": 0.026,
+                            "return_local": 0.015,
+                            "return_fx": 0.011,
+                            "weight_bop": 0.20,
+                        }
+                    ],
+                },
+            ],
+            "benchmark_groups_data": [
+                {
+                    "key": {"currency": "EUR", "sector": "Equity"},
+                    "observations": [
+                        {
+                            "date": "2025-01-01",
+                            "return_base": 0.031,
+                            "return_local": 0.020,
+                            "return_fx": 0.011,
+                            "weight_bop": 0.25,
+                        }
+                    ],
+                },
+                {
+                    "key": {"currency": "EUR", "sector": "Bonds"},
+                    "observations": [
+                        {
+                            "date": "2025-01-01",
+                            "return_base": 0.051,
+                            "return_local": 0.040,
+                            "return_fx": 0.011,
+                            "weight_bop": 0.25,
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    effects_df, _ = run_attribution_calculations(request)
+    result, lineage = aggregate_attribution_results(effects_df, request)
+
+    totals = result.currency_attribution_totals
+    assert totals is not None
+    assert totals.currency_count == 1
+    assert result.supportability_evidence.currency_attribution_status == "complete"
+    assert "currency_attribution_effects.csv" in lineage
+
+    # Currency-level returns are weight-averaged before Karnosky-Singer formulas are applied.
+    expected_portfolio_local_return = ((0.30 * 0.030) + (0.20 * 0.015)) / 0.50
+    expected_benchmark_local_return = ((0.25 * 0.020) + (0.25 * 0.040)) / 0.50
+    expected_benchmark_fx_return = ((0.25 * 0.011) + (0.25 * 0.011)) / 0.50
+    expected_local_allocation = (0.50 - 0.50) * expected_benchmark_local_return
+    expected_local_selection = 0.50 * (expected_portfolio_local_return - expected_benchmark_local_return)
+    expected_currency_allocation = (0.50 - 0.50) * (1 + expected_benchmark_local_return) * expected_benchmark_fx_return
+    expected_currency_selection = (
+        0.50 * (expected_portfolio_local_return - expected_benchmark_local_return) * expected_benchmark_fx_return
+    )
+    expected_total_effect = (
+        expected_local_allocation
+        + expected_local_selection
+        + expected_currency_allocation
+        + expected_currency_selection
+    )
+
+    assert totals.local_allocation == pytest.approx(expected_local_allocation * 100)
+    assert totals.local_selection == pytest.approx(expected_local_selection * 100)
+    assert totals.currency_allocation == pytest.approx(expected_currency_allocation * 100)
+    assert totals.currency_selection == pytest.approx(expected_currency_selection * 100)
+    assert totals.total_effect == pytest.approx(expected_total_effect * 100)
+
+
 def test_run_attribution_calculations_invalid_mode_raises_value_error():
     class _UnsupportedRequest:
         mode = "unsupported"

--- a/wiki/Attribution-Analytics.md
+++ b/wiki/Attribution-Analytics.md
@@ -88,7 +88,10 @@ When currency attribution is source-ready, each period also carries
 currency buckets. This gives downstream consumers an authoritative local allocation, local
 selection, currency allocation, currency selection, total effect, and bucket count without requiring
 Gateway, Workbench, reporting, or manage flows to reconstruct portfolio-level FX attribution from
-visible rows.
+visible rows. When `group_by` includes `currency` plus another dimension, `lotus-performance`
+recomputes the portfolio-level date/currency panel with summed weights and weight-averaged local/FX
+returns before applying the Karnosky-Singer formulas, so FX attribution totals are not distorted by
+visible-row granularity.
 
 ## Data Product Contract
 


### PR DESCRIPTION
## Summary
- Fixes portfolio-level `currency_attribution_totals` so Karnosky-Singer FX attribution is computed from a date/currency panel with summed weights and weight-averaged local/FX returns.
- Adds a regression proving totals are invariant when callers request `group_by=["currency", "sector"]` instead of only `currency`.
- Updates methodology, endpoint certification, doc guards, and wiki source to document that downstream consumers must use source-owned totals rather than reconstructing FX attribution from visible rows.

## WTBD / Source-Owner Posture
- Advances RFC42-WTBD-006 source-owner FX methodology depth in `lotus-performance`.
- No OMS, execution, tax-advice, funding, or Workbench product claim is added.
- No public API shape changed; existing `currency_attribution_totals` semantics are corrected and documented.

## Validation
- `python -m pytest tests/unit/engine/test_attribution.py::test_currency_attribution_totals_are_invariant_to_extra_grouping_dimensions tests/unit/engine/test_attribution.py::test_calculate_currency_attribution_effects_matches_exact_formulas -q` passed.
- `python -m pytest tests/unit/docs/test_metric_methodology_docs.py::test_attribution_methodology_docs_cover_stateful_source_owned_input_resolution tests/unit/docs/test_public_docs_contract.py::test_attribution_documentation_map_and_wiki_navigation_are_present -q` passed.
- `make lint` passed.
- `make typecheck` passed.
- `make openapi-gate` passed.
- `make api-vocabulary-gate` passed.
- `make domain-product-validate` passed.
- `make no-alias-gate` passed.
- `make test-unit` passed (`1272 passed`).
- `make ci` passed, including migration smoke, dependency/security audit (`Known vulnerabilities: 0`), unit/integration/e2e, coverage (`99%`), and Docker build.
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance` reports expected pre-merge drift on `Attribution-Analytics.md` because this PR changes wiki source.