### PR TITLE
Add stateless MWR source FX evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ Current request-model highlights:
 - returns-series outputs include `active_returns` and `cumulative_active_returns`
 - attribution emits source-owned `currency_attribution_totals` for portfolio-level
   Karnosky-Singer FX attribution when `currency_mode=BOTH` is source-ready
+- MWR stateless requests may supply complete `source_preconverted_fx_evidence`; the service
+  validates per-input FX provenance and emits `currency_evidence` while still computing on a
+  single reporting-currency schedule
 - benchmark exposure context is certified at `frequency=DAILY` for `POSITION`, `SECTOR`,
   `ASSET_CLASS`, and `ISSUER`; issuer groups use lotus-core index-catalog issuer labels
 - Older examples using `period_type` are not current

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -54,6 +54,10 @@ Current repository posture:
    `currency_mode=BOTH` path is source-ready, giving downstream Gateway, Workbench, reporting, and
    manage consumers a source-owned portfolio-level FX attribution total instead of requiring local
    row summation.
+10. stateless MWR accepts complete `source_preconverted_fx_evidence`, validates per-input FX
+    provenance for beginning market value, ending market value, and every cash flow, and emits
+    `currency_evidence` while preserving the engine boundary that MWR calculates one
+    reporting-currency schedule and does not perform in-engine FX conversion.
 
 ## Architecture And Module Map
 

--- a/app/api/endpoints/performance.py
+++ b/app/api/endpoints/performance.py
@@ -544,7 +544,10 @@ async def get_twr_result(calculation_id: UUID) -> PerformanceResponse | JSONResp
         "the question is how the portfolio performed for the client after the size and timing of external "
         "cash flows, deposits, withdrawals, and sourced capital-base adjustments are considered. Use "
         '`input_mode="stateless"` when the caller already owns beginning value, ending value, and the signed '
-        'cash-flow schedule. Use `input_mode="stateful"` for lotus-core-sourced portfolio analytics input; '
+        "cash-flow schedule; callers with upstream-converted source-currency inputs may supply complete "
+        "`source_preconverted_fx_evidence` for every market value and cash flow so the response records "
+        "validated FX provenance while the MWR engine still calculates on reporting-currency amounts. "
+        'Use `input_mode="stateful"` for lotus-core-sourced portfolio analytics input; '
         "lotus-performance reads the query-control-plane portfolio timeseries, normalizes explicit external "
         "cash flows and cross-observation carry-forward capital breaks into canonical MWR inputs, keeps "
         "operational fees as performance drag rather than investor cash movement, and then runs the requested "

--- a/app/models/mwr_analytics_requests.py
+++ b/app/models/mwr_analytics_requests.py
@@ -82,6 +82,8 @@ class MoneyWeightedReturnAnalyticsRequest(MoneyWeightedReturnRequestBase):
                 raise ValueError("stateless_input must be null when input_mode=stateful")
             if has_legacy_stateless:
                 raise ValueError("begin_mv, end_mv, and cash_flows must be null when input_mode=stateful")
+            if self.source_preconverted_fx_evidence is not None:
+                raise ValueError("source_preconverted_fx_evidence must be null when input_mode=stateful")
         return self
 
     def to_stateless_mwr_request(

--- a/app/models/mwr_requests.py
+++ b/app/models/mwr_requests.py
@@ -1,5 +1,6 @@
 # app/models/mwr_requests.py
-from datetime import date
+from datetime import date, datetime
+from decimal import Decimal
 from typing import List, Literal, Optional
 from uuid import UUID, uuid4
 
@@ -13,6 +14,49 @@ class CashFlow(BaseModel):
 
     amount: float
     date: date
+
+
+class MWRSourcePreconvertedFXComponent(BaseModel):
+    """Per-input FX provenance for a value that was converted before MWR execution."""
+
+    source_amount: Decimal = Field(description="Amount in the source currency before upstream conversion.")
+    source_currency: str = Field(description="Currency of the source amount before upstream conversion.")
+    reporting_amount: Decimal = Field(description="Amount supplied to MWR in the reporting currency.")
+    reporting_currency: str = Field(description="Reporting currency used by the MWR calculation.")
+    fx_rate: Decimal = Field(gt=0, description="Positive source-to-reporting FX rate applied upstream.")
+    fx_pair: str = Field(description="Currency pair used for upstream conversion, for example EUR/USD.")
+    fx_rate_date: date = Field(description="Date of the FX rate used for upstream conversion.")
+    fx_rate_source: str = Field(description="Authoritative source of the FX rate.")
+    fx_rate_version: str = Field(description="Version, snapshot, or fixing identifier for the FX rate.")
+    conversion_policy: str = Field(description="Named policy used to select and apply the FX rate.")
+    conversion_timestamp: datetime = Field(description="Timestamp when the upstream conversion was performed.")
+    conversion_fingerprint: str = Field(description="Stable fingerprint of the conversion evidence.")
+
+
+class MWRMarketValueFXEvidence(MWRSourcePreconvertedFXComponent):
+    value_role: Literal["beginning_market_value", "ending_market_value"] = Field(
+        description="Whether the evidence covers the beginning or ending market value."
+    )
+
+
+class MWRCashFlowFXEvidence(MWRSourcePreconvertedFXComponent):
+    cash_flow_index: int = Field(ge=0, description="Zero-based index of the corresponding cash flow.")
+    cash_flow_date: date = Field(description="Date of the corresponding cash flow.")
+
+
+class MWRSourcePreconvertedFXEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_scope: Literal["stateless_mwr_source_preconverted"] = Field(
+        default="stateless_mwr_source_preconverted",
+        description="Scope of source-preconverted FX evidence supplied by the caller.",
+    )
+    market_values: List[MWRMarketValueFXEvidence] = Field(
+        description="Complete beginning and ending market-value conversion evidence."
+    )
+    cash_flows: List[MWRCashFlowFXEvidence] = Field(
+        description="Complete per-cash-flow conversion evidence aligned by cash_flow_index."
+    )
 
 
 class Solver(BaseModel):
@@ -43,6 +87,14 @@ class MoneyWeightedReturnRequestBase(BaseModel):
     output: Output = Field(default_factory=Output)
     flags: Flags = Field(default_factory=Flags)
     report_ccy: Optional[str] = None
+    source_preconverted_fx_evidence: Optional[MWRSourcePreconvertedFXEvidence] = Field(
+        default=None,
+        description=(
+            "Optional complete FX provenance for stateless MWR inputs that were converted upstream. "
+            "Lotus-performance validates this evidence and computes on the supplied reporting amounts; "
+            "it does not convert source-currency amounts inside the MWR engine."
+        ),
+    )
 
 
 class MoneyWeightedReturnRequest(MoneyWeightedReturnRequestBase):

--- a/app/models/mwr_responses.py
+++ b/app/models/mwr_responses.py
@@ -1,5 +1,6 @@
 # app/models/mwr_responses.py
 from datetime import date as Date
+from datetime import datetime as DateTime
 from typing import List, Literal, Optional
 from uuid import UUID
 
@@ -109,9 +110,9 @@ class MoneyWeightedReturnResponse(BaseModel):
     currency_evidence: Optional["MWRCurrencyEvidence"] = Field(
         default=None,
         description=(
-            "Currency context and source-component evidence for stateful MWR. The block is additive "
-            "to legacy cashflows_used and documents when upstream values are pre-converted without "
-            "per-input FX metadata."
+            "Currency context and source-component evidence for MWR. The block is additive to legacy "
+            "cashflows_used and documents either stateful upstream pre-conversion without per-input FX "
+            "metadata or stateless source-preconverted inputs with complete per-input FX provenance."
         ),
     )
     start_date: Date = Field(description="Inclusive start date for the evaluated window.", examples=["2026-01-01"])
@@ -151,6 +152,24 @@ class MWRCashFlowEvidence(BaseModel):
         default_factory=list,
         description="Source components aggregated into this MWR cash flow.",
     )
+    source_amount: Optional[str] = Field(
+        default=None, description="Cash-flow amount in source currency before upstream FX conversion."
+    )
+    source_currency: Optional[str] = Field(default=None, description="Source currency before upstream FX conversion.")
+    reporting_amount: Optional[str] = Field(default=None, description="Cash-flow amount supplied to MWR.")
+    reporting_currency: Optional[str] = Field(default=None, description="Reporting currency supplied to MWR.")
+    fx_rate: Optional[str] = Field(default=None, description="FX rate applied before MWR execution.")
+    fx_pair: Optional[str] = Field(default=None, description="FX pair used for upstream conversion.")
+    fx_rate_date: Optional[Date] = Field(default=None, description="FX rate date used for upstream conversion.")
+    fx_rate_source: Optional[str] = Field(default=None, description="Source of the FX rate.")
+    fx_rate_version: Optional[str] = Field(default=None, description="Version or fixing identifier for the FX rate.")
+    conversion_policy: Optional[str] = Field(default=None, description="Policy used for upstream FX conversion.")
+    conversion_timestamp: Optional[DateTime] = Field(
+        default=None, description="Timestamp when upstream conversion was performed."
+    )
+    conversion_fingerprint: Optional[str] = Field(
+        default=None, description="Stable fingerprint of the conversion evidence."
+    )
 
 
 class MWRMarketValueEvidence(BaseModel):
@@ -167,9 +186,27 @@ class MWRMarketValueEvidence(BaseModel):
         default="PortfolioTimeseriesInput",
         description="Upstream source data product used for stateful MWR sourcing.",
     )
-    conversion_status: Literal["upstream_preconverted"] = Field(
+    conversion_status: Literal["upstream_preconverted", "source_preconverted_with_fx_evidence"] = Field(
         default="upstream_preconverted",
         description="Conversion posture for the source amount.",
+    )
+    source_amount: Optional[str] = Field(
+        default=None, description="Market value amount in source currency before upstream FX conversion."
+    )
+    source_currency: Optional[str] = Field(default=None, description="Source currency before upstream FX conversion.")
+    reporting_amount: Optional[str] = Field(default=None, description="Market value amount supplied to MWR.")
+    reporting_currency: Optional[str] = Field(default=None, description="Reporting currency supplied to MWR.")
+    fx_rate: Optional[str] = Field(default=None, description="FX rate applied before MWR execution.")
+    fx_pair: Optional[str] = Field(default=None, description="FX pair used for upstream conversion.")
+    fx_rate_date: Optional[Date] = Field(default=None, description="FX rate date used for upstream conversion.")
+    fx_rate_source: Optional[str] = Field(default=None, description="Source of the FX rate.")
+    fx_rate_version: Optional[str] = Field(default=None, description="Version or fixing identifier for the FX rate.")
+    conversion_policy: Optional[str] = Field(default=None, description="Policy used for upstream FX conversion.")
+    conversion_timestamp: Optional[DateTime] = Field(
+        default=None, description="Timestamp when upstream conversion was performed."
+    )
+    conversion_fingerprint: Optional[str] = Field(
+        default=None, description="Stable fingerprint of the conversion evidence."
     )
 
 
@@ -179,12 +216,16 @@ class MWRCurrencyEvidence(BaseModel):
         description="Effective reporting currency used for the MWR market values and cash flows.",
     )
     portfolio_currency: Optional[str] = Field(default=None, description="Portfolio base currency reported by core.")
-    currency_mode: Literal["SINGLE_REPORTING_CURRENCY"] = Field(
-        description="MWR currently calculates one reporting-currency cash-flow schedule."
+    currency_mode: Literal["SINGLE_REPORTING_CURRENCY", "SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"] = Field(
+        description=(
+            "MWR calculation currency mode. Source-preconverted mode means the caller supplied complete "
+            "per-input FX provenance while the engine still calculated one reporting-currency schedule."
+        )
     )
-    conversion_evidence_status: Literal["upstream_preconverted_missing_per_input_fx_metadata"] = Field(
-        description="Whether per-input FX conversion evidence is complete for the MWR response."
-    )
+    conversion_evidence_status: Literal[
+        "upstream_preconverted_missing_per_input_fx_metadata",
+        "complete_source_preconverted_fx_metadata",
+    ] = Field(description="Whether per-input FX conversion evidence is complete for the MWR response.")
     conversion_evidence_reason_codes: List[str] = Field(
         default_factory=list,
         description="Machine-readable reason codes for conversion evidence completeness.",

--- a/app/services/mwr_fx_evidence_service.py
+++ b/app/services/mwr_fx_evidence_service.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal
+
+from fastapi import HTTPException, status
+
+from app.models.mwr_requests import (
+    MoneyWeightedReturnRequest,
+    MWRMarketValueFXEvidence,
+    MWRSourcePreconvertedFXComponent,
+)
+from app.services.stateful_mwr_input_service import (
+    MWRCashFlowEvidence,
+    MWRCurrencyEvidence,
+    MWRMarketValueEvidence,
+)
+
+FX_EVIDENCE_COMPLETE_REASON_CODES = [
+    "SOURCE_PRECONVERTED_INPUTS_SUPPLIED",
+    "PER_INPUT_FX_METADATA_VALIDATED",
+    "MWR_ENGINE_CALCULATED_REPORTING_CURRENCY_SCHEDULE",
+]
+
+
+def build_source_preconverted_mwr_currency_evidence(
+    request: MoneyWeightedReturnRequest,
+) -> MWRCurrencyEvidence | None:
+    """Validate stateless source-preconverted FX evidence and return response evidence."""
+
+    evidence = request.source_preconverted_fx_evidence
+    if evidence is None:
+        return None
+
+    reporting_currency = request.report_ccy or request.currency
+    market_values_by_role = {item.value_role: item for item in evidence.market_values}
+    if set(market_values_by_role) != {"beginning_market_value", "ending_market_value"}:
+        _raise_fx_evidence_error(
+            "source_preconverted_fx_evidence.market_values must contain exactly one beginning_market_value "
+            "and one ending_market_value record"
+        )
+    if len(evidence.market_values) != 2:
+        _raise_fx_evidence_error("source_preconverted_fx_evidence.market_values must contain exactly two records")
+
+    cash_flows_by_index = {item.cash_flow_index: item for item in evidence.cash_flows}
+    expected_indexes = set(range(len(request.cash_flows)))
+    if set(cash_flows_by_index) != expected_indexes or len(evidence.cash_flows) != len(request.cash_flows):
+        _raise_fx_evidence_error(
+            "source_preconverted_fx_evidence.cash_flows must contain exactly one record for each cash flow index"
+        )
+
+    beginning_evidence = market_values_by_role["beginning_market_value"]
+    ending_evidence = market_values_by_role["ending_market_value"]
+    _validate_component(
+        beginning_evidence,
+        reporting_amount=_decimal(request.begin_mv),
+        reporting_currency=reporting_currency,
+        location="source_preconverted_fx_evidence.market_values[beginning_market_value]",
+    )
+    _validate_component(
+        ending_evidence,
+        reporting_amount=_decimal(request.end_mv),
+        reporting_currency=reporting_currency,
+        location="source_preconverted_fx_evidence.market_values[ending_market_value]",
+    )
+
+    cashflow_evidence: list[MWRCashFlowEvidence] = []
+    for index, cash_flow in enumerate(request.cash_flows):
+        item = cash_flows_by_index[index]
+        if item.cash_flow_date != cash_flow.date:
+            _raise_fx_evidence_error(
+                f"source_preconverted_fx_evidence.cash_flows[{index}].cash_flow_date must match cash_flows[{index}].date"
+            )
+        _validate_component(
+            item,
+            reporting_amount=_decimal(cash_flow.amount),
+            reporting_currency=reporting_currency,
+            location=f"source_preconverted_fx_evidence.cash_flows[{index}]",
+        )
+        cashflow_evidence.append(
+            MWRCashFlowEvidence(
+                date=cash_flow.date,
+                amount=_decimal(cash_flow.amount),
+                currency=reporting_currency,
+                source_components=[],
+                source_amount=_decimal(item.source_amount),
+                source_currency=item.source_currency,
+                reporting_amount=_decimal(item.reporting_amount),
+                reporting_currency=item.reporting_currency,
+                fx_rate=_decimal(item.fx_rate),
+                fx_pair=item.fx_pair,
+                fx_rate_date=item.fx_rate_date,
+                fx_rate_source=item.fx_rate_source,
+                fx_rate_version=item.fx_rate_version,
+                conversion_policy=item.conversion_policy,
+                conversion_timestamp=item.conversion_timestamp,
+                conversion_fingerprint=item.conversion_fingerprint,
+            )
+        )
+
+    return MWRCurrencyEvidence(
+        reporting_currency=reporting_currency,
+        portfolio_currency=request.currency,
+        currency_mode="SOURCE_PRECONVERTED_WITH_FX_EVIDENCE",
+        conversion_evidence_status="complete_source_preconverted_fx_metadata",
+        conversion_evidence_reason_codes=FX_EVIDENCE_COMPLETE_REASON_CODES,
+        market_values_used=[
+            _market_value_response_evidence(
+                beginning_evidence,
+                reporting_amount=_decimal(request.begin_mv),
+                reporting_currency=reporting_currency,
+                value_role="beginning_market_value",
+                valuation_date=request.start_date or request.as_of,
+            ),
+            _market_value_response_evidence(
+                ending_evidence,
+                reporting_amount=_decimal(request.end_mv),
+                reporting_currency=reporting_currency,
+                value_role="ending_market_value",
+                valuation_date=request.as_of,
+            ),
+        ],
+        cashflow_evidence=cashflow_evidence,
+    )
+
+
+def _market_value_response_evidence(
+    item: MWRMarketValueFXEvidence,
+    *,
+    reporting_amount: Decimal,
+    reporting_currency: str,
+    value_role: Literal["beginning_market_value", "ending_market_value"],
+    valuation_date,
+) -> MWRMarketValueEvidence:
+    return MWRMarketValueEvidence(
+        valuation_date=valuation_date,
+        amount=reporting_amount,
+        currency=reporting_currency,
+        value_role=value_role,
+        conversion_status="source_preconverted_with_fx_evidence",
+        source_amount=_decimal(item.source_amount),
+        source_currency=item.source_currency,
+        reporting_amount=_decimal(item.reporting_amount),
+        reporting_currency=item.reporting_currency,
+        fx_rate=_decimal(item.fx_rate),
+        fx_pair=item.fx_pair,
+        fx_rate_date=item.fx_rate_date,
+        fx_rate_source=item.fx_rate_source,
+        fx_rate_version=item.fx_rate_version,
+        conversion_policy=item.conversion_policy,
+        conversion_timestamp=item.conversion_timestamp,
+        conversion_fingerprint=item.conversion_fingerprint,
+    )
+
+
+def _validate_component(
+    item: MWRSourcePreconvertedFXComponent,
+    *,
+    reporting_amount: Decimal,
+    reporting_currency: str,
+    location: str,
+) -> None:
+    if item.reporting_currency != reporting_currency:
+        _raise_fx_evidence_error(f"{location}.reporting_currency must match the MWR reporting currency")
+    if _decimal(item.reporting_amount) != reporting_amount:
+        _raise_fx_evidence_error(f"{location}.reporting_amount must match the MWR input amount")
+    if item.source_currency == item.reporting_currency and _decimal(item.fx_rate) != Decimal("1"):
+        _raise_fx_evidence_error(f"{location}.fx_rate must be 1 when source_currency equals reporting_currency")
+    required_text_fields = {
+        "source_currency": item.source_currency,
+        "reporting_currency": item.reporting_currency,
+        "fx_pair": item.fx_pair,
+        "fx_rate_source": item.fx_rate_source,
+        "fx_rate_version": item.fx_rate_version,
+        "conversion_policy": item.conversion_policy,
+        "conversion_fingerprint": item.conversion_fingerprint,
+    }
+    missing_fields = [field for field, value in required_text_fields.items() if not value.strip()]
+    if missing_fields:
+        _raise_fx_evidence_error(f"{location} is missing required FX evidence fields: {', '.join(missing_fields)}")
+
+
+def _decimal(value: object) -> Decimal:
+    return Decimal(str(value))
+
+
+def _raise_fx_evidence_error(message: str) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=f"Invalid source_preconverted_fx_evidence: {message}",
+    )

--- a/app/services/mwr_mode_service.py
+++ b/app/services/mwr_mode_service.py
@@ -8,6 +8,7 @@ from app.core.config import Settings
 from app.models.mwr_analytics_requests import MoneyWeightedReturnAnalyticsRequest, MWRInputMode
 from app.models.mwr_requests import MoneyWeightedReturnRequest
 from app.services.execution_registry import execution_registry
+from app.services.mwr_fx_evidence_service import build_source_preconverted_mwr_currency_evidence
 from app.services.stateful_mwr_input_service import MWRCurrencyEvidence, build_stateful_mwr_input_for_window
 from app.services.stateful_performance_input_service import retrieve_stateful_portfolio_input
 
@@ -27,9 +28,11 @@ async def resolve_mwr_request(
     settings: Settings,
 ) -> ResolvedMWRRequest:
     if request.input_mode == MWRInputMode.STATELESS:
+        mwr_request = request.to_stateless_mwr_request()
         return ResolvedMWRRequest(
-            mwr_request=request.to_stateless_mwr_request(),
+            mwr_request=mwr_request,
             input_mode=MWRInputMode.STATELESS,
+            currency_evidence=build_source_preconverted_mwr_currency_evidence(mwr_request),
         )
 
     stateful_input = request.stateful_input

--- a/app/services/stateful_mwr_input_service.py
+++ b/app/services/stateful_mwr_input_service.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date as Date
+from datetime import datetime as DateTime
 from decimal import Decimal, InvalidOperation
 from typing import Literal
 
@@ -22,28 +23,57 @@ class MWRCashFlowEvidenceComponent:
 
 @dataclass(frozen=True)
 class MWRCashFlowEvidence:
-    date: date
+    date: Date
     amount: Decimal
     currency: str | None
     source_components: list[MWRCashFlowEvidenceComponent]
+    source_amount: Decimal | None = None
+    source_currency: str | None = None
+    reporting_amount: Decimal | None = None
+    reporting_currency: str | None = None
+    fx_rate: Decimal | None = None
+    fx_pair: str | None = None
+    fx_rate_date: Date | None = None
+    fx_rate_source: str | None = None
+    fx_rate_version: str | None = None
+    conversion_policy: str | None = None
+    conversion_timestamp: DateTime | None = None
+    conversion_fingerprint: str | None = None
 
 
 @dataclass(frozen=True)
 class MWRMarketValueEvidence:
-    valuation_date: date | None
+    valuation_date: Date | None
     amount: Decimal
     currency: str | None
     value_role: Literal["beginning_market_value", "ending_market_value"]
     source_product: Literal["PortfolioTimeseriesInput"] = "PortfolioTimeseriesInput"
-    conversion_status: Literal["upstream_preconverted"] = "upstream_preconverted"
+    conversion_status: Literal["upstream_preconverted", "source_preconverted_with_fx_evidence"] = (
+        "upstream_preconverted"
+    )
+    source_amount: Decimal | None = None
+    source_currency: str | None = None
+    reporting_amount: Decimal | None = None
+    reporting_currency: str | None = None
+    fx_rate: Decimal | None = None
+    fx_pair: str | None = None
+    fx_rate_date: Date | None = None
+    fx_rate_source: str | None = None
+    fx_rate_version: str | None = None
+    conversion_policy: str | None = None
+    conversion_timestamp: DateTime | None = None
+    conversion_fingerprint: str | None = None
 
 
 @dataclass(frozen=True)
 class MWRCurrencyEvidence:
     reporting_currency: str | None
     portfolio_currency: str | None
-    currency_mode: Literal["SINGLE_REPORTING_CURRENCY"]
-    conversion_evidence_status: Literal["upstream_preconverted_missing_per_input_fx_metadata"]
+    currency_mode: Literal["SINGLE_REPORTING_CURRENCY", "SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"]
+    conversion_evidence_status: Literal[
+        "upstream_preconverted_missing_per_input_fx_metadata",
+        "complete_source_preconverted_fx_metadata",
+    ]
     conversion_evidence_reason_codes: list[str]
     market_values_used: list[MWRMarketValueEvidence]
     cashflow_evidence: list[MWRCashFlowEvidence]
@@ -51,7 +81,7 @@ class MWRCurrencyEvidence:
 
 @dataclass(frozen=True)
 class StatefulMWRInput:
-    start_date: date
+    start_date: Date
     begin_mv: Decimal
     end_mv: Decimal
     cash_flows: list[CashFlow]
@@ -69,7 +99,7 @@ def build_stateful_mwr_input(*, source_input: StatefulPortfolioInput) -> Statefu
 def build_stateful_mwr_input_for_window(
     *,
     source_input: StatefulPortfolioInput,
-    window_start_date: date,
+    window_start_date: Date,
 ) -> StatefulMWRInput:
     first_observation = source_input.observations[0]
     last_observation = source_input.observations[-1]
@@ -78,15 +108,15 @@ def build_stateful_mwr_input_for_window(
     end_mv = Decimal(str(last_observation["ending_market_value"]))
     reporting_currency = _resolve_reporting_currency(source_input)
 
-    cash_flows_by_date: dict[date, Decimal] = {}
-    cash_flow_components_by_date: dict[date, list[MWRCashFlowEvidenceComponent]] = {}
+    cash_flows_by_date: dict[Date, Decimal] = {}
+    cash_flow_components_by_date: dict[Date, list[MWRCashFlowEvidenceComponent]] = {}
     previous_ending_market_value: Decimal | None = None
     for observation in source_input.observations:
         valuation_date_raw = observation.get("valuation_date")
         if not isinstance(valuation_date_raw, str):
             previous_ending_market_value = None
             continue
-        valuation_date = date.fromisoformat(valuation_date_raw)
+        valuation_date = Date.fromisoformat(valuation_date_raw)
         beginning_market_value = _parse_decimal(observation.get("beginning_market_value"))
         if beginning_market_value is not None and previous_ending_market_value is not None:
             carry_forward_adjustment = beginning_market_value - previous_ending_market_value
@@ -188,12 +218,12 @@ def _parse_decimal(value: object) -> Decimal | None:
         return None
 
 
-def _parse_observation_date(observation: dict[str, object]) -> date | None:
+def _parse_observation_date(observation: dict[str, object]) -> Date | None:
     valuation_date_raw = observation.get("valuation_date")
     if not isinstance(valuation_date_raw, str):
         return None
     try:
-        return date.fromisoformat(valuation_date_raw)
+        return Date.fromisoformat(valuation_date_raw)
     except ValueError:
         return None
 

--- a/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
+++ b/docs/RFCs/RFC_IMPLEMENTATION_STATUS.md
@@ -44,7 +44,7 @@ implementation-backed.
 
 | RFC Number | Title | Status | Current boundary |
 | :--------- | :---- | :----- | :--------------- |
-| RFC 020 | Multi-Currency & FX-Aware Performance | ⚠️ Partially Implemented | TWR, contribution, and attribution have FX-aware support. MWR remains a single reporting-currency schedule and does not perform per-flow FX conversion. The implementation-readiness contract for FX-aware MWR lives in `docs/technical/mwr-fx-contract-design.md`. |
+| RFC 020 | Multi-Currency & FX-Aware Performance | ⚠️ Partially Implemented | TWR, contribution, and attribution have FX-aware support. MWR remains a single reporting-currency schedule and does not perform per-flow FX conversion. Stateless MWR can now validate complete `source_preconverted_fx_evidence` and emit per-input FX provenance for already converted schedules. Stateful per-flow conversion evidence readiness remains governed by `docs/technical/mwr-fx-contract-design.md`. |
 
 ---
 
@@ -81,14 +81,18 @@ delivery evidence for completed work.
 
 3.  **RFC 020 — Multi-Currency & FX-Aware Performance**
     * **Reasoning:** **Keep multi-currency claims truthful before extending MWR.** TWR,
-      contribution, and attribution have implementation-backed FX-aware paths, but MWR is currently
-      a single reporting-currency money-weighted return contract. The next RFC-020 slice for MWR
-      must satisfy `docs/technical/mwr-fx-contract-design.md`: governed upstream FX evidence,
-      OpenAPI fields, deterministic conversion tests, gateway and Workbench propagation, and data
-      mesh declaration updates.
-    * **Current state:** **Partially implemented.** Do not claim fully FX-aware MWR until per-flow
-      conversion evidence, stale/missing-rate failure behavior, response provenance, and downstream
-      preservation are all merged and validated.
+      contribution, and attribution have implementation-backed FX-aware paths. MWR now supports a
+      bounded stateless source-preconverted evidence path, but it still calculates a single
+      reporting-currency money-weighted return schedule and does not perform in-engine FX
+      conversion. The remaining RFC-020 MWR scope must satisfy
+      `docs/technical/mwr-fx-contract-design.md`: governed upstream FX evidence, stale/missing-rate
+      per-flow conversion evidence, stale/missing-rate failure behavior, gateway and Workbench
+      propagation, and data mesh declaration updates.
+    * **Current state:** **Partially implemented.** Stateless MWR validates complete
+      `source_preconverted_fx_evidence` and emits response provenance for already converted
+      schedules. Do not claim fully FX-aware MWR until stateful upstream per-flow conversion
+      evidence, stale/missing-rate failure behavior, and downstream preservation are all merged and
+      validated.
 
 ### Phase 1: Foundational Enhancements
 

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -133,8 +133,9 @@ descriptions and examples are maintained in the generated OpenAPI contract.
   - stateful MWR includes explicit external source cash flows and cross-observation capital carry-forward adjustments in the MWR cash-flow schedule
   - operational fees remain performance drag; they are not treated as investor deposits or withdrawals
   - `emit_cashflows_used=true` returns the signed cash-flow schedule used by the calculation
-  - responses expose `reporting_currency`; stateful responses also expose `currency_evidence` with `market_values_used`, `cashflow_evidence`, and `currency_mode="SINGLE_REPORTING_CURRENCY"`
-  - current `currency_evidence.conversion_evidence_status` is `upstream_preconverted_missing_per_input_fx_metadata`, so consumers must not infer per-input FX rates, conversion policy, or conversion fingerprints
+  - stateless callers may supply complete `source_preconverted_fx_evidence`; lotus-performance validates it against the reporting-currency MWR inputs and emits `currency_evidence.currency_mode="SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"`
+  - responses expose `reporting_currency`; stateful responses expose `currency_evidence` with `market_values_used`, `cashflow_evidence`, and `currency_mode="SINGLE_REPORTING_CURRENCY"`
+  - current `currency_evidence.conversion_evidence_status` is `upstream_preconverted_missing_per_input_fx_metadata` for stateful MWR, so consumers must not infer per-input FX rates, conversion policy, or conversion fingerprints when those fields are absent
   - XIRR responses expose `status`, `reason_codes`, `warnings`, `holding_period_return`, `is_annualized_primary`, `fallback_from`, `fallback_reason`, and `is_approximation`
   - XIRR convergence diagnostics expose root count, residual NPV, searched bounds, day-count basis, anchor date, normalized flow count, and gross solver-flow scale
   - ambiguous XIRR cases such as no root or multiple roots are labeled and fall back to Dietz; consumers should use `status` and `fallback_reason` instead of inferring quality from `method` alone

--- a/docs/guides/complete_service_reference.md
+++ b/docs/guides/complete_service_reference.md
@@ -303,7 +303,11 @@ Stateful MWR responses populate `currency_evidence` with `market_values_used[]`,
 `cashflow_evidence[]`, and `currency_mode="SINGLE_REPORTING_CURRENCY"`. The current conversion
 evidence status is `upstream_preconverted_missing_per_input_fx_metadata`, which means
 lotus-performance preserves the reporting-currency context and source components received from
-lotus-core but does not yet expose full per-input FX rate provenance.
+lotus-core but does not yet expose full per-input FX rate provenance. Stateless callers may supply
+complete `source_preconverted_fx_evidence`; when present and valid, the response emits
+`currency_mode="SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"` and
+`conversion_evidence_status="complete_source_preconverted_fx_metadata"` while the engine still
+computes on the supplied reporting-currency schedule.
 
 ### `POST /performance/workspace-summary`
 

--- a/docs/guides/mwr.md
+++ b/docs/guides/mwr.md
@@ -139,8 +139,8 @@ When `emit_cashflows_used=true`, which is the default, the response also include
 so support, front office, and downstream clients can see the exact signed flow schedule used by the
 calculation.
 
-The response also exposes `reporting_currency`. For stateful runs, `currency_evidence` preserves
-the current Lotus sourcing truth:
+The response also exposes `reporting_currency`. `currency_evidence` preserves the current Lotus
+sourcing truth:
 
 - `currency_mode="SINGLE_REPORTING_CURRENCY"`
 - `market_values_used[]` for the beginning and ending `PortfolioTimeseriesInput` values used by
@@ -150,15 +150,25 @@ the current Lotus sourcing truth:
 - `conversion_evidence_status="upstream_preconverted_missing_per_input_fx_metadata"` until
   `lotus-core` publishes per-input FX rate, policy, version, and fingerprint evidence
 
+For stateless source-preconverted schedules, callers may provide complete
+`source_preconverted_fx_evidence`. Lotus-performance validates the evidence and emits:
+
+- `currency_mode="SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"`
+- `conversion_evidence_status="complete_source_preconverted_fx_metadata"`
+- per-market-value and per-cash-flow source amount, source currency, reporting amount, reporting
+  currency, FX rate, rate source/version/date, conversion policy, conversion timestamp, and
+  conversion fingerprint
+
 ## Multi-currency note
 
 MWR is not decomposed into local and FX components on the current public contract. Callers should
-submit `begin_mv`, `end_mv`, and `cash_flows` in one consistent reporting currency.
-`cashflows_used` proves the signed schedule used by the engine; `currency_evidence` proves the
-stateful reporting-currency context and source components currently available to lotus-performance.
-It is not yet full FX conversion provenance because the upstream portfolio timeseries contract does
-not expose per-input rate source, rate version, conversion policy, or conversion fingerprint fields.
-The implementation-readiness contract for a future FX-aware MWR extension is documented in
+submit `begin_mv`, `end_mv`, and `cash_flows` in one consistent reporting currency. If those values
+were converted before submission, callers can attach `source_preconverted_fx_evidence`; the service
+validates and records provenance but does not convert source-currency amounts inside the MWR engine.
+`cashflows_used` proves the signed schedule used by the engine. Stateful upstream MWR is not yet
+full FX conversion provenance because the upstream portfolio timeseries contract does not expose
+per-input rate source, rate version, conversion policy, or conversion fingerprint fields. The
+implementation-readiness contract for future stateful FX-aware MWR is documented in
 [MWR FX-aware contract design](../technical/mwr-fx-contract-design.md).
 
 ## Example request

--- a/docs/methodologies/metrics/master-index.md
+++ b/docs/methodologies/metrics/master-index.md
@@ -49,9 +49,13 @@ This index maps implemented lotus-performance metrics to detailed methodology do
   aggregation beyond the current single reporting-currency guard remain unsupported.
 - In current engine behavior, `mwr_method=MODIFIED_DIETZ` uses dated cash-flow weights and
   `mwr_method=DIETZ` keeps the midpoint Simple Dietz path.
-- Current MWR methodology documents assume a single reporting-currency schedule. Future FX-aware MWR
-  is governed by `docs/technical/mwr-fx-contract-design.md` and is not implementation-supported
-  until upstream FX evidence, response provenance, consumer propagation, and tests are complete.
+- Future FX-aware MWR remains bounded by the current single reporting-currency engine contract.
+  Current MWR methodology documents assume a single reporting-currency schedule. Stateless callers
+  may supply complete `source_preconverted_fx_evidence` so responses preserve validated per-input
+  FX provenance, but the engine still computes on supplied reporting-currency amounts and does not
+  convert source-currency amounts. Stateful upstream FX-aware MWR remains governed by
+  `docs/technical/mwr-fx-contract-design.md` until upstream FX evidence, consumer propagation, and
+  tests are complete.
 
 
 ## Documentation Standard

--- a/docs/methodologies/metrics/metric-mwr-dietz.md
+++ b/docs/methodologies/metrics/metric-mwr-dietz.md
@@ -37,7 +37,12 @@ or `MODIFIED_DIETZ`)
 ## Unit Conventions
 - Amount fields are currency amounts.
 - `begin_mv`, `end_mv`, and `cash_flows[].amount` must be in one reporting currency before the
-  Dietz-family calculation runs; current `cashflows_used` output is schedule evidence, not FX
+  Dietz-family calculation runs.
+- Stateless callers may supply `source_preconverted_fx_evidence` for every market value and cash
+  flow. Lotus-performance validates that the supplied reporting amounts match the MWR inputs and
+  then emits `currency_evidence` with complete per-input FX provenance; the Dietz-family engine
+  still operates only on the reporting-currency schedule and does not convert source amounts.
+- Without `source_preconverted_fx_evidence`, `cashflows_used` is schedule evidence, not FX
   conversion provenance.
 - `money_weighted_return`, `mwr_annualized`, and `holding_period_return` are percentage points.
 - Internal periodic Dietz rate is decimal and multiplied by 100 for output.
@@ -55,8 +60,26 @@ or `MODIFIED_DIETZ`)
   earliest cash-flow date when no start date is supplied)
 - `days`: `(as_of - start_date).days`
 - `ppy`: annualization factor (`365.25` for `ACT/ACT`, else `365.0`)
+- `SRC_i`: optional source-currency amount supplied in `source_preconverted_fx_evidence`
+- `FX_i`: optional positive FX rate supplied in `source_preconverted_fx_evidence`
+- `RCY`: reporting currency for all MWR engine inputs
 
 ## Methodology and Formulas
+0. Optional source-preconverted FX evidence validation:
+- When `source_preconverted_fx_evidence` is supplied, the endpoint validates exactly one
+  beginning-market-value record, exactly one ending-market-value record, and exactly one cash-flow
+  evidence record for each `cash_flows[]` index.
+- For each component, `reporting_currency` must match `report_ccy` when supplied, otherwise
+  `currency`.
+- For each component, `reporting_amount` must equal the corresponding MWR input amount:
+  `begin_mv`, `end_mv`, or `cash_flows[i].amount`.
+- Required FX provenance fields are `source_amount`, `source_currency`, `fx_rate`, `fx_pair`,
+  `fx_rate_date`, `fx_rate_source`, `fx_rate_version`, `conversion_policy`,
+  `conversion_timestamp`, and `conversion_fingerprint`.
+- If `source_currency == reporting_currency`, `fx_rate` must equal `1`.
+- These checks produce response provenance only; no source amount is converted inside the
+  Dietz-family engine.
+
 1. Modified Dietz periodic return:
 - `CF_sum = sum_i CF_i`
 - `w_i = (as_of - CF_i.date).days / (as_of - S).days`
@@ -108,8 +131,9 @@ or `MODIFIED_DIETZ`)
   included as investor cash flows; unsupported or invalid source cash-flow rows are skipped during
   normalization rather than guessed.
 - Mixed source-currency schedules are not converted by the current Dietz-family path. FX-aware MWR
-  remains gated by `docs/technical/mwr-fx-contract-design.md` and must fail closed in any future
-  implementation when conversion evidence is incomplete.
+  remains gated by `docs/technical/mwr-fx-contract-design.md` for stateful upstream conversion.
+  Stateless source-preconverted schedules may include complete `source_preconverted_fx_evidence`;
+  incomplete or inconsistent evidence fails closed with HTTP 422.
 - Explicit `MODIFIED_DIETZ` and `DIETZ` requests return `status="CALCULATED"` when the denominator
   is non-zero.
 - XIRR fallback responses return `status="FALLBACK_USED"`, include the XIRR failure reason and
@@ -142,6 +166,9 @@ Primary fields:
 - `is_annualized_primary`
 - `is_approximation`
 - `start_date`, `end_date`, `notes`
+- `reporting_currency`
+- `currency_evidence` when stateful source context or stateless source-preconverted FX evidence is
+  available
 - `calculation_supportability`, `meta`, `diagnostics`, and `audit`
 
 ## Worked Example

--- a/docs/methodologies/metrics/metric-mwr-xirr.md
+++ b/docs/methodologies/metrics/metric-mwr-xirr.md
@@ -33,8 +33,13 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 ## Unit Conventions
 - Cash flow and market values are currency amounts.
 - `begin_mv`, `end_mv`, and `cash_flows[].amount` must be in one reporting currency before the
-  XIRR solver runs; current `cashflows_used` output is schedule evidence, not FX conversion
-  provenance.
+  XIRR solver runs.
+- Stateless callers may supply `source_preconverted_fx_evidence` for every market value and cash
+  flow. Lotus-performance validates that the supplied reporting amounts match the MWR inputs and
+  then emits `currency_evidence` with complete per-input FX provenance; the XIRR solver still
+  operates only on the reporting-currency schedule and does not convert source amounts.
+- Without `source_preconverted_fx_evidence`, `cashflows_used` is schedule evidence, not FX
+  conversion provenance.
 - `money_weighted_return`, `mwr_annualized`, and `holding_period_return` are percentage points.
 - XIRR uses a decimal annual rate internally, then multiplies by 100 for response fields.
 - Successful XIRR returns an annualized primary value; `holding_period_return` gives the measured-period equivalent.
@@ -51,8 +56,26 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 - `tau_j`: year fraction from anchor date using `(date_j - anchor).days / D`
 - `V_j`: signed value at position `j` in the solver vector after same-day netting
 - `NPV(r)`: discounted cash-flow sum used for root solving
+- `SRC_j`: optional source-currency amount supplied in `source_preconverted_fx_evidence`
+- `FX_j`: optional positive FX rate supplied in `source_preconverted_fx_evidence`
+- `RCY`: reporting currency for all MWR engine inputs
 
 ## Methodology and Formulas
+0. Optional source-preconverted FX evidence validation:
+- When `source_preconverted_fx_evidence` is supplied, the endpoint validates exactly one
+  beginning-market-value record, exactly one ending-market-value record, and exactly one cash-flow
+  evidence record for each `cash_flows[]` index.
+- For each component, `reporting_currency` must match `report_ccy` when supplied, otherwise
+  `currency`.
+- For each component, `reporting_amount` must equal the corresponding MWR input amount:
+  `begin_mv`, `end_mv`, or `cash_flows[i].amount`.
+- Required FX provenance fields are `source_amount`, `source_currency`, `fx_rate`, `fx_pair`,
+  `fx_rate_date`, `fx_rate_source`, `fx_rate_version`, `conversion_policy`,
+  `conversion_timestamp`, and `conversion_fingerprint`.
+- If `source_currency == reporting_currency`, `fx_rate` must equal `1`.
+- These checks produce response provenance only; no source amount is converted inside the XIRR
+  engine.
+
 1. Cash-flow vector construction (`calculate_money_weighted_return`):
 - `S` is the resolved measurement start date. In stateful mode it is the requested
   `stateful_input.window_start_date`; in stateless mode it is explicit `start_date`, the earliest
@@ -104,8 +127,9 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
   included as investor cash flows; unsupported or invalid source cash-flow rows are skipped during
   normalization rather than guessed.
 - Mixed source-currency schedules are not converted by the current XIRR path. FX-aware MWR remains
-  gated by `docs/technical/mwr-fx-contract-design.md` and must fail closed in any future
-  implementation when conversion evidence is incomplete.
+  gated by `docs/technical/mwr-fx-contract-design.md` for stateful upstream conversion. Stateless
+  source-preconverted schedules may include complete `source_preconverted_fx_evidence`; incomplete
+  or inconsistent evidence fails closed with HTTP 422.
 - `NO_ECONOMIC_CONTENT` returns `status="NOT_APPLICABLE"`.
 - `NO_POSITIVE_AND_NEGATIVE_CASH_FLOW`, `NO_ROOT_FOUND`, `MULTIPLE_IRR_ROOTS_DETECTED`, and
   `INVALID_SOLVER_BOUNDS` enter a labeled Modified Dietz fallback unless no economic content exists.
@@ -141,6 +165,9 @@ Primary fields for this metric when XIRR succeeds:
 - `convergence.residual_npv`
 - `convergence.day_count_basis`
 - `cashflows_used` when `emit_cashflows_used=true`
+- `reporting_currency`
+- `currency_evidence` when stateful source context or stateless source-preconverted FX evidence is
+  available
 - `start_date`, `end_date`, `notes`
 - `calculation_supportability`, `meta`, `diagnostics`, and `audit`
 

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-16T00:34:59.570177+00:00",
+  "generatedAt": "2026-05-20T01:15:49.587152+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -1315,12 +1315,12 @@
       "semanticId": "lotus.currency_evidence",
       "canonicalTerm": "currency_evidence",
       "preferredName": "currency_evidence",
-      "description": "Currency context and source-component evidence for stateful MWR. The block is additive to legacy cashflows_used and documents when upstream values are pre-converted without per-input FX metadata.",
+      "description": "Currency context and source-component evidence for MWR. The block is additive to legacy cashflows_used and documents either stateful upstream pre-conversion without per-input FX metadata or stateless source-preconverted inputs with complete per-input FX provenance.",
       "example": {
         "reporting_currency": "USD",
         "portfolio_currency": "USD",
-        "currency_mode": "USD",
-        "conversion_evidence_status": "example_conversion_evidence_status",
+        "currency_mode": "SINGLE_REPORTING_CURRENCY",
+        "conversion_evidence_status": "upstream_preconverted_missing_per_input_fx_metadata",
         "conversion_evidence_reason_codes": [
           "example_conversion_evidence_reason_codes_item"
         ],
@@ -1331,7 +1331,19 @@
             "currency": "USD",
             "value_role": "beginning_market_value",
             "source_product": "example_source_product",
-            "conversion_status": "example_conversion_status"
+            "conversion_status": "upstream_preconverted",
+            "source_amount": "example_source_amount",
+            "source_currency": "USD",
+            "reporting_amount": "example_reporting_amount",
+            "reporting_currency": "USD",
+            "fx_rate": "example_fx_rate",
+            "fx_pair": "example_fx_pair",
+            "fx_rate_date": "2026-02-27",
+            "fx_rate_source": "example_fx_rate_source",
+            "fx_rate_version": "example_fx_rate_version",
+            "conversion_policy": "example_conversion_policy",
+            "conversion_timestamp": "2026-02-27T10:30:00Z",
+            "conversion_fingerprint": "example_conversion_fingerprint"
           }
         ],
         "cashflow_evidence": [
@@ -1348,7 +1360,19 @@
                 "flow_scope": "example_flow_scope",
                 "source_classification": "example_source_classification"
               }
-            ]
+            ],
+            "source_amount": "example_source_amount",
+            "source_currency": "USD",
+            "reporting_amount": "example_reporting_amount",
+            "reporting_currency": "USD",
+            "fx_rate": "example_fx_rate",
+            "fx_pair": "example_fx_pair",
+            "fx_rate_date": "2026-02-27",
+            "fx_rate_source": "example_fx_rate_source",
+            "fx_rate_version": "example_fx_rate_version",
+            "conversion_policy": "example_conversion_policy",
+            "conversion_timestamp": "2026-02-27T10:30:00Z",
+            "conversion_fingerprint": "example_conversion_fingerprint"
           }
         ]
       },
@@ -5911,6 +5935,57 @@
       ]
     },
     {
+      "semanticId": "lotus.source_preconverted_fx_evidence",
+      "canonicalTerm": "source_preconverted_fx_evidence",
+      "preferredName": "source_preconverted_fx_evidence",
+      "description": "Optional complete FX provenance for stateless MWR inputs that were converted upstream. Lotus-performance validates this evidence and computes on the supplied reporting amounts; it does not convert source-currency amounts inside the MWR engine.",
+      "example": {
+        "evidence_scope": "example_evidence_scope",
+        "market_values": [
+          {
+            "source_amount": 0.1234,
+            "source_currency": "USD",
+            "reporting_amount": 0.1234,
+            "reporting_currency": "USD",
+            "fx_rate": 0.1234,
+            "fx_pair": "example_fx_pair",
+            "fx_rate_date": "2026-02-27",
+            "fx_rate_source": "example_fx_rate_source",
+            "fx_rate_version": "example_fx_rate_version",
+            "conversion_policy": "example_conversion_policy",
+            "conversion_timestamp": "2026-02-27T10:30:00Z",
+            "conversion_fingerprint": "example_conversion_fingerprint",
+            "value_role": "beginning_market_value"
+          }
+        ],
+        "cash_flows": [
+          {
+            "source_amount": 0.1234,
+            "source_currency": "USD",
+            "reporting_amount": 0.1234,
+            "reporting_currency": "USD",
+            "fx_rate": 0.1234,
+            "fx_pair": "example_fx_pair",
+            "fx_rate_date": "2026-02-27",
+            "fx_rate_source": "example_fx_rate_source",
+            "fx_rate_version": "example_fx_rate_version",
+            "conversion_policy": "example_conversion_policy",
+            "conversion_timestamp": "2026-02-27T10:30:00Z",
+            "conversion_fingerprint": "example_conversion_fingerprint",
+            "cash_flow_index": 1,
+            "cash_flow_date": "2026-02-27"
+          }
+        ]
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.source_quality_evidence",
       "canonicalTerm": "source_quality_evidence",
       "preferredName": "source_quality_evidence",
@@ -8547,6 +8622,14 @@
             "type": "string",
             "semanticId": "lotus.report_ccy",
             "attributeRef": "#/attributeCatalog/lotus.report_ccy"
+          },
+          {
+            "name": "source_preconverted_fx_evidence",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_preconverted_fx_evidence",
+            "attributeRef": "#/attributeCatalog/lotus.source_preconverted_fx_evidence"
           },
           {
             "name": "input_mode",

--- a/docs/technical/mwr-endpoint-certification.md
+++ b/docs/technical/mwr-endpoint-certification.md
@@ -28,6 +28,9 @@ for that TWR lens.
   weights.
 - `mwr_method="DIETZ"` returns the period midpoint Dietz return.
 - `emit_cashflows_used=true` returns the exact signed cash-flow schedule used by the calculation.
+- `source_preconverted_fx_evidence` is optional for stateless requests whose inputs were converted
+  upstream; when supplied, the endpoint validates complete per-input FX provenance and returns it
+  in `currency_evidence` without performing in-engine FX conversion.
 - `solver` controls searched annual-rate bounds, root scan density, tolerance, and maximum
   bisection iterations.
 
@@ -35,6 +38,11 @@ The XIRR implementation nets same-day solver flows after sign normalization, sca
 log-rate interval for all sign-changing roots, and returns XIRR only when exactly one root exists.
 No-root and multiple-root cases are not silently interpreted as a valid annual IRR; they are labeled
 through `status`, `reason_codes`, `fallback_from`, and `fallback_reason`.
+
+Stateless source-preconverted FX evidence fails closed when the evidence does not align with the
+reporting-currency MWR inputs. This protects downstream consumers from accepting a mixed-currency
+story that cannot be reproduced from the submitted market values, cash flows, rate metadata, policy,
+timestamp, and conversion fingerprint.
 
 ## Upstream Integration
 

--- a/docs/technical/mwr-fx-contract-design.md
+++ b/docs/technical/mwr-fx-contract-design.md
@@ -18,6 +18,13 @@ values and cash flows to already be expressed in one consistent reporting curren
 Modified Dietz, or Simple Dietz execution. This is intentional: today's `cashflows_used` response
 echo proves the signed schedule used by the engine, not FX conversion provenance.
 
+Stateless callers may now supply `source_preconverted_fx_evidence` for already converted inputs.
+When present, `lotus-performance` validates complete per-input FX provenance for both market values
+and every cash flow, rejects inconsistent reporting amounts or missing evidence with HTTP 422, and
+emits `currency_evidence.currency_mode="SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"` with
+`conversion_evidence_status="complete_source_preconverted_fx_metadata"`. This is a source-
+preconverted evidence contract, not an in-engine FX conversion contract.
+
 Current stateful execution does preserve the reporting-currency context that `lotus-core` already
 publishes on `PortfolioTimeseriesInput`. The MWR response now includes `reporting_currency` and a
 `currency_evidence` block with `market_values_used[]`, `cashflow_evidence[]`, and
@@ -62,21 +69,33 @@ carry enough evidence to make the reporting-currency schedule reproducible.
 | `conversion_timestamp` | Timestamp at which conversion evidence was assembled. |
 | `conversion_fingerprint` | Stable fingerprint for reproducibility and lineage tie-out. |
 
-For stateful MWR, this evidence must come from governed upstream analytics-input contracts. For
-stateless MWR, the caller must provide complete conversion evidence if the request asks
-`lotus-performance` to treat amounts as FX-aware. Missing or partial evidence must fail closed
-rather than falling back to guessed rates.
+For stateful MWR, this evidence must come from governed upstream analytics-input contracts before
+stateful MWR can claim complete per-input FX provenance. For stateless MWR, the caller must provide
+complete conversion evidence through `source_preconverted_fx_evidence` if the response should carry
+complete FX provenance. Missing, partial, or inconsistent evidence fails closed rather than falling
+back to guessed rates. In operational terms, the endpoint must fail closed when source and
+reporting-currency evidence cannot be tied out.
 
-## Proposed Response Semantics
+## Implemented And Proposed Response Semantics
 
-When implemented, FX-aware MWR should extend the response only after OpenAPI, gateway, Workbench,
-and documentation consumers are ready. The response should make the following visible:
+Implemented for stateless source-preconverted evidence:
 
 - `reporting_currency` for the MWR result.
-- `currency_mode` or equivalent posture that distinguishes base-only from FX-aware execution.
+- `currency_evidence.currency_mode="SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"` when every supplied
+  input has complete validated source-preconverted FX evidence.
+- `currency_evidence.market_values_used[]` with source amount, source currency, reporting amount,
+  reporting currency, FX rate, rate source/version/date, conversion policy/timestamp, and
+  conversion fingerprint.
+- `currency_evidence.cashflow_evidence[]` with the same per-cash-flow conversion fields aligned to
+  `cash_flows[]` by index.
+- reason codes documenting that the engine calculated a reporting-currency schedule after evidence
+  validation.
+
+Still proposed for future stateful upstream FX-aware MWR:
+
+- `reporting_currency` for the MWR result.
 - `cashflows_used[]` entries with both source and reporting-currency evidence when FX conversion is
-  active.
-- `market_values_used` or equivalent evidence for beginning and ending market-value conversion.
+  active from governed upstream source contracts.
 - conversion-policy metadata in `meta`, `diagnostics`, or a governed supportability block.
 - reason codes for missing FX evidence, stale rates, conflicting reporting currency, or unsupported
   conversion policy.
@@ -122,9 +141,9 @@ FX-aware MWR is not done until all of these are true:
 - Stateful mode consumes a governed upstream FX analytics-input contract, not an operational-read
   shortcut with implicit semantics.
 - `currency_evidence.conversion_evidence_status` moves from
-  `upstream_preconverted_missing_per_input_fx_metadata` to a complete governed status only after
-  upstream per-input FX evidence is available and validated.
-- Stateless mode validates complete FX evidence when FX-aware execution is requested.
+  `upstream_preconverted_missing_per_input_fx_metadata` to a complete governed status in stateful
+  mode only after upstream per-input FX evidence is available and validated.
+- Stateless mode validates complete FX evidence when source-preconverted evidence is supplied.
 - Engine tests cover XIRR and Dietz-family schedules with mixed source currencies after conversion.
 - API tests cover missing FX evidence, stale FX evidence, conflicting reporting currency, and
   source-preconverted schedules.
@@ -133,5 +152,6 @@ FX-aware MWR is not done until all of these are true:
 - Methodology, API guide, wiki, and support docs describe the implemented behavior using Lotus
   reporting-currency and supportability language.
 
-Until those items are complete, Lotus documentation must continue to describe MWR as a
-single-reporting-currency calculation.
+Until stateful upstream FX evidence and downstream consumers are complete, Lotus documentation must
+continue to describe MWR as a single-reporting-currency calculation with optional stateless
+source-preconverted FX provenance, not as an in-engine FX conversion capability.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ fastapi==0.135.3
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
-idna==3.11
+idna==3.15
 iniconfig==2.1.0
 numpy==2.3.2
 orjson==3.11.6

--- a/tests/integration/test_mwr_api.py
+++ b/tests/integration/test_mwr_api.py
@@ -188,6 +188,164 @@ def test_calculate_mwr_endpoint_supports_stateful_mode(client, monkeypatch):
     )
 
 
+def test_calculate_mwr_endpoint_accepts_complete_stateless_source_fx_evidence(client):
+    payload = {
+        "calculation_id": str(uuid4()),
+        "portfolio_id": "MWR_FX_EVIDENCE_01",
+        "begin_mv": 110000.0,
+        "end_mv": 126500.0,
+        "as_of": "2025-12-31",
+        "start_date": "2025-01-01",
+        "currency": "EUR",
+        "report_ccy": "USD",
+        "cash_flows": [{"amount": 5500.0, "date": "2025-06-30"}],
+        "mwr_method": "DIETZ",
+        "source_preconverted_fx_evidence": {
+            "market_values": [
+                {
+                    "value_role": "beginning_market_value",
+                    "source_amount": 100000.0,
+                    "source_currency": "EUR",
+                    "reporting_amount": 110000.0,
+                    "reporting_currency": "USD",
+                    "fx_rate": 1.1,
+                    "fx_pair": "EUR/USD",
+                    "fx_rate_date": "2025-01-01",
+                    "fx_rate_source": "ECB_FIXING",
+                    "fx_rate_version": "ECB-2025-01-01",
+                    "conversion_policy": "valuation-date-close",
+                    "conversion_timestamp": "2025-01-01T17:00:00Z",
+                    "conversion_fingerprint": "fx-begin-001",
+                },
+                {
+                    "value_role": "ending_market_value",
+                    "source_amount": 115000.0,
+                    "source_currency": "EUR",
+                    "reporting_amount": 126500.0,
+                    "reporting_currency": "USD",
+                    "fx_rate": 1.1,
+                    "fx_pair": "EUR/USD",
+                    "fx_rate_date": "2025-12-31",
+                    "fx_rate_source": "ECB_FIXING",
+                    "fx_rate_version": "ECB-2025-12-31",
+                    "conversion_policy": "valuation-date-close",
+                    "conversion_timestamp": "2025-12-31T17:00:00Z",
+                    "conversion_fingerprint": "fx-end-001",
+                },
+            ],
+            "cash_flows": [
+                {
+                    "cash_flow_index": 0,
+                    "cash_flow_date": "2025-06-30",
+                    "source_amount": 5000.0,
+                    "source_currency": "EUR",
+                    "reporting_amount": 5500.0,
+                    "reporting_currency": "USD",
+                    "fx_rate": 1.1,
+                    "fx_pair": "EUR/USD",
+                    "fx_rate_date": "2025-06-30",
+                    "fx_rate_source": "ECB_FIXING",
+                    "fx_rate_version": "ECB-2025-06-30",
+                    "conversion_policy": "cash-flow-date-close",
+                    "conversion_timestamp": "2025-06-30T17:00:00Z",
+                    "conversion_fingerprint": "fx-cashflow-001",
+                }
+            ],
+        },
+    }
+
+    response = client.post("/performance/mwr", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["input_mode"] == "stateless"
+    assert body["reporting_currency"] == "USD"
+    evidence = body["currency_evidence"]
+    assert evidence["currency_mode"] == "SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"
+    assert evidence["conversion_evidence_status"] == "complete_source_preconverted_fx_metadata"
+    assert evidence["conversion_evidence_reason_codes"] == [
+        "SOURCE_PRECONVERTED_INPUTS_SUPPLIED",
+        "PER_INPUT_FX_METADATA_VALIDATED",
+        "MWR_ENGINE_CALCULATED_REPORTING_CURRENCY_SCHEDULE",
+    ]
+    assert evidence["market_values_used"][0]["conversion_status"] == "source_preconverted_with_fx_evidence"
+    assert evidence["market_values_used"][0]["source_currency"] == "EUR"
+    assert evidence["market_values_used"][0]["reporting_currency"] == "USD"
+    assert evidence["cashflow_evidence"][0]["conversion_fingerprint"] == "fx-cashflow-001"
+    assert evidence["cashflow_evidence"][0]["source_components"] == []
+
+
+def test_calculate_mwr_endpoint_rejects_inconsistent_stateless_fx_evidence(client):
+    payload = {
+        "calculation_id": str(uuid4()),
+        "portfolio_id": "MWR_FX_EVIDENCE_BAD",
+        "begin_mv": 110000.0,
+        "end_mv": 126500.0,
+        "as_of": "2025-12-31",
+        "start_date": "2025-01-01",
+        "report_ccy": "USD",
+        "cash_flows": [{"amount": 5500.0, "date": "2025-06-30"}],
+        "mwr_method": "DIETZ",
+        "source_preconverted_fx_evidence": {
+            "market_values": [
+                {
+                    "value_role": "beginning_market_value",
+                    "source_amount": 100000.0,
+                    "source_currency": "EUR",
+                    "reporting_amount": 111000.0,
+                    "reporting_currency": "USD",
+                    "fx_rate": 1.11,
+                    "fx_pair": "EUR/USD",
+                    "fx_rate_date": "2025-01-01",
+                    "fx_rate_source": "ECB_FIXING",
+                    "fx_rate_version": "ECB-2025-01-01",
+                    "conversion_policy": "valuation-date-close",
+                    "conversion_timestamp": "2025-01-01T17:00:00Z",
+                    "conversion_fingerprint": "fx-begin-001",
+                },
+                {
+                    "value_role": "ending_market_value",
+                    "source_amount": 115000.0,
+                    "source_currency": "EUR",
+                    "reporting_amount": 126500.0,
+                    "reporting_currency": "USD",
+                    "fx_rate": 1.1,
+                    "fx_pair": "EUR/USD",
+                    "fx_rate_date": "2025-12-31",
+                    "fx_rate_source": "ECB_FIXING",
+                    "fx_rate_version": "ECB-2025-12-31",
+                    "conversion_policy": "valuation-date-close",
+                    "conversion_timestamp": "2025-12-31T17:00:00Z",
+                    "conversion_fingerprint": "fx-end-001",
+                },
+            ],
+            "cash_flows": [
+                {
+                    "cash_flow_index": 0,
+                    "cash_flow_date": "2025-06-30",
+                    "source_amount": 5000.0,
+                    "source_currency": "EUR",
+                    "reporting_amount": 5500.0,
+                    "reporting_currency": "USD",
+                    "fx_rate": 1.1,
+                    "fx_pair": "EUR/USD",
+                    "fx_rate_date": "2025-06-30",
+                    "fx_rate_source": "ECB_FIXING",
+                    "fx_rate_version": "ECB-2025-06-30",
+                    "conversion_policy": "cash-flow-date-close",
+                    "conversion_timestamp": "2025-06-30T17:00:00Z",
+                    "conversion_fingerprint": "fx-cashflow-001",
+                }
+            ],
+        },
+    }
+
+    response = client.post("/performance/mwr", json=payload)
+
+    assert response.status_code == 422
+    assert "reporting_amount must match the MWR input amount" in response.json()["detail"]
+
+
 def test_mwr_stateful_hashes_follow_resolved_inputs(client, monkeypatch):
     async def _mock_get_portfolio_timeseries(self, **kwargs):  # noqa: ARG001
         return (

--- a/tests/unit/app/test_mwr_openapi_contract.py
+++ b/tests/unit/app/test_mwr_openapi_contract.py
@@ -15,8 +15,12 @@ def test_mwr_openapi_explains_capital_timing_purpose_and_modes() -> None:
     assert "annual IRR" in mwr_post["description"]
     assert "dated cash-flow weights" in mwr_post["description"]
     assert "midpoint Dietz period return" in mwr_post["description"]
+    assert "source_preconverted_fx_evidence" in mwr_post["description"]
+    assert "validated FX provenance" in mwr_post["description"]
     assert "200" in mwr_post["responses"]
     assert "422" in mwr_post["responses"]
+    request_schema = spec["components"]["schemas"]["MoneyWeightedReturnAnalyticsRequest"]
+    assert "source_preconverted_fx_evidence" in request_schema["properties"]
     response_schema = spec["components"]["schemas"]["MoneyWeightedReturnResponse"]
     assert "calculation_supportability" in response_schema["properties"]
     assert "reporting_currency" in response_schema["properties"]
@@ -26,3 +30,8 @@ def test_mwr_openapi_explains_capital_timing_purpose_and_modes() -> None:
     assert "market_values_used" in evidence_schema["properties"]
     assert "cashflow_evidence" in evidence_schema["properties"]
     assert "conversion_evidence_status" in evidence_schema["properties"]
+    assert "SOURCE_PRECONVERTED_WITH_FX_EVIDENCE" in evidence_schema["properties"]["currency_mode"]["enum"]
+    assert (
+        "complete_source_preconverted_fx_metadata"
+        in evidence_schema["properties"]["conversion_evidence_status"]["enum"]
+    )

--- a/tests/unit/services/test_mwr_fx_evidence_service.py
+++ b/tests/unit/services/test_mwr_fx_evidence_service.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.mwr_requests import MoneyWeightedReturnRequest
+from app.services.mwr_fx_evidence_service import build_source_preconverted_mwr_currency_evidence
+
+
+def _request_with_evidence(**overrides) -> MoneyWeightedReturnRequest:
+    payload = {
+        "portfolio_id": "MWR_FX_UNIT",
+        "begin_mv": 110000.0,
+        "end_mv": 126500.0,
+        "as_of": "2025-12-31",
+        "start_date": "2025-01-01",
+        "currency": "EUR",
+        "report_ccy": "USD",
+        "cash_flows": [{"amount": 5500.0, "date": "2025-06-30"}],
+        "mwr_method": "DIETZ",
+        "source_preconverted_fx_evidence": {
+            "market_values": [
+                _market_value("beginning_market_value", 100000.0, 110000.0, "2025-01-01", "fx-begin"),
+                _market_value("ending_market_value", 115000.0, 126500.0, "2025-12-31", "fx-end"),
+            ],
+            "cash_flows": [_cash_flow()],
+        },
+    }
+    payload.update(overrides)
+    return MoneyWeightedReturnRequest.model_validate(payload)
+
+
+def _market_value(role: str, source_amount: float, reporting_amount: float, rate_date: str, fingerprint: str) -> dict:
+    return {
+        "value_role": role,
+        "source_amount": source_amount,
+        "source_currency": "EUR",
+        "reporting_amount": reporting_amount,
+        "reporting_currency": "USD",
+        "fx_rate": 1.1,
+        "fx_pair": "EUR/USD",
+        "fx_rate_date": rate_date,
+        "fx_rate_source": "ECB_FIXING",
+        "fx_rate_version": f"ECB-{rate_date}",
+        "conversion_policy": "valuation-date-close",
+        "conversion_timestamp": f"{rate_date}T17:00:00Z",
+        "conversion_fingerprint": fingerprint,
+    }
+
+
+def _cash_flow(**overrides) -> dict:
+    payload = {
+        "cash_flow_index": 0,
+        "cash_flow_date": "2025-06-30",
+        "source_amount": 5000.0,
+        "source_currency": "EUR",
+        "reporting_amount": 5500.0,
+        "reporting_currency": "USD",
+        "fx_rate": 1.1,
+        "fx_pair": "EUR/USD",
+        "fx_rate_date": "2025-06-30",
+        "fx_rate_source": "ECB_FIXING",
+        "fx_rate_version": "ECB-2025-06-30",
+        "conversion_policy": "cash-flow-date-close",
+        "conversion_timestamp": "2025-06-30T17:00:00Z",
+        "conversion_fingerprint": "fx-cashflow",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_source_preconverted_mwr_currency_evidence_returns_none_without_evidence():
+    request = MoneyWeightedReturnRequest.model_validate(
+        {
+            "portfolio_id": "MWR_NO_FX",
+            "begin_mv": 100.0,
+            "end_mv": 110.0,
+            "as_of": "2025-12-31",
+            "cash_flows": [],
+        }
+    )
+
+    assert build_source_preconverted_mwr_currency_evidence(request) is None
+
+
+def test_source_preconverted_mwr_currency_evidence_maps_valid_payload():
+    evidence = build_source_preconverted_mwr_currency_evidence(_request_with_evidence())
+
+    assert evidence is not None
+    assert evidence.currency_mode == "SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"
+    assert evidence.market_values_used[0].conversion_status == "source_preconverted_with_fx_evidence"
+    assert evidence.cashflow_evidence[0].conversion_fingerprint == "fx-cashflow"
+
+
+@pytest.mark.parametrize(
+    "evidence_override, expected_message",
+    [
+        (
+            {
+                "market_values": [
+                    _market_value("beginning_market_value", 100000.0, 110000.0, "2025-01-01", "fx-begin")
+                ],
+                "cash_flows": [_cash_flow()],
+            },
+            "must contain exactly one beginning_market_value and one ending_market_value",
+        ),
+        (
+            {
+                "market_values": [
+                    _market_value("beginning_market_value", 100000.0, 110000.0, "2025-01-01", "fx-begin"),
+                    _market_value("beginning_market_value", 100001.0, 110001.0, "2025-01-01", "fx-begin-2"),
+                ],
+                "cash_flows": [_cash_flow()],
+            },
+            "must contain exactly one beginning_market_value and one ending_market_value",
+        ),
+        (
+            {
+                "market_values": [
+                    _market_value("beginning_market_value", 100000.0, 110000.0, "2025-01-01", "fx-begin"),
+                    _market_value("ending_market_value", 115000.0, 126500.0, "2025-12-31", "fx-end"),
+                    _market_value("ending_market_value", 115001.0, 126501.0, "2025-12-31", "fx-end-2"),
+                ],
+                "cash_flows": [_cash_flow()],
+            },
+            "must contain exactly two records",
+        ),
+        (
+            {
+                "market_values": [
+                    _market_value("beginning_market_value", 100000.0, 110000.0, "2025-01-01", "fx-begin"),
+                    _market_value("ending_market_value", 115000.0, 126500.0, "2025-12-31", "fx-end"),
+                ],
+                "cash_flows": [],
+            },
+            "must contain exactly one record for each cash flow index",
+        ),
+    ],
+)
+def test_source_preconverted_mwr_currency_evidence_rejects_incomplete_collections(
+    evidence_override,
+    expected_message,
+):
+    request = _request_with_evidence(source_preconverted_fx_evidence=evidence_override)
+
+    with pytest.raises(HTTPException, match=expected_message):
+        build_source_preconverted_mwr_currency_evidence(request)
+
+
+@pytest.mark.parametrize(
+    "cash_flow_override, expected_message",
+    [
+        ({"cash_flow_date": "2025-07-01"}, "cash_flow_date must match"),
+        ({"reporting_currency": "CHF"}, "reporting_currency must match"),
+        ({"reporting_amount": 5501.0}, "reporting_amount must match"),
+        (
+            {"source_currency": "USD", "reporting_currency": "USD", "fx_rate": 1.1},
+            "fx_rate must be 1 when source_currency equals reporting_currency",
+        ),
+        ({"conversion_policy": " "}, "missing required FX evidence fields"),
+    ],
+)
+def test_source_preconverted_mwr_currency_evidence_rejects_inconsistent_components(
+    cash_flow_override,
+    expected_message,
+):
+    request = _request_with_evidence(
+        source_preconverted_fx_evidence={
+            "market_values": [
+                _market_value("beginning_market_value", 100000.0, 110000.0, "2025-01-01", "fx-begin"),
+                _market_value("ending_market_value", 115000.0, 126500.0, "2025-12-31", "fx-end"),
+            ],
+            "cash_flows": [_cash_flow(**cash_flow_override)],
+        }
+    )
+
+    with pytest.raises(HTTPException, match=expected_message):
+        build_source_preconverted_mwr_currency_evidence(request)

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -58,12 +58,16 @@ calculation-quality metadata (`status`, `reason_codes`, `warnings`, `fallback_re
 support workflows, and downstream UI panels can explain whether the value is an annualized XIRR, a
 Modified Dietz fallback, Simple Dietz result, or not calculable.
 Current MWR inputs must be in one reporting currency. `cashflows_used` remains the legacy
-calculation-schedule echo. Stateful responses also carry `reporting_currency` and
-`currency_evidence`, including beginning/ending market values, source cash-flow components, and the
-explicit `upstream_preconverted_missing_per_input_fx_metadata` posture. FX-aware MWR is still
-contract-gated by [docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md),
-and downstream consumers must not infer missing FX rates or conversion policy from the current
-response.
+calculation-schedule echo. Stateless callers may supply complete
+`source_preconverted_fx_evidence`; lotus-performance validates it against the supplied
+reporting-currency schedule and emits `currency_evidence` with per-input FX provenance. Stateful
+responses also carry `reporting_currency` and `currency_evidence`, including beginning/ending
+market values, source cash-flow components, and the explicit
+`upstream_preconverted_missing_per_input_fx_metadata` posture. Stateful upstream FX-aware MWR is
+still contract-gated by
+[docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md), and
+downstream consumers must not infer missing FX rates or conversion policy when those fields are
+absent.
 
 `POST /performance/contribution` supports both stateless caller-owned inputs and stateful lotus-core
 portfolio/position timeseries sourcing. In stateful mode it is the source-owned contribution

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -76,15 +76,17 @@ and emits MWR plus supportability metadata for downstream consumers.
 Gateway and Workbench should consume the emitted MWR response as source-owned performance truth;
 they must not reconstruct cash flows from TWR, benchmark, or workspace summary payloads.
 Current MWR inputs are a single reporting-currency schedule. Gateway, Workbench, reporting, and
-support tooling must not infer FX rates, conversion policy, or source-currency provenance from
-today's `cashflows_used` echo.
+support tooling must not infer FX rates, conversion policy, or source-currency provenance from the
+legacy `cashflows_used` echo. Stateless callers may provide complete
+`source_preconverted_fx_evidence`; when present, downstream consumers should preserve the emitted
+`currency_evidence` and must not recalculate FX conversion or MWR locally.
 Gateway should preserve calculation-quality fields (`status`, `reason_codes`, `warnings`,
 `fallback_reason`, `is_approximation`, and `holding_period_return`) because they explain whether the
 client-facing number is annualized XIRR, a labeled Modified Dietz fallback, a Simple Dietz result,
 or not calculable.
 The implementation-backed Lotus production control guide is maintained at
 [docs/guides/mwr-lotus-production-controls.md](../docs/guides/mwr-lotus-production-controls.md).
-The future FX-aware MWR gate is maintained at
+The stateful upstream FX-aware MWR gate is maintained at
 [docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md).
 
 ```mermaid

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -42,8 +42,10 @@
   outside the producer, or infer per-input FX provenance from pre-converted source amounts.
   It is now declared as `MoneyWeightedReturnAnalytics` in
   `contracts/domain-data-products/lotus-performance-products.v1.json`. Current MWR is a single
-  reporting-currency product with explicit source-component evidence; future FX-aware MWR remains
-  gated by
+  reporting-currency product with explicit source-component evidence. Stateless callers may supply
+  complete `source_preconverted_fx_evidence`; consumers should preserve the emitted
+  `currency_evidence` and must not reconstruct FX conversion locally. Stateful upstream FX-aware
+  MWR remains gated by
   [docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md).
   Production controls and review findings are maintained in
   [docs/guides/mwr-lotus-production-controls.md](../docs/guides/mwr-lotus-production-controls.md)


### PR DESCRIPTION
## Summary
- add complete source-preconverted FX evidence models for stateless MWR inputs
- validate per-input reporting amount, reporting currency, FX metadata, and conversion fingerprints before emitting currency_evidence
- update OpenAPI vocabulary, MWR methodology docs, README/context, certification docs, and wiki source without claiming in-engine FX conversion

## Validation
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- python -m pytest tests\\integration\\test_mwr_api.py tests\\unit\\app\\test_mwr_openapi_contract.py tests\\unit\\docs\\test_public_docs_contract.py
- python -m pytest tests\\unit\\docs\\test_metric_methodology_docs.py tests\\unit\\docs\\test_public_docs_contract.py
- make test-unit
- make test-integration
- make test-e2e
- make domain-product-validate
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance (expected pre-merge drift: API-Surface.md, Integrations.md, Mesh-Data-Products.md)