### PR TITLE
Add mandate performance health context

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -25,8 +25,9 @@ This repository owns:
 1. time-weighted and money-weighted return workflows,
 2. benchmark analytics,
 3. contribution and attribution analytics,
-4. performance execution lifecycle tracking,
-5. performance lineage and reproducibility evidence.
+4. mandate performance health context for bounded DPM supportability consumption,
+5. performance execution lifecycle tracking,
+6. performance lineage and reproducibility evidence.
 
 ## Current-State Summary
 
@@ -58,6 +59,11 @@ Current repository posture:
     provenance for beginning market value, ending market value, and every cash flow, and emits
     `currency_evidence` while preserving the engine boundary that MWR calculates one
     reporting-currency schedule and does not perform in-engine FX conversion.
+11. `MandatePerformanceHealthContext:v1` is a bounded performance-owned data product at
+    `POST /performance/mandate-health-context` for DPM supportability consumers. It emits
+    active-return threshold posture, methodology posture, request fingerprint, and reason codes;
+    it does not create mandate actions, rebalance waves, client communications, orders, OMS
+    actions, or execution instructions.
 
 ## Architecture And Module Map
 

--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -166,6 +166,21 @@ INTEGRATION_CAPABILITIES_RESPONSE_EXAMPLES = [
                 "options": [],
             },
             {
+                "key": "mandate_performance_health_context",
+                "path": "/performance/mandate-health-context",
+                "enabled": True,
+                "supported_input_modes": ["stateless"],
+                "supports_async": False,
+                "poll_path_template": None,
+                "result_path_template": None,
+                "stateful_restrictions": [],
+                "contract_notes": [
+                    "emits bounded lotus-performance-owned active-return health posture for lotus-manage DPM supportability",
+                    "does not create mandate actions, rebalance waves, client communications, orders, OMS, or execution instructions",
+                ],
+                "options": [],
+            },
+            {
                 "key": "returns_series",
                 "path": "/integration/returns/series",
                 "enabled": True,
@@ -253,6 +268,12 @@ INTEGRATION_CAPABILITIES_RESPONSE_EXAMPLES = [
                 "description": CALCULATION_SUPPORTABILITY_DESCRIPTION,
             },
             {
+                "key": "performance.integration.mandate_performance_health_context",
+                "enabled": True,
+                "owner_service": "lotus-performance",
+                "description": "Bounded source-owned mandate performance health context for DPM supportability.",
+            },
+            {
                 "key": "performance.execution.stateful",
                 "enabled": True,
                 "owner_service": "lotus-performance",
@@ -293,6 +314,14 @@ INTEGRATION_CAPABILITIES_RESPONSE_EXAMPLES = [
                 "workflow_key": "performance_support_triage",
                 "enabled": True,
                 "required_features": ["performance.analytics.twr", "performance.support.twr_inspection"],
+            },
+            {
+                "workflow_key": "mandate_performance_health_context",
+                "enabled": True,
+                "required_features": [
+                    "performance.analytics.twr",
+                    "performance.integration.mandate_performance_health_context",
+                ],
             },
             {
                 "workflow_key": "execution_stateful",
@@ -541,6 +570,12 @@ async def get_integration_capabilities(
             description=CALCULATION_SUPPORTABILITY_DESCRIPTION,
         ),
         FeatureCapability(
+            key="performance.integration.mandate_performance_health_context",
+            enabled=twr_enabled,
+            owner_service="lotus-performance",
+            description="Bounded source-owned mandate performance health context for DPM supportability.",
+        ),
+        FeatureCapability(
             key="performance.execution.stateful",
             enabled=stateful_mode_enabled,
             owner_service="lotus-performance",
@@ -582,6 +617,14 @@ async def get_integration_capabilities(
             workflow_key="performance_support_triage",
             enabled=twr_enabled,
             required_features=["performance.analytics.twr", "performance.support.twr_inspection"],
+        ),
+        WorkflowCapability(
+            workflow_key="mandate_performance_health_context",
+            enabled=twr_enabled,
+            required_features=[
+                "performance.analytics.twr",
+                "performance.integration.mandate_performance_health_context",
+            ],
         ),
         WorkflowCapability(
             workflow_key="execution_stateful",
@@ -735,6 +778,21 @@ async def get_integration_capabilities(
                     "currency_mode=BOTH requires report_ccy and fx.rates for mixed-currency positions",
                 ]
                 if stateful_mode_enabled and attribution_enabled
+                else []
+            ),
+        ),
+        AnalyticsSurfaceCapability(
+            key="mandate_performance_health_context",
+            path="/performance/mandate-health-context",
+            enabled=twr_enabled,
+            supported_input_modes=["stateless"],
+            supports_async=False,
+            contract_notes=(
+                [
+                    "emits bounded lotus-performance-owned active-return health posture for lotus-manage DPM supportability",
+                    "does not create mandate actions, rebalance waves, client communications, orders, OMS, or execution instructions",
+                ]
+                if twr_enabled
                 else []
             ),
         ),

--- a/app/api/endpoints/mandate_health_context.py
+++ b/app/api/endpoints/mandate_health_context.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.models.mandate_health import (
+    MandatePerformanceHealthContextRequest,
+    MandatePerformanceHealthContextResponse,
+)
+from app.services.mandate_health_context_service import (
+    evaluate_mandate_performance_health_context,
+)
+
+router = APIRouter(tags=["Performance"])
+
+
+@router.post(
+    "/mandate-health-context",
+    response_model=MandatePerformanceHealthContextResponse,
+    summary="Evaluate source-owned mandate performance health context",
+    description=(
+        "Evaluates a bounded mandate performance health context using lotus-performance "
+        "source-owned active-return interpretation. The response preserves threshold posture, "
+        "methodology ownership, request lineage, and reason codes for downstream consumers such "
+        "as lotus-manage without creating mandate actions, rebalance waves, client "
+        "communications, orders, or execution."
+    ),
+)
+def evaluate_mandate_performance_health_context_endpoint(
+    request: MandatePerformanceHealthContextRequest,
+) -> MandatePerformanceHealthContextResponse:
+    return evaluate_mandate_performance_health_context(request)

--- a/app/models/mandate_health.py
+++ b/app/models/mandate_health.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+MandatePerformanceHealthState = Literal["ready", "attention", "unavailable"]
+
+
+class MandatePerformanceHealthContextRequest(BaseModel):
+    portfolio_id: str = Field(
+        description="Portfolio identifier for the mandate performance health context.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    as_of_date: date = Field(
+        description="As-of date used for the source-owned performance health context.",
+        examples=["2026-02-27"],
+    )
+    period_name: str = Field(
+        description="Resolved performance period label evaluated by the source product.",
+        examples=["YTD"],
+    )
+    portfolio_period_return: Decimal | None = Field(
+        default=None,
+        description="Portfolio period return in percentage-point output units.",
+        examples=["2.45"],
+    )
+    benchmark_period_return: Decimal | None = Field(
+        default=None,
+        description="Benchmark period return in percentage-point output units.",
+        examples=["2.80"],
+    )
+    active_return_attention_threshold: Decimal = Field(
+        default=Decimal("-0.50"),
+        description=(
+            "Active-return attention threshold in percentage points. Negative values indicate "
+            "underperformance tolerance; -0.50 means attention when portfolio underperforms by "
+            "more than 50 bps for the evaluated period."
+        ),
+        examples=["-0.50"],
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MandatePerformanceHealthSourceMetric(BaseModel):
+    metric_name: Literal["ACTIVE_RETURN"] = Field(
+        default="ACTIVE_RETURN",
+        description="Source-owned performance metric used for mandate health posture.",
+        examples=["ACTIVE_RETURN"],
+    )
+    portfolio_period_return: Decimal | None = Field(
+        default=None,
+        description="Portfolio period return in percentage-point output units.",
+        examples=["2.45"],
+    )
+    benchmark_period_return: Decimal | None = Field(
+        default=None,
+        description="Benchmark period return in percentage-point output units.",
+        examples=["2.80"],
+    )
+    active_return: Decimal | None = Field(
+        default=None,
+        description="Portfolio return minus benchmark return in percentage points.",
+        examples=["-0.35"],
+    )
+
+
+class MandatePerformanceHealthMethodologyPosture(BaseModel):
+    source_product_name: Literal["MandatePerformanceHealthContext"] = Field(
+        default="MandatePerformanceHealthContext",
+        description="Source-owned mandate health performance product name.",
+        examples=["MandatePerformanceHealthContext"],
+    )
+    source_product_version: Literal["v1"] = Field(
+        default="v1",
+        description="Source-owned mandate health performance product version.",
+        examples=["v1"],
+    )
+    source_service: Literal["lotus-performance"] = Field(
+        default="lotus-performance",
+        description="Authoritative source service for this performance context.",
+        examples=["lotus-performance"],
+    )
+    source_metrics_product: Literal["TimeWeightedReturnAnalytics:v1"] = Field(
+        default="TimeWeightedReturnAnalytics:v1",
+        description="Underlying source-owned performance product family used for this context.",
+        examples=["TimeWeightedReturnAnalytics:v1"],
+    )
+    methodology_version: Literal["twr.v1"] = Field(
+        default="twr.v1",
+        description="Source methodology family used for period and active-return interpretation.",
+        examples=["twr.v1"],
+    )
+    source_route: Literal["/performance/twr"] = Field(
+        default="/performance/twr",
+        description="Underlying source route for full source-owned TWR calculation.",
+        examples=["/performance/twr"],
+    )
+
+
+class MandatePerformanceBenchmarkContext(BaseModel):
+    benchmark_available: bool = Field(
+        description="Whether benchmark period-return evidence was available for active-return evaluation.",
+        examples=[True],
+    )
+    benchmark_return_source: Literal["request_supplied_period_return"] = Field(
+        default="request_supplied_period_return",
+        description="Bounded benchmark-return source posture for this stateless context product.",
+        examples=["request_supplied_period_return"],
+    )
+
+
+class MandatePerformanceHealthContextResponse(BaseModel):
+    product_name: Literal["MandatePerformanceHealthContext"] = Field(
+        default="MandatePerformanceHealthContext",
+        description="Source-owned product emitted by lotus-performance for mandate health performance context.",
+        examples=["MandatePerformanceHealthContext"],
+    )
+    product_version: Literal["v1"] = Field(
+        default="v1",
+        description="Product contract version.",
+        examples=["v1"],
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier evaluated by the source product.",
+        examples=["PB_SG_GLOBAL_BAL_001"],
+    )
+    as_of_date: date = Field(
+        description="As-of date for the source-owned mandate performance health context.",
+        examples=["2026-02-27"],
+    )
+    period_name: str = Field(
+        description="Resolved period key evaluated by the source product.",
+        examples=["YTD"],
+    )
+    health_state: MandatePerformanceHealthState = Field(
+        description="Bounded performance health posture derived from source-owned active return.",
+        examples=["ready"],
+    )
+    threshold_breached: bool | None = Field(
+        default=None,
+        description="Whether active return breached the supplied underperformance threshold.",
+        examples=[False],
+    )
+    active_return_attention_threshold: Decimal = Field(
+        description="Applied active-return threshold in percentage points.",
+        examples=["-0.50"],
+    )
+    source_metric: MandatePerformanceHealthSourceMetric = Field(
+        description="Bounded source metric evidence used to derive health state.",
+        json_schema_extra={
+            "example": {
+                "metric_name": "ACTIVE_RETURN",
+                "portfolio_period_return": "2.45",
+                "benchmark_period_return": "2.80",
+                "active_return": "-0.35",
+            }
+        },
+    )
+    methodology_posture: MandatePerformanceHealthMethodologyPosture = Field(
+        default_factory=MandatePerformanceHealthMethodologyPosture,
+        description="Source ownership and methodology posture for consumers.",
+        json_schema_extra={
+            "example": {
+                "source_product_name": "MandatePerformanceHealthContext",
+                "source_product_version": "v1",
+                "source_service": "lotus-performance",
+                "source_metrics_product": "TimeWeightedReturnAnalytics:v1",
+                "methodology_version": "twr.v1",
+                "source_route": "/performance/twr",
+            }
+        },
+    )
+    source_services: list[Literal["lotus-performance"]] = Field(
+        default_factory=lambda: ["lotus-performance"],
+        description="Ordered source services that materially contribute to this product payload.",
+        examples=[["lotus-performance"]],
+    )
+    benchmark_context: MandatePerformanceBenchmarkContext = Field(
+        description="Benchmark evidence posture for the active-return evaluation.",
+        json_schema_extra={
+            "example": {
+                "benchmark_available": True,
+                "benchmark_return_source": "request_supplied_period_return",
+            }
+        },
+    )
+    request_fingerprint: str = Field(
+        description="Fingerprint of the mandate performance health context request.",
+        examples=["sha256:..."],
+    )
+    reason_codes: list[str] = Field(
+        description="Bounded reason codes safe for downstream supportability and audit use.",
+        examples=[
+            [
+                "MANDATE_PERFORMANCE_HEALTH_ACTIVE_RETURN_SOURCE_READY",
+                "PERFORMANCE_METHODOLOGY_SOURCE_OWNED",
+            ]
+        ],
+    )

--- a/app/services/mandate_health_context_service.py
+++ b/app/services/mandate_health_context_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.models.mandate_health import (
+    MandatePerformanceBenchmarkContext,
+    MandatePerformanceHealthContextRequest,
+    MandatePerformanceHealthContextResponse,
+    MandatePerformanceHealthSourceMetric,
+    MandatePerformanceHealthState,
+)
+from core.repro import generate_canonical_hash_from_value
+
+
+def evaluate_mandate_performance_health_context(
+    request: MandatePerformanceHealthContextRequest,
+) -> MandatePerformanceHealthContextResponse:
+    reason_codes = ["PERFORMANCE_METHODOLOGY_SOURCE_OWNED"]
+    active_return: Decimal | None = None
+
+    if request.portfolio_period_return is None or request.benchmark_period_return is None:
+        health_state: MandatePerformanceHealthState = "unavailable"
+        threshold_breached = None
+        reason_codes.append("MANDATE_PERFORMANCE_HEALTH_ACTIVE_RETURN_UNAVAILABLE")
+    else:
+        active_return = request.portfolio_period_return - request.benchmark_period_return
+        threshold_breached = active_return < request.active_return_attention_threshold
+        health_state = "attention" if threshold_breached else "ready"
+        reason_codes.append("MANDATE_PERFORMANCE_HEALTH_ACTIVE_RETURN_SOURCE_READY")
+        if threshold_breached:
+            reason_codes.append("MANDATE_PERFORMANCE_HEALTH_ACTIVE_RETURN_THRESHOLD_BREACHED")
+
+    request_fingerprint, _ = generate_canonical_hash_from_value(
+        request,
+        engine_version="mandate-performance-health-context.v1",
+    )
+
+    return MandatePerformanceHealthContextResponse(
+        portfolio_id=request.portfolio_id,
+        as_of_date=request.as_of_date,
+        period_name=request.period_name,
+        health_state=health_state,
+        threshold_breached=threshold_breached,
+        active_return_attention_threshold=request.active_return_attention_threshold,
+        source_metric=MandatePerformanceHealthSourceMetric(
+            portfolio_period_return=request.portfolio_period_return,
+            benchmark_period_return=request.benchmark_period_return,
+            active_return=active_return,
+        ),
+        benchmark_context=MandatePerformanceBenchmarkContext(
+            benchmark_available=request.benchmark_period_return is not None
+        ),
+        request_fingerprint=request_fingerprint,
+        reason_codes=reason_codes,
+    )

--- a/contracts/domain-data-products/lotus-performance-products.v1.json
+++ b/contracts/domain-data-products/lotus-performance-products.v1.json
@@ -254,6 +254,63 @@
       "temporal_semantics_ref": "as_of_date"
     },
     {
+      "product_name": "MandatePerformanceHealthContext",
+      "product_version": "v1",
+      "owner_repository": "lotus-performance",
+      "product_family": "analytics_output",
+      "authoritative_domain": "performance_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "valuation_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "request_fingerprint",
+        "source_services",
+        "benchmark_context"
+      ],
+      "current_routes": [
+        "/performance/mandate-health-context"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Mandate performance health context is derived from source-owned portfolio and benchmark period-return evidence for the requested as-of date and period."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable",
+        "lineage_bundle_class_ref": "customer_lineage_summary"
+      },
+      "security_profile_ref": "system_access:client_confidential:retain_for_client_record:audit_system_access",
+      "approved_consumers": [
+        "lotus-gateway",
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "benchmark_id",
+        "correlation_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
       "product_name": "ReturnsSeriesBundle",
       "product_version": "v1",
       "owner_repository": "lotus-performance",

--- a/docs/examples/integration_capabilities_response.json
+++ b/docs/examples/integration_capabilities_response.json
@@ -158,6 +158,23 @@
       "supports_async": true
     },
     {
+      "contract_notes": [
+        "emits bounded lotus-performance-owned active-return health posture for lotus-manage DPM supportability",
+        "does not create mandate actions, rebalance waves, client communications, orders, OMS, or execution instructions"
+      ],
+      "enabled": true,
+      "key": "mandate_performance_health_context",
+      "options": [],
+      "path": "/performance/mandate-health-context",
+      "poll_path_template": null,
+      "result_path_template": null,
+      "stateful_restrictions": [],
+      "supported_input_modes": [
+        "stateless"
+      ],
+      "supports_async": false
+    },
+    {
       "contract_notes": [],
       "enabled": true,
       "key": "returns_series",
@@ -253,6 +270,12 @@
       "owner_service": "lotus-performance"
     },
     {
+      "description": "Bounded source-owned mandate performance health context for DPM supportability.",
+      "enabled": true,
+      "key": "performance.integration.mandate_performance_health_context",
+      "owner_service": "lotus-performance"
+    },
+    {
       "description": "lotus-performance executes using platform-managed stateful input retrieval.",
       "enabled": true,
       "key": "performance.execution.stateful",
@@ -307,6 +330,14 @@
         "performance.support.twr_inspection"
       ],
       "workflow_key": "performance_support_triage"
+    },
+    {
+      "enabled": true,
+      "required_features": [
+        "performance.analytics.twr",
+        "performance.integration.mandate_performance_health_context"
+      ],
+      "workflow_key": "mandate_performance_health_context"
     },
     {
       "enabled": true,

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -38,6 +38,22 @@ descriptions and examples are maintained in the generated OpenAPI contract.
   - completed: `app.models.responses.PerformanceResponse`
   - still running: `app.models.responses.TWRAcceptedResponse`
 
+### `POST /performance/mandate-health-context`
+
+- purpose: evaluate a bounded source-owned mandate performance health context
+- request model: `app.models.mandate_health.MandatePerformanceHealthContextRequest`
+- response model: `app.models.mandate_health.MandatePerformanceHealthContextResponse`
+- execution mode: synchronous
+- supported input modes:
+  - `stateless`
+- contract note:
+  - emits `MandatePerformanceHealthContext:v1` for DPM supportability consumers such as `lotus-manage`
+  - derives `ACTIVE_RETURN` from supplied portfolio and benchmark period returns in percentage-point output units
+  - returns `health_state="unavailable"` when active-return evidence is incomplete
+  - preserves lotus-performance methodology posture through `TimeWeightedReturnAnalytics:v1` and `/performance/twr`
+  - does not create mandate actions, rebalance waves, client communications, trades, orders, OMS actions, or execution instructions
+- guide: `docs/guides/mandate_performance_health_context.md`
+
 ### `GET /performance/executions/{calculation_id}`
 
 - purpose: poll durable execution lifecycle state for async and synchronous calculations

--- a/docs/guides/mandate_performance_health_context.md
+++ b/docs/guides/mandate_performance_health_context.md
@@ -1,0 +1,56 @@
+# Mandate Performance Health Context
+
+`MandatePerformanceHealthContext:v1` gives downstream DPM consumers a bounded performance-owned
+health signal for portfolio mandate supportability. It is intentionally narrow: lotus-performance
+evaluates supplied portfolio and benchmark period-return evidence, emits active-return posture,
+preserves methodology ownership, and records request lineage.
+
+## Endpoint
+
+`POST /performance/mandate-health-context`
+
+The endpoint is synchronous and stateless. It does not retrieve source rows, create DPM review
+actions, create rebalance waves, contact clients, place orders, or integrate with OMS or execution
+systems.
+
+## Request
+
+Required fields:
+
+- `portfolio_id`
+- `as_of_date`
+- `period_name`
+
+Performance evidence fields:
+
+- `portfolio_period_return`: portfolio period return in percentage points
+- `benchmark_period_return`: benchmark period return in percentage points
+- `active_return_attention_threshold`: underperformance threshold in percentage points, default
+  `-0.50`
+
+When either portfolio or benchmark return is absent, the response is `health_state="unavailable"`
+and no active-return threshold conclusion is emitted.
+
+## Response
+
+The response includes:
+
+- `product_name="MandatePerformanceHealthContext"`
+- `product_version="v1"`
+- `health_state`: `ready`, `attention`, or `unavailable`
+- `threshold_breached`
+- `source_metric.metric_name="ACTIVE_RETURN"`
+- `source_metric.active_return`
+- `methodology_posture.source_service="lotus-performance"`
+- `methodology_posture.source_metrics_product="TimeWeightedReturnAnalytics:v1"`
+- `methodology_posture.source_route="/performance/twr"`
+- `request_fingerprint`
+- bounded `reason_codes`
+
+## Consumer Boundary
+
+`lotus-manage` may consume this source product as performance evidence for DPM supportability and
+portfolio-memory posture. Downstream services must preserve the emitted methodology posture,
+threshold posture, and reason codes. They must not reconstruct active return, reinterpret
+performance methodology, or treat this context as a mandate decision, client communication,
+trade recommendation, order, OMS action, or execution instruction.

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-20T01:15:49.587152+00:00",
+  "generatedAt": "2026-05-22T01:45:33.261162+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -64,6 +64,35 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.active_return",
+      "canonicalTerm": "active_return",
+      "preferredName": "active_return",
+      "description": "Canonical active return used by lotus-performance APIs.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.active_return_attention_threshold",
+      "canonicalTerm": "active_return_attention_threshold",
+      "preferredName": "active_return_attention_threshold",
+      "description": "Active-return attention threshold in percentage points. Negative values indicate underperformance tolerance; -0.50 means attention when portfolio underperforms by more than 50 bps for the evaluated period.",
+      "example": "STANDARD_VALUE",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
       ]
     },
     {
@@ -543,6 +572,36 @@
       ]
     },
     {
+      "semanticId": "lotus.benchmark_available",
+      "canonicalTerm": "benchmark_available",
+      "preferredName": "benchmark_available",
+      "description": "Whether benchmark period-return evidence was available for active-return evaluation.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.benchmark_context",
+      "canonicalTerm": "benchmark_context",
+      "preferredName": "benchmark_context",
+      "description": "mandate performance benchmark context object.",
+      "example": {
+        "key": "value"
+      },
+      "type": "MandatePerformanceBenchmarkContext",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "MandatePerformanceBenchmarkContext"
+      ]
+    },
+    {
       "semanticId": "lotus.benchmark_groups_data",
       "canonicalTerm": "benchmark_groups_data",
       "preferredName": "benchmark_groups_data",
@@ -577,6 +636,35 @@
       "preferredName": "benchmark_id",
       "description": "Benchmark identifier.",
       "example": "ENTITY_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.benchmark_period_return",
+      "canonicalTerm": "benchmark_period_return",
+      "preferredName": "benchmark_period_return",
+      "description": "Benchmark period return in percentage-point output units.",
+      "example": "STANDARD_VALUE",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.benchmark_return_source",
+      "canonicalTerm": "benchmark_return_source",
+      "preferredName": "benchmark_return_source",
+      "description": "Bounded benchmark-return source posture for this stateless context product.",
+      "example": "STANDARD_VALUE",
       "type": "string",
       "locations": [
         "body"
@@ -2430,6 +2518,20 @@
       ]
     },
     {
+      "semanticId": "lotus.health_state",
+      "canonicalTerm": "health_state",
+      "preferredName": "health_state",
+      "description": "Bounded performance health posture derived from source-owned active return.",
+      "example": "ready",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.hedging",
       "canonicalTerm": "hedging",
       "preferredName": "hedging",
@@ -3436,6 +3538,36 @@
       ]
     },
     {
+      "semanticId": "lotus.methodology_posture",
+      "canonicalTerm": "methodology_posture",
+      "preferredName": "methodology_posture",
+      "description": "mandate performance health methodology posture object.",
+      "example": {
+        "key": "value"
+      },
+      "type": "MandatePerformanceHealthMethodologyPosture",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "MandatePerformanceHealthMethodologyPosture"
+      ]
+    },
+    {
+      "semanticId": "lotus.methodology_version",
+      "canonicalTerm": "methodology_version",
+      "preferredName": "methodology_version",
+      "description": "Source methodology family used for period and active-return interpretation.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.metric_basis",
       "canonicalTerm": "metric_basis",
       "preferredName": "metric_basis",
@@ -3467,6 +3599,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.metric_name",
+      "canonicalTerm": "metric_name",
+      "preferredName": "metric_name",
+      "description": "Source-owned performance metric used for mandate health posture.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -4163,6 +4309,20 @@
       ]
     },
     {
+      "semanticId": "lotus.period_name",
+      "canonicalTerm": "period_name",
+      "preferredName": "period_name",
+      "description": "Resolved performance period label evaluated by the source product.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.period_start",
       "canonicalTerm": "period_start",
       "preferredName": "period_start",
@@ -4343,6 +4503,21 @@
       ]
     },
     {
+      "semanticId": "lotus.portfolio_period_return",
+      "canonicalTerm": "portfolio_period_return",
+      "preferredName": "portfolio_period_return",
+      "description": "Portfolio period return in percentage-point output units.",
+      "example": "STANDARD_VALUE",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.positions_data",
       "canonicalTerm": "positions_data",
       "preferredName": "positions_data",
@@ -4427,6 +4602,34 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.product_name",
+      "canonicalTerm": "product_name",
+      "preferredName": "product_name",
+      "description": "Source-owned product emitted by lotus-performance for mandate health performance context.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.product_version",
+      "canonicalTerm": "product_version",
+      "preferredName": "product_version",
+      "description": "Product contract version.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -5935,6 +6138,36 @@
       ]
     },
     {
+      "semanticId": "lotus.source_metric",
+      "canonicalTerm": "source_metric",
+      "preferredName": "source_metric",
+      "description": "mandate performance health source metric object.",
+      "example": {
+        "key": "value"
+      },
+      "type": "MandatePerformanceHealthSourceMetric",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "MandatePerformanceHealthSourceMetric"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_metrics_product",
+      "canonicalTerm": "source_metrics_product",
+      "preferredName": "source_metrics_product",
+      "description": "Underlying source-owned performance product family used for this context.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.source_preconverted_fx_evidence",
       "canonicalTerm": "source_preconverted_fx_evidence",
       "preferredName": "source_preconverted_fx_evidence",
@@ -5986,6 +6219,34 @@
       ]
     },
     {
+      "semanticId": "lotus.source_product_name",
+      "canonicalTerm": "source_product_name",
+      "preferredName": "source_product_name",
+      "description": "Source-owned mandate health performance product name.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_product_version",
+      "canonicalTerm": "source_product_version",
+      "preferredName": "source_product_version",
+      "description": "Source-owned mandate health performance product version.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.source_quality_evidence",
       "canonicalTerm": "source_quality_evidence",
       "preferredName": "source_quality_evidence",
@@ -6020,17 +6281,47 @@
       ]
     },
     {
-      "semanticId": "lotus.source_service",
-      "canonicalTerm": "source_service",
-      "preferredName": "source_service",
-      "description": "Service that owns and emitted this capability contract.",
-      "example": "lotus-performance",
+      "semanticId": "lotus.source_route",
+      "canonicalTerm": "source_route",
+      "preferredName": "source_route",
+      "description": "Underlying source route for full source-owned TWR calculation.",
+      "example": "STANDARD_VALUE",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_service",
+      "canonicalTerm": "source_service",
+      "preferredName": "source_service",
+      "description": "Authoritative source service for this performance context.",
+      "example": "STANDARD_VALUE",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_services",
+      "canonicalTerm": "source_services",
+      "preferredName": "source_services",
+      "description": "Ordered source services that materially contribute to this product payload.",
+      "example": [
+        "STANDARD_VALUE"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -6473,6 +6764,20 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.threshold_breached",
+      "canonicalTerm": "threshold_breached",
+      "preferredName": "threshold_breached",
+      "description": "Canonical threshold breached used by lotus-performance APIs.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
       ]
     },
     {
@@ -11349,6 +11654,277 @@
       },
       "response": {
         "fields": []
+      }
+    },
+    {
+      "domain": "performance",
+      "method": "POST",
+      "path": "/performance/mandate-health-context",
+      "operationId": "evaluate_mandate_performance_health_context_endpoint_performance_mandate_health_context_post",
+      "summary": "Evaluate source-owned mandate performance health context",
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "period_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.period_name",
+            "attributeRef": "#/attributeCatalog/lotus.period_name"
+          },
+          {
+            "name": "portfolio_period_return",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_period_return",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_period_return"
+          },
+          {
+            "name": "benchmark_period_return",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.benchmark_period_return",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_period_return"
+          },
+          {
+            "name": "active_return_attention_threshold",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.active_return_attention_threshold",
+            "attributeRef": "#/attributeCatalog/lotus.active_return_attention_threshold"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "product_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_name",
+            "attributeRef": "#/attributeCatalog/lotus.product_name"
+          },
+          {
+            "name": "product_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_version",
+            "attributeRef": "#/attributeCatalog/lotus.product_version"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "period_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.period_name",
+            "attributeRef": "#/attributeCatalog/lotus.period_name"
+          },
+          {
+            "name": "health_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.health_state",
+            "attributeRef": "#/attributeCatalog/lotus.health_state"
+          },
+          {
+            "name": "threshold_breached",
+            "location": "body",
+            "required": false,
+            "type": "boolean",
+            "semanticId": "lotus.threshold_breached",
+            "attributeRef": "#/attributeCatalog/lotus.threshold_breached"
+          },
+          {
+            "name": "active_return_attention_threshold",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.active_return_attention_threshold",
+            "attributeRef": "#/attributeCatalog/lotus.active_return_attention_threshold"
+          },
+          {
+            "name": "source_metric",
+            "location": "body",
+            "required": true,
+            "type": "MandatePerformanceHealthSourceMetric",
+            "semanticId": "lotus.source_metric",
+            "attributeRef": "#/attributeCatalog/lotus.source_metric"
+          },
+          {
+            "name": "source_metric.metric_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.metric_name",
+            "attributeRef": "#/attributeCatalog/lotus.metric_name"
+          },
+          {
+            "name": "source_metric.portfolio_period_return",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.portfolio_period_return",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_period_return"
+          },
+          {
+            "name": "source_metric.benchmark_period_return",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.benchmark_period_return",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_period_return"
+          },
+          {
+            "name": "source_metric.active_return",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.active_return",
+            "attributeRef": "#/attributeCatalog/lotus.active_return"
+          },
+          {
+            "name": "methodology_posture",
+            "location": "body",
+            "required": false,
+            "type": "MandatePerformanceHealthMethodologyPosture",
+            "semanticId": "lotus.methodology_posture",
+            "attributeRef": "#/attributeCatalog/lotus.methodology_posture"
+          },
+          {
+            "name": "methodology_posture.source_product_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_product_name",
+            "attributeRef": "#/attributeCatalog/lotus.source_product_name"
+          },
+          {
+            "name": "methodology_posture.source_product_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_product_version",
+            "attributeRef": "#/attributeCatalog/lotus.source_product_version"
+          },
+          {
+            "name": "methodology_posture.source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "methodology_posture.source_metrics_product",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_metrics_product",
+            "attributeRef": "#/attributeCatalog/lotus.source_metrics_product"
+          },
+          {
+            "name": "methodology_posture.methodology_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.methodology_version",
+            "attributeRef": "#/attributeCatalog/lotus.methodology_version"
+          },
+          {
+            "name": "methodology_posture.source_route",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_route",
+            "attributeRef": "#/attributeCatalog/lotus.source_route"
+          },
+          {
+            "name": "source_services",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.source_services",
+            "attributeRef": "#/attributeCatalog/lotus.source_services"
+          },
+          {
+            "name": "benchmark_context",
+            "location": "body",
+            "required": true,
+            "type": "MandatePerformanceBenchmarkContext",
+            "semanticId": "lotus.benchmark_context",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_context"
+          },
+          {
+            "name": "benchmark_context.benchmark_available",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.benchmark_available",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_available"
+          },
+          {
+            "name": "benchmark_context.benchmark_return_source",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.benchmark_return_source",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_return_source"
+          },
+          {
+            "name": "request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
+          },
+          {
+            "name": "reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          }
+        ]
       }
     },
     {

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from app.api.endpoints import (
     inspections,
     integration_capabilities,
     lineage,
+    mandate_health_context,
     performance,
     recovery_drill_history,
     returns_series,
@@ -157,6 +158,7 @@ app.include_router(contribution.router, prefix="/performance")
 app.include_router(executions.router, prefix="/performance")
 app.include_router(inspections.router, prefix="/performance")
 app.include_router(lineage.router, prefix="/performance")
+app.include_router(mandate_health_context.router, prefix="/performance")
 app.include_router(integration_capabilities.router, prefix="/integration")
 app.include_router(returns_series.router, prefix="/integration")
 app.include_router(benchmark_exposure_context.router, prefix="/integration")

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -116,6 +116,12 @@ def test_integration_capabilities_default_contract():
         "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions are supported",
         "ISSUER groups use lotus-core index-catalog issuer_id and issuer_name classification labels",
     ]
+    assert surfaces["mandate_performance_health_context"]["path"] == "/performance/mandate-health-context"
+    assert surfaces["mandate_performance_health_context"]["supported_input_modes"] == ["stateless"]
+    assert surfaces["mandate_performance_health_context"]["supports_async"] is False
+    assert "orders, OMS, or execution instructions" in " ".join(
+        surfaces["mandate_performance_health_context"]["contract_notes"]
+    )
     features = {item["key"]: item for item in body["features"]}
     assert "performance.analytics.benchmark" in features
     assert (
@@ -131,6 +137,7 @@ def test_integration_capabilities_default_contract():
     )
     assert "performance.execution.stateful" in features
     assert "performance.execution.stateless" in features
+    assert "performance.integration.mandate_performance_health_context" in features
     assert surfaces["twr"]["contract_notes"] == [
         "supports portfolio-level TWR only",
         "does not advertise composite, group, or sleeve TWR calculation support",
@@ -165,6 +172,7 @@ def test_integration_capabilities_env_override(monkeypatch):
     assert surfaces["attribution"]["enabled"] is False
     assert surfaces["attribution"]["stateful_restrictions"] == []
     assert surfaces["workspace_summary"]["enabled"] is True
+    assert surfaces["mandate_performance_health_context"]["enabled"] is True
     assert surfaces["workspace_summary"]["contract_notes"]
     assert surfaces["workspace_summary"]["poll_path_template"] == "/performance/executions/{calculation_id}"
     assert (
@@ -191,6 +199,7 @@ def test_integration_capabilities_keeps_supportability_enabled_when_twr_is_disab
     assert surfaces["attribution"]["enabled"] is True
     assert features["performance.support.twr_inspection"]["enabled"] is False
     assert features["performance.observability.calculation_supportability"]["enabled"] is True
+    assert features["performance.integration.mandate_performance_health_context"]["enabled"] is False
 
 
 def test_integration_capabilities_honors_canonical_query_controls():
@@ -229,10 +238,12 @@ def test_integration_capabilities_advertises_every_supported_surface():
         "workspace_summary",
         "contribution",
         "attribution",
+        "mandate_performance_health_context",
         "returns_series",
         "benchmark_exposure_context",
     }
     assert surfaces["mwr"]["supports_async"] is False
+    assert surfaces["mandate_performance_health_context"]["supports_async"] is False
     for key in {
         "twr",
         "benchmark",

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -678,6 +678,7 @@ def test_api_reference_documents_endpoint_level_capabilities_contract():
         "workspace_summary",
         "contribution",
         "attribution",
+        "mandate_performance_health_context",
         "returns_series",
         "benchmark_exposure_context",
     }

--- a/tests/unit/models/test_integration_capabilities_models.py
+++ b/tests/unit/models/test_integration_capabilities_models.py
@@ -22,6 +22,7 @@ def test_integration_capabilities_response_schema_includes_certified_surface_exa
         "workspace_summary",
         "contribution",
         "attribution",
+        "mandate_performance_health_context",
         "returns_series",
         "benchmark_exposure_context",
     }
@@ -32,7 +33,9 @@ def test_integration_capabilities_response_schema_includes_certified_surface_exa
         "does not advertise composite, group, or sleeve TWR calculation support",
     ]
     assert "performance.analytics.workspace_summary" in features
+    assert "performance.integration.mandate_performance_health_context" in features
     assert "performance_workspace" in workflows
+    assert "mandate_performance_health_context" in workflows
 
 
 def test_integration_capabilities_json_example_matches_schema_example():

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -56,6 +56,7 @@ def test_repo_native_producer_declarations_cover_governed_first_wave_products_an
         "MoneyWeightedReturnAnalytics",
         "ContributionAnalytics",
         "AttributionAnalytics",
+        "MandatePerformanceHealthContext",
         "ReturnsSeriesBundle",
         "BenchmarkExposureContext",
         "CompositePerformanceAnalytics",
@@ -86,9 +87,16 @@ def test_repo_native_producer_declarations_cover_governed_first_wave_products_an
     assert "reconciliation_status" in attribution_product["required_trust_metadata"]
     assert "coverage_status" in attribution_product["required_trust_metadata"]
     assert "coverage_ratio" in attribution_product["required_trust_metadata"]
-    assert payload["products"][4]["approved_consumers"] == ["lotus-risk"]
+    mandate_health_product = payload["products"][4]
+    assert mandate_health_product["approved_consumers"] == ["lotus-gateway", "lotus-manage"]
+    assert mandate_health_product["current_routes"] == ["/performance/mandate-health-context"]
+    assert mandate_health_product["completeness_policy"]["partial_allowed"] is True
+    assert "request_fingerprint" in mandate_health_product["required_trust_metadata"]
+    assert "source_services" in mandate_health_product["required_trust_metadata"]
+    assert "benchmark_context" in mandate_health_product["required_trust_metadata"]
     assert payload["products"][5]["approved_consumers"] == ["lotus-risk"]
-    composite_product = payload["products"][6]
+    assert payload["products"][6]["approved_consumers"] == ["lotus-risk"]
+    composite_product = payload["products"][7]
     assert composite_product["approved_consumers"] == ["lotus-gateway"]
     assert composite_product["current_routes"] == ["/performance/composites/twr"]
     assert composite_product["request_scope"]["scope_level"] == "portfolio_set"

--- a/tests/unit/test_mandate_performance_health_context.py
+++ b/tests/unit/test_mandate_performance_health_context.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+from app.models.mandate_health import MandatePerformanceHealthContextRequest
+from app.services.mandate_health_context_service import evaluate_mandate_performance_health_context
+from main import app
+
+
+def _request_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-02-27",
+        "period_name": "YTD",
+        "portfolio_period_return": "0.20",
+        "benchmark_period_return": "1.50",
+        "active_return_attention_threshold": "-1.00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_mandate_performance_health_context_flags_source_owned_underperformance() -> None:
+    request = MandatePerformanceHealthContextRequest.model_validate(_request_payload())
+
+    response = evaluate_mandate_performance_health_context(request)
+
+    assert response.product_name == "MandatePerformanceHealthContext"
+    assert response.product_version == "v1"
+    assert response.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert response.period_name == "YTD"
+    assert response.health_state == "attention"
+    assert response.threshold_breached is True
+    assert response.active_return_attention_threshold == Decimal("-1.00")
+    assert response.source_metric.metric_name == "ACTIVE_RETURN"
+    assert response.source_metric.active_return == Decimal("-1.30")
+    assert response.methodology_posture.source_service == "lotus-performance"
+    assert response.methodology_posture.source_metrics_product == "TimeWeightedReturnAnalytics:v1"
+    assert response.methodology_posture.source_route == "/performance/twr"
+    assert response.source_services == ["lotus-performance"]
+    assert response.benchmark_context.benchmark_available is True
+    assert response.request_fingerprint.startswith("sha256:")
+    assert "PERFORMANCE_METHODOLOGY_SOURCE_OWNED" in response.reason_codes
+    assert "MANDATE_PERFORMANCE_HEALTH_ACTIVE_RETURN_SOURCE_READY" in response.reason_codes
+    assert "MANDATE_PERFORMANCE_HEALTH_ACTIVE_RETURN_THRESHOLD_BREACHED" in response.reason_codes
+
+
+def test_mandate_performance_health_context_is_unavailable_without_benchmark() -> None:
+    request = MandatePerformanceHealthContextRequest.model_validate(_request_payload(benchmark_period_return=None))
+
+    response = evaluate_mandate_performance_health_context(request)
+
+    assert response.health_state == "unavailable"
+    assert response.threshold_breached is None
+    assert response.source_metric.active_return is None
+    assert response.benchmark_context.benchmark_available is False
+    assert "MANDATE_PERFORMANCE_HEALTH_ACTIVE_RETURN_UNAVAILABLE" in response.reason_codes
+
+
+def test_mandate_performance_health_context_endpoint_returns_source_product() -> None:
+    client = TestClient(app)
+
+    response = client.post("/performance/mandate-health-context", json=_request_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["product_name"] == "MandatePerformanceHealthContext"
+    assert body["methodology_posture"]["source_service"] == "lotus-performance"
+    assert body["methodology_posture"]["source_metrics_product"] == "TimeWeightedReturnAnalytics:v1"
+    assert body["source_services"] == ["lotus-performance"]
+    assert body["benchmark_context"]["benchmark_available"] is True
+    assert body["health_state"] == "attention"
+    assert body["threshold_breached"] is True
+
+
+def test_capabilities_include_mandate_performance_health_context_workflow() -> None:
+    client = TestClient(app)
+
+    response = client.get("/integration/capabilities?consumer_system=lotus-manage")
+
+    assert response.status_code == 200
+    body = response.json()
+    surfaces = {surface["key"]: surface for surface in body["analytics_surfaces"]}
+    features = {feature["key"]: feature for feature in body["features"]}
+    workflows = {workflow["workflow_key"]: workflow for workflow in body["workflows"]}
+
+    surface = surfaces["mandate_performance_health_context"]
+    assert surface["path"] == "/performance/mandate-health-context"
+    assert surface["supported_input_modes"] == ["stateless"]
+    assert surface["supports_async"] is False
+    assert "orders, OMS, or execution instructions" in " ".join(surface["contract_notes"])
+    assert features["performance.integration.mandate_performance_health_context"]["enabled"] is True
+    assert workflows["mandate_performance_health_context"]["required_features"] == [
+        "performance.analytics.twr",
+        "performance.integration.mandate_performance_health_context",
+    ]

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -21,6 +21,9 @@
 - Product ID: `lotus-performance:CompositePerformanceAnalytics:v1`
 - Product role: governed persisted-fact composite performance product for private-banking
   composite TWR, source-fact lineage, restatement evidence, and supportable publication workflows
+- Product ID: `lotus-performance:MandatePerformanceHealthContext:v1`
+- Product role: governed active-return health context for DPM supportability consumers that need
+  source-owned performance threshold posture without downstream methodology reconstruction
 - Product ID: `lotus-performance:ReturnsSeriesBundle:v1`
 - Product role: governed return-series and performance evidence consumed by risk, advisory, reporting, gateway, and Workbench discovery flows
 - Source declaration: `contracts/domain-data-products/`
@@ -92,6 +95,14 @@
   Composite contribution, attribution, MWR, sleeves, carve-outs, and multi-currency composite
   aggregation beyond the current single reporting-currency guard remain unsupported. See
   [Composite Performance](Composite-Performance).
+- Mandate performance health product evidence: `POST /performance/mandate-health-context` emits
+  source-owned active-return threshold posture, methodology posture, request fingerprint, and
+  reason codes for DPM supportability consumers such as `lotus-manage`. The governed product is
+  declared as `MandatePerformanceHealthContext` in
+  `contracts/domain-data-products/lotus-performance-products.v1.json` and approved for Gateway and
+  Manage consumption. Downstream consumers may preserve this evidence, but must not reconstruct
+  active return, reinterpret TWR methodology, create mandate actions, create rebalance waves,
+  contact clients, place orders, or imply OMS/execution behavior.
 
 ## Platform relationship
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -17,6 +17,7 @@ claim list.
 | Composite TWR | Private-banking composite performance from persisted member-return facts | `POST /performance/composites/twr`, `POST /performance/composites/inspect` | Asset-weighted composite period returns, geometric linking, member weights and contributions, dispersion, blocked/degraded supportability, source fingerprints, source snapshots, restatement versions, classified inspector artifacts, governed `CompositePerformanceAnalytics:v1` data-product declaration, Gateway route realization, Workbench typed BFF consumption, and live RFC-049 proof. Downstream consumers should not reconstruct composite returns, weights, lineage, or restatement posture. |
 | Returns series | Performance-owned return-series bundle for downstream analytics engines | `POST /integration/returns/series` | Correct downstream surface for risk engines; `lotus-risk` should consume this rather than direct TWR response internals. |
 | Benchmark exposure context | Benchmark exposure rows for risk and integration workflows | `POST /integration/benchmarks/exposure-context` | Benchmark-context integration product; not a composite TWR calculation surface. |
+| Mandate performance health context | Bounded active-return health posture for DPM supportability consumers | `POST /performance/mandate-health-context` | Source-owned `MandatePerformanceHealthContext:v1` evidence with threshold posture, methodology posture, request fingerprint, and reason codes. It does not create mandate actions, rebalance waves, client communications, orders, OMS actions, or execution instructions. |
 | Workspace summary | Interaction-efficient performance summary for product surfaces | `POST /performance/workspace-summary` | Product-oriented summary contract for Gateway and Workbench. It should consume performance-owned calculations, not rebuild them. |
 | Execution and lineage | Async polling, result retrieval, lineage metadata, artifacts | `/performance/executions/*`, `/performance/lineage/*` | Durable evidence path for reproducibility, operations, and support. |
 | Runtime operations | Health, readiness, metrics, runtime status, recovery, retention | `/health`, `/metrics`, `/integration/runtime-status`, recovery and retention routes | Supports enterprise operational posture and CI/runtime diagnostics. |
@@ -99,12 +100,20 @@ Downstream consumers may present attribution evidence, but must not reconstruct 
 selection, interaction, residual materiality, linked-return posture, or period status. The product is
 detailed in [Attribution Analytics](Attribution-Analytics).
 
+`MandatePerformanceHealthContext:v1` is a governed `lotus-performance` data product. It is declared
+in `contracts/domain-data-products/lotus-performance-products.v1.json`, uses daily freshness
+semantics, requires lineage posture, and is approved for Gateway and Manage consumption. Downstream
+consumers may preserve the emitted active-return health posture, threshold posture, methodology
+posture, request fingerprint, and reason codes; they must not treat it as a mandate decision,
+client communication, trade recommendation, order, OMS action, or execution instruction.
+
 ## References
 
 - [Time-Weighted Return](Time-Weighted-Return)
 - [Contribution Analytics](Contribution-Analytics)
 - [Attribution Analytics](Attribution-Analytics)
 - [Mesh Data Products](Mesh-Data-Products)
+- [docs/guides/mandate_performance_health_context.md](../docs/guides/mandate_performance_health_context.md)
 - [docs/guides/twr.md](../docs/guides/twr.md)
 - [docs/technical/twr-documentation-map.md](../docs/technical/twr-documentation-map.md)
 - [docs/technical/twr-endpoint-certification.md](../docs/technical/twr-endpoint-certification.md)


### PR DESCRIPTION
## Summary
- add `POST /performance/mandate-health-context` as `MandatePerformanceHealthContext:v1`
- emit bounded active-return health posture, source services, benchmark context, methodology posture, request fingerprint, and reason codes for DPM supportability consumers
- advertise the surface in integration capabilities and update domain-product, API vocabulary, docs, wiki source, and repository context

## Boundary
- does not create mandate actions, rebalance waves, client communications, trades, orders, OMS actions, or execution instructions
- does not touch Gateway, Workbench, or Advise

## Validation
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make domain-product-validate`
- `python -m pytest tests\unit\test_mandate_performance_health_context.py tests\unit\test_domain_data_product_contracts.py tests\integration\test_integration_capabilities_api.py::test_integration_capabilities_default_contract tests\integration\test_integration_capabilities_api.py::test_integration_capabilities_keeps_supportability_enabled_when_twr_is_disabled tests\integration\test_integration_capabilities_api.py::test_integration_capabilities_advertises_every_supported_surface tests\unit\docs\test_public_docs_contract.py tests\unit\models\test_integration_capabilities_models.py -q`
- `make test-unit` (sequential after clearing generated durable metadata): 1287 passed
- `make test-integration` (sequential after clearing generated durable metadata): 290 passed
- `make test-e2e` (sequential after clearing generated durable metadata): 21 passed
- `make migration-smoke`
- `make security-audit`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-performance` reports expected drift in `Mesh-Data-Products.md` and `Supported-Features.md` until this PR is merged and wiki source is published

## Notes
- An initial parallel run of unit/integration/e2e caused shared local durable-store interference; reran the suites sequentially after clearing generated local runtime artifacts and they passed.