### PR TITLE
Harden stateful MWR single-currency evidence

### DIFF
--- a/app/models/mwr_responses.py
+++ b/app/models/mwr_responses.py
@@ -186,7 +186,11 @@ class MWRMarketValueEvidence(BaseModel):
         default="PortfolioTimeseriesInput",
         description="Upstream source data product used for stateful MWR sourcing.",
     )
-    conversion_status: Literal["upstream_preconverted", "source_preconverted_with_fx_evidence"] = Field(
+    conversion_status: Literal[
+        "upstream_preconverted",
+        "source_preconverted_with_fx_evidence",
+        "no_conversion_required",
+    ] = Field(
         default="upstream_preconverted",
         description="Conversion posture for the source amount.",
     )
@@ -225,6 +229,7 @@ class MWRCurrencyEvidence(BaseModel):
     conversion_evidence_status: Literal[
         "upstream_preconverted_missing_per_input_fx_metadata",
         "complete_source_preconverted_fx_metadata",
+        "not_required_single_currency_inputs",
     ] = Field(description="Whether per-input FX conversion evidence is complete for the MWR response.")
     conversion_evidence_reason_codes: List[str] = Field(
         default_factory=list,

--- a/app/services/stateful_mwr_input_service.py
+++ b/app/services/stateful_mwr_input_service.py
@@ -48,9 +48,9 @@ class MWRMarketValueEvidence:
     currency: str | None
     value_role: Literal["beginning_market_value", "ending_market_value"]
     source_product: Literal["PortfolioTimeseriesInput"] = "PortfolioTimeseriesInput"
-    conversion_status: Literal["upstream_preconverted", "source_preconverted_with_fx_evidence"] = (
-        "upstream_preconverted"
-    )
+    conversion_status: Literal[
+        "upstream_preconverted", "source_preconverted_with_fx_evidence", "no_conversion_required"
+    ] = "upstream_preconverted"
     source_amount: Decimal | None = None
     source_currency: str | None = None
     reporting_amount: Decimal | None = None
@@ -73,6 +73,7 @@ class MWRCurrencyEvidence:
     conversion_evidence_status: Literal[
         "upstream_preconverted_missing_per_input_fx_metadata",
         "complete_source_preconverted_fx_metadata",
+        "not_required_single_currency_inputs",
     ]
     conversion_evidence_reason_codes: list[str]
     market_values_used: list[MWRMarketValueEvidence]
@@ -107,6 +108,10 @@ def build_stateful_mwr_input_for_window(
     begin_mv = Decimal(str(first_observation["beginning_market_value"]))
     end_mv = Decimal(str(last_observation["ending_market_value"]))
     reporting_currency = _resolve_reporting_currency(source_input)
+    single_currency_inputs = _has_single_currency_inputs(
+        source_input=source_input,
+        reporting_currency=reporting_currency,
+    )
 
     cash_flows_by_date: dict[Date, Decimal] = {}
     cash_flow_components_by_date: dict[Date, list[MWRCashFlowEvidenceComponent]] = {}
@@ -185,23 +190,28 @@ def build_stateful_mwr_input_for_window(
             reporting_currency=reporting_currency,
             portfolio_currency=source_input.portfolio_currency,
             currency_mode="SINGLE_REPORTING_CURRENCY",
-            conversion_evidence_status="upstream_preconverted_missing_per_input_fx_metadata",
-            conversion_evidence_reason_codes=[
-                "UPSTREAM_PORTFOLIO_TIMESERIES_PRECONVERTED",
-                "PER_INPUT_FX_METADATA_NOT_EXPOSED_BY_SOURCE_CONTRACT",
-            ],
+            conversion_evidence_status=(
+                "not_required_single_currency_inputs"
+                if single_currency_inputs
+                else "upstream_preconverted_missing_per_input_fx_metadata"
+            ),
+            conversion_evidence_reason_codes=_stateful_currency_reason_codes(
+                single_currency_inputs=single_currency_inputs,
+            ),
             market_values_used=[
                 MWRMarketValueEvidence(
                     valuation_date=_parse_observation_date(first_observation),
                     amount=begin_mv,
                     currency=reporting_currency,
                     value_role="beginning_market_value",
+                    conversion_status=("no_conversion_required" if single_currency_inputs else "upstream_preconverted"),
                 ),
                 MWRMarketValueEvidence(
                     valuation_date=_parse_observation_date(last_observation),
                     amount=end_mv,
                     currency=reporting_currency,
                     value_role="ending_market_value",
+                    conversion_status=("no_conversion_required" if single_currency_inputs else "upstream_preconverted"),
                 ),
             ],
             cashflow_evidence=cashflow_evidence,
@@ -239,3 +249,28 @@ def _resolve_reporting_currency(source_input: StatefulPortfolioInput) -> str | N
     if len(observation_currencies) == 1:
         return next(iter(observation_currencies))
     return source_input.portfolio_currency
+
+
+def _has_single_currency_inputs(*, source_input: StatefulPortfolioInput, reporting_currency: str | None) -> bool:
+    if not reporting_currency or not source_input.portfolio_currency:
+        return False
+    if source_input.portfolio_currency.upper() != reporting_currency.upper():
+        return False
+    for observation in source_input.observations:
+        cash_flow_currency = observation.get("cash_flow_currency")
+        if isinstance(cash_flow_currency, str) and cash_flow_currency.upper() != reporting_currency.upper():
+            return False
+    return True
+
+
+def _stateful_currency_reason_codes(*, single_currency_inputs: bool) -> list[str]:
+    if single_currency_inputs:
+        return [
+            "SOURCE_AND_REPORTING_CURRENCY_MATCH",
+            "PER_INPUT_FX_CONVERSION_NOT_REQUIRED",
+            "MWR_ENGINE_CALCULATED_REPORTING_CURRENCY_SCHEDULE",
+        ]
+    return [
+        "UPSTREAM_PORTFOLIO_TIMESERIES_PRECONVERTED",
+        "PER_INPUT_FX_METADATA_NOT_EXPOSED_BY_SOURCE_CONTRACT",
+    ]

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -151,7 +151,8 @@ descriptions and examples are maintained in the generated OpenAPI contract.
   - `emit_cashflows_used=true` returns the signed cash-flow schedule used by the calculation
   - stateless callers may supply complete `source_preconverted_fx_evidence`; lotus-performance validates it against the reporting-currency MWR inputs and emits `currency_evidence.currency_mode="SOURCE_PRECONVERTED_WITH_FX_EVIDENCE"`
   - responses expose `reporting_currency`; stateful responses expose `currency_evidence` with `market_values_used`, `cashflow_evidence`, and `currency_mode="SINGLE_REPORTING_CURRENCY"`
-  - current `currency_evidence.conversion_evidence_status` is `upstream_preconverted_missing_per_input_fx_metadata` for stateful MWR, so consumers must not infer per-input FX rates, conversion policy, or conversion fingerprints when those fields are absent
+  - stateful single-currency MWR emits `currency_evidence.conversion_evidence_status="not_required_single_currency_inputs"` when source and reporting currencies match
+  - stateful cross-currency MWR keeps `currency_evidence.conversion_evidence_status="upstream_preconverted_missing_per_input_fx_metadata"`, so consumers must not infer per-input FX rates, conversion policy, or conversion fingerprints when those fields are absent
   - XIRR responses expose `status`, `reason_codes`, `warnings`, `holding_period_return`, `is_annualized_primary`, `fallback_from`, `fallback_reason`, and `is_approximation`
   - XIRR convergence diagnostics expose root count, residual NPV, searched bounds, day-count basis, anchor date, normalized flow count, and gross solver-flow scale
   - ambiguous XIRR cases such as no root or multiple roots are labeled and fall back to Dietz; consumers should use `status` and `fallback_reason` instead of inferring quality from `method` alone

--- a/docs/guides/complete_service_reference.md
+++ b/docs/guides/complete_service_reference.md
@@ -300,8 +300,10 @@ Sample response:
 ```
 
 Stateful MWR responses populate `currency_evidence` with `market_values_used[]`,
-`cashflow_evidence[]`, and `currency_mode="SINGLE_REPORTING_CURRENCY"`. The current conversion
-evidence status is `upstream_preconverted_missing_per_input_fx_metadata`, which means
+`cashflow_evidence[]`, and `currency_mode="SINGLE_REPORTING_CURRENCY"`. Single-currency stateful
+inputs emit `conversion_evidence_status="not_required_single_currency_inputs"` when source and
+reporting currencies match. Cross-currency stateful inputs keep
+`conversion_evidence_status="upstream_preconverted_missing_per_input_fx_metadata"`, which means
 lotus-performance preserves the reporting-currency context and source components received from
 lotus-core but does not yet expose full per-input FX rate provenance. Stateless callers may supply
 complete `source_preconverted_fx_evidence`; when present and valid, the response emits

--- a/docs/guides/mwr.md
+++ b/docs/guides/mwr.md
@@ -147,8 +147,11 @@ sourcing truth:
   the engine
 - `cashflow_evidence[]` with the source cash-flow and carry-forward components aggregated into each
   MWR cash-flow date
-- `conversion_evidence_status="upstream_preconverted_missing_per_input_fx_metadata"` until
-  `lotus-core` publishes per-input FX rate, policy, version, and fingerprint evidence
+- `conversion_evidence_status="not_required_single_currency_inputs"` when source and reporting
+  currencies match and no per-input FX conversion is required
+- `conversion_evidence_status="upstream_preconverted_missing_per_input_fx_metadata"` for
+  cross-currency stateful inputs until `lotus-core` publishes per-input FX rate, policy, version,
+  and fingerprint evidence
 
 For stateless source-preconverted schedules, callers may provide complete
 `source_preconverted_fx_evidence`. Lotus-performance validates the evidence and emits:
@@ -165,10 +168,12 @@ MWR is not decomposed into local and FX components on the current public contrac
 submit `begin_mv`, `end_mv`, and `cash_flows` in one consistent reporting currency. If those values
 were converted before submission, callers can attach `source_preconverted_fx_evidence`; the service
 validates and records provenance but does not convert source-currency amounts inside the MWR engine.
-`cashflows_used` proves the signed schedule used by the engine. Stateful upstream MWR is not yet
-full FX conversion provenance because the upstream portfolio timeseries contract does not expose
-per-input rate source, rate version, conversion policy, or conversion fingerprint fields. The
-implementation-readiness contract for future stateful FX-aware MWR is documented in
+`cashflows_used` proves the signed schedule used by the engine. Stateful single-currency MWR now
+marks FX conversion evidence as not required when source and reporting currencies match. Stateful
+upstream cross-currency MWR is not yet full FX conversion provenance because the upstream portfolio
+timeseries contract does not expose per-input rate source, rate version, conversion policy, or
+conversion fingerprint fields. The implementation-readiness contract for future stateful FX-aware
+MWR is documented in
 [MWR FX-aware contract design](../technical/mwr-fx-contract-design.md).
 
 ## Example request

--- a/docs/technical/mwr-fx-contract-design.md
+++ b/docs/technical/mwr-fx-contract-design.md
@@ -29,7 +29,10 @@ Current stateful execution does preserve the reporting-currency context that `lo
 publishes on `PortfolioTimeseriesInput`. The MWR response now includes `reporting_currency` and a
 `currency_evidence` block with `market_values_used[]`, `cashflow_evidence[]`, and
 `currency_mode="SINGLE_REPORTING_CURRENCY"`. That block documents the source-owned values and
-cash-flow components used by MWR. It deliberately reports
+cash-flow components used by MWR. Single-currency stateful inputs now report
+`conversion_evidence_status="not_required_single_currency_inputs"` and market values with
+`conversion_status="no_conversion_required"` when source and reporting currencies match. Cross-
+currency stateful inputs continue to report
 `conversion_evidence_status="upstream_preconverted_missing_per_input_fx_metadata"` because the
 current upstream portfolio-timeseries contract exposes converted amounts and currency context, but
 not per-input FX rate source, rate version, conversion policy, conversion timestamp, or conversion
@@ -69,12 +72,14 @@ carry enough evidence to make the reporting-currency schedule reproducible.
 | `conversion_timestamp` | Timestamp at which conversion evidence was assembled. |
 | `conversion_fingerprint` | Stable fingerprint for reproducibility and lineage tie-out. |
 
-For stateful MWR, this evidence must come from governed upstream analytics-input contracts before
-stateful MWR can claim complete per-input FX provenance. For stateless MWR, the caller must provide
-complete conversion evidence through `source_preconverted_fx_evidence` if the response should carry
-complete FX provenance. Missing, partial, or inconsistent evidence fails closed rather than falling
-back to guessed rates. In operational terms, the endpoint must fail closed when source and
-reporting-currency evidence cannot be tied out.
+For stateful cross-currency MWR, this evidence must come from governed upstream analytics-input
+contracts before stateful MWR can claim complete per-input FX provenance. Single-currency stateful
+MWR does not require FX conversion evidence when source and reporting currencies match. For
+stateless MWR, the caller must provide complete conversion evidence through
+`source_preconverted_fx_evidence` if the response should carry complete FX provenance. Missing,
+partial, or inconsistent evidence fails closed rather than falling back to guessed rates. In
+operational terms, the endpoint must fail closed when source and reporting-currency evidence cannot
+be tied out.
 
 ## Implemented And Proposed Response Semantics
 
@@ -90,6 +95,16 @@ Implemented for stateless source-preconverted evidence:
   `cash_flows[]` by index.
 - reason codes documenting that the engine calculated a reporting-currency schedule after evidence
   validation.
+
+Implemented for stateful single-currency evidence:
+
+- `reporting_currency` for the MWR result.
+- `currency_evidence.currency_mode="SINGLE_REPORTING_CURRENCY"`.
+- `currency_evidence.conversion_evidence_status="not_required_single_currency_inputs"` when
+  source and reporting currencies match.
+- `currency_evidence.market_values_used[].conversion_status="no_conversion_required"`.
+- reason codes documenting that source and reporting currencies match and the engine calculated a
+  reporting-currency schedule without FX conversion.
 
 Still proposed for future stateful upstream FX-aware MWR:
 

--- a/tests/integration/test_mwr_api.py
+++ b/tests/integration/test_mwr_api.py
@@ -188,6 +188,65 @@ def test_calculate_mwr_endpoint_supports_stateful_mode(client, monkeypatch):
     )
 
 
+def test_calculate_mwr_endpoint_marks_stateful_single_currency_fx_not_required(client, monkeypatch):
+    async def _mock_get_portfolio_timeseries(self, **kwargs):  # noqa: ARG001
+        return (
+            200,
+            {
+                "portfolio_open_date": "2024-01-01",
+                "portfolio_currency": "EUR",
+                "reporting_currency": "EUR",
+                "observations": [
+                    {
+                        "valuation_date": "2025-01-01",
+                        "beginning_market_value": "100000",
+                        "ending_market_value": "110000",
+                        "cash_flow_currency": "EUR",
+                        "cash_flows": [{"amount": "10000", "timing": "bod"}],
+                    },
+                    {
+                        "valuation_date": "2025-01-03",
+                        "beginning_market_value": "110000",
+                        "ending_market_value": "111000",
+                        "cash_flow_currency": "EUR",
+                        "cash_flows": [],
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(
+        "app.services.stateful_input_service.StatefulInputService.get_portfolio_timeseries",
+        _mock_get_portfolio_timeseries,
+    )
+
+    response = client.post(
+        "/performance/mwr",
+        json={
+            "portfolio_id": "MWR_STATEFUL_SINGLE_CCY",
+            "as_of": "2025-01-03",
+            "mwr_method": "DIETZ",
+            "input_mode": "stateful",
+            "stateful_input": {
+                "window_start_date": "2025-01-01",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    evidence = response.json()["currency_evidence"]
+    assert evidence["conversion_evidence_status"] == "not_required_single_currency_inputs"
+    assert evidence["conversion_evidence_reason_codes"] == [
+        "SOURCE_AND_REPORTING_CURRENCY_MATCH",
+        "PER_INPUT_FX_CONVERSION_NOT_REQUIRED",
+        "MWR_ENGINE_CALCULATED_REPORTING_CURRENCY_SCHEDULE",
+    ]
+    assert [item["conversion_status"] for item in evidence["market_values_used"]] == [
+        "no_conversion_required",
+        "no_conversion_required",
+    ]
+
+
 def test_calculate_mwr_endpoint_accepts_complete_stateless_source_fx_evidence(client):
     payload = {
         "calculation_id": str(uuid4()),

--- a/tests/unit/docs/test_public_docs_contract.py
+++ b/tests/unit/docs/test_public_docs_contract.py
@@ -420,6 +420,7 @@ def test_mwr_guide_matches_current_method_reality():
     assert "emit_cashflows_used=true" in guide
     assert "cashflows_used" in guide
     assert "currency_evidence" in guide
+    assert "not_required_single_currency_inputs" in guide
     assert "upstream_preconverted_missing_per_input_fx_metadata" in guide
     assert "holding_period_return" in guide
     assert "fallback_reason" in guide
@@ -428,7 +429,8 @@ def test_mwr_guide_matches_current_method_reality():
     assert "mwr-lotus-production-controls.md" in guide
     assert "mwr-fx-contract-design.md" in guide
     assert "cashflows_used` proves the signed schedule" in guide
-    assert "current `currency_evidence.conversion_evidence_status`" in api_reference
+    assert "stateful single-currency MWR emits" in api_reference
+    assert "stateful cross-currency MWR keeps" in api_reference
     assert "mwr-production-support-playbook.md" in guide
     assert "mwr-industry-review-findings.md" in guide
     assert "investor capital-timing lens" in certification
@@ -477,6 +479,8 @@ def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     assert "Current stateful execution does preserve the reporting-currency context" in fx_design
     assert "source_amount" in fx_design
     assert "conversion_fingerprint" in fx_design
+    assert "not_required_single_currency_inputs" in fx_design
+    assert "no_conversion_required" in fx_design
     assert "upstream_preconverted_missing_per_input_fx_metadata" in fx_design
     assert "must not reconstruct FX conversion" in fx_design
     assert "fail closed" in fx_design
@@ -493,6 +497,8 @@ def test_mwrr_industry_material_is_converted_to_lotus_product_docs():
     assert "mwr-fx-contract-design.md" in api_wiki
     assert "currency_evidence" in api_wiki
     assert "currency_evidence" in mesh_wiki
+    assert "not_required_single_currency_inputs" in api_wiki
+    assert "not_required_single_currency_inputs" in mesh_wiki
     assert "mwr-production-support-playbook.md" in ops_wiki
     assert "mwr-alert-rule-templates.md" in ops_wiki
     assert "must not infer FX rates" in integrations_wiki

--- a/tests/unit/services/test_mwr_mode_service.py
+++ b/tests/unit/services/test_mwr_mode_service.py
@@ -99,6 +99,77 @@ def test_build_stateful_mwr_input_for_window_uses_requested_window_start():
     assert normalized.start_date == date(2025, 1, 10)
 
 
+def test_build_stateful_mwr_input_marks_single_currency_fx_conversion_not_required():
+    source_input = StatefulPortfolioInput(
+        performance_start_date=date(2025, 1, 1),
+        portfolio_currency="EUR",
+        reporting_currency="EUR",
+        observations=[
+            {
+                "valuation_date": "2025-01-01",
+                "beginning_market_value": "1000",
+                "ending_market_value": "1110",
+                "cash_flow_currency": "EUR",
+                "cash_flows": [{"amount": "100", "timing": "bod"}],
+            },
+            {
+                "valuation_date": "2025-01-03",
+                "beginning_market_value": "1110",
+                "ending_market_value": "1120",
+                "cash_flow_currency": "EUR",
+                "cash_flows": [],
+            },
+        ],
+    )
+
+    normalized = build_stateful_mwr_input(source_input=source_input)
+
+    assert normalized.currency_evidence.conversion_evidence_status == "not_required_single_currency_inputs"
+    assert normalized.currency_evidence.conversion_evidence_reason_codes == [
+        "SOURCE_AND_REPORTING_CURRENCY_MATCH",
+        "PER_INPUT_FX_CONVERSION_NOT_REQUIRED",
+        "MWR_ENGINE_CALCULATED_REPORTING_CURRENCY_SCHEDULE",
+    ]
+    assert [item.conversion_status for item in normalized.currency_evidence.market_values_used] == [
+        "no_conversion_required",
+        "no_conversion_required",
+    ]
+
+
+def test_build_stateful_mwr_input_keeps_fx_metadata_gap_when_cash_flow_currency_differs():
+    source_input = StatefulPortfolioInput(
+        performance_start_date=date(2025, 1, 1),
+        portfolio_currency="EUR",
+        reporting_currency="EUR",
+        observations=[
+            {
+                "valuation_date": "2025-01-01",
+                "beginning_market_value": "1000",
+                "ending_market_value": "1110",
+                "cash_flow_currency": "USD",
+                "cash_flows": [{"amount": "100", "timing": "bod"}],
+            },
+            {
+                "valuation_date": "2025-01-03",
+                "beginning_market_value": "1110",
+                "ending_market_value": "1120",
+                "cash_flow_currency": "EUR",
+                "cash_flows": [],
+            },
+        ],
+    )
+
+    normalized = build_stateful_mwr_input(source_input=source_input)
+
+    assert normalized.currency_evidence.conversion_evidence_status == (
+        "upstream_preconverted_missing_per_input_fx_metadata"
+    )
+    assert [item.conversion_status for item in normalized.currency_evidence.market_values_used] == [
+        "upstream_preconverted",
+        "upstream_preconverted",
+    ]
+
+
 def test_build_stateful_mwr_input_captures_carry_forward_capital_breaks():
     source_input = StatefulPortfolioInput(
         performance_start_date=date(2025, 1, 1),

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -62,9 +62,10 @@ calculation-schedule echo. Stateless callers may supply complete
 `source_preconverted_fx_evidence`; lotus-performance validates it against the supplied
 reporting-currency schedule and emits `currency_evidence` with per-input FX provenance. Stateful
 responses also carry `reporting_currency` and `currency_evidence`, including beginning/ending
-market values, source cash-flow components, and the explicit
-`upstream_preconverted_missing_per_input_fx_metadata` posture. Stateful upstream FX-aware MWR is
-still contract-gated by
+market values and source cash-flow components. Single-currency stateful responses emit
+`not_required_single_currency_inputs` when source and reporting currencies match. Cross-currency
+stateful responses keep the explicit `upstream_preconverted_missing_per_input_fx_metadata` posture.
+Stateful upstream FX-aware MWR is still contract-gated by
 [docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md), and
 downstream consumers must not infer missing FX rates or conversion policy when those fields are
 absent.

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -80,6 +80,9 @@ support tooling must not infer FX rates, conversion policy, or source-currency p
 legacy `cashflows_used` echo. Stateless callers may provide complete
 `source_preconverted_fx_evidence`; when present, downstream consumers should preserve the emitted
 `currency_evidence` and must not recalculate FX conversion or MWR locally.
+Stateful single-currency MWR emits `not_required_single_currency_inputs` when source and reporting
+currencies match; cross-currency stateful MWR keeps the missing per-input FX metadata posture until
+the upstream source contract publishes rate, policy, version, and fingerprint evidence.
 Gateway should preserve calculation-quality fields (`status`, `reason_codes`, `warnings`,
 `fallback_reason`, `is_approximation`, and `holding_period_return`) because they explain whether the
 client-facing number is annualized XIRR, a labeled Modified Dietz fallback, a Simple Dietz result,

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -47,8 +47,9 @@
   `contracts/domain-data-products/lotus-performance-products.v1.json`. Current MWR is a single
   reporting-currency product with explicit source-component evidence. Stateless callers may supply
   complete `source_preconverted_fx_evidence`; consumers should preserve the emitted
-  `currency_evidence` and must not reconstruct FX conversion locally. Stateful upstream FX-aware
-  MWR remains gated by
+  `currency_evidence` and must not reconstruct FX conversion locally. Stateful single-currency MWR
+  emits `not_required_single_currency_inputs` when source and reporting currencies match. Stateful
+  upstream cross-currency FX-aware MWR remains gated by
   [docs/technical/mwr-fx-contract-design.md](../docs/technical/mwr-fx-contract-design.md).
   Production controls and review findings are maintained in
   [docs/guides/mwr-lotus-production-controls.md](../docs/guides/mwr-lotus-production-controls.md)


### PR DESCRIPTION
## Summary
- add explicit stateful MWR single-currency evidence posture: `not_required_single_currency_inputs`
- mark stateful MWR market values as `no_conversion_required` when source and reporting currencies match
- preserve existing fail-closed cross-currency posture until upstream per-input FX evidence is available
- update MWR docs/wiki and docs contract coverage

## Validation
- `python -m pytest tests\unit\services\test_mwr_mode_service.py tests\integration\test_mwr_api.py tests\unit\docs\test_public_docs_contract.py -q`
- `python -m ruff check app\services\stateful_mwr_input_service.py app\models\mwr_responses.py tests\unit\services\test_mwr_mode_service.py tests\integration\test_mwr_api.py tests\unit\docs\test_public_docs_contract.py`
- `python -m ruff format --check app\services\stateful_mwr_input_service.py app\models\mwr_responses.py tests\unit\services\test_mwr_mode_service.py tests\integration\test_mwr_api.py tests\unit\docs\test_public_docs_contract.py`
- `python -m mypy --config-file mypy.ini app\services\stateful_mwr_input_service.py app\models\mwr_responses.py`
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- `python scripts\no_alias_contract_guard.py`
- `python scripts\validate_domain_data_product_contracts.py`
- `make check`
- `make test-integration`
- `make test-e2e`

## Wiki
- Source wiki changed: `wiki/API-Surface.md`, `wiki/Integrations.md`, `wiki/Mesh-Data-Products.md`
- Pre-merge wiki check reports expected drift until this branch is merged and published

## Boundaries
- Does not claim cross-currency stateful MWR per-input FX provenance
- Does not claim OMS, predictive execution, order routing, client communication, or downstream UI realization