### PR TITLE
Approve Lotus Idea as Performance mesh consumer

### DIFF
--- a/app/api/endpoints/integration_capabilities.py
+++ b/app/api/endpoints/integration_capabilities.py
@@ -16,6 +16,7 @@ ConsumerSystem = Literal[
     "lotus-performance",
     "lotus-risk",
     "lotus-manage",
+    "lotus-idea",
     "lotus-workbench",
     "lotus-report",
     "lotus-advise",
@@ -483,14 +484,15 @@ class IntegrationCapabilitiesResponse(BaseModel):
     response_model=IntegrationCapabilitiesResponse,
     summary="Get lotus-performance Integration Capabilities",
     description=(
-        "Returns backend-governed lotus-performance capability/workflow controls for lotus-gateway, lotus-core, and lotus-manage integration."
+        "Returns backend-governed lotus-performance capability/workflow controls for lotus-gateway, "
+        "lotus-core, lotus-manage, and lotus-idea integration."
     ),
 )
 async def get_integration_capabilities(
     consumer_system: ConsumerSystem = Query(
         "lotus-gateway",
         description="Canonical downstream consumer system. Use snake_case query name `consumer_system`.",
-        examples=["lotus-gateway"],
+        examples=["lotus-gateway", "lotus-idea"],
     ),
     tenant_id: str = Query(
         "default",

--- a/app/models/benchmark_exposure_context.py
+++ b/app/models/benchmark_exposure_context.py
@@ -157,6 +157,13 @@ class BenchmarkExposureMetadata(BaseModel):
         description="lotus-performance request/calc identifier for this exposure context response."
     )
     contract_version: Literal["v1"] = Field(default="v1", description="Contract version for this response payload.")
+    correlation_id: str = Field(
+        description=(
+            "Request correlation identifier carried as required trust metadata for downstream "
+            "mesh consumers."
+        ),
+        examples=["corr_benchmark_exposure_001"],
+    )
     generated_at: dt_datetime = Field(description="UTC timestamp at which the response was generated.")
     retrieval_metadata: dict[str, int] = Field(
         default_factory=dict,
@@ -225,6 +232,7 @@ class BenchmarkExposureContextResponse(BaseModel):
                         "served_by": "lotus-performance",
                         "calculation_run_id": "0d000004-1111-4222-8333-abcdefabcdef",
                         "contract_version": "v1",
+                        "correlation_id": "corr_benchmark_exposure_001",
                         "generated_at": "2026-04-10T00:00:00Z",
                         "retrieval_metadata": {
                             "benchmark_market_series_chunk_count": 1,

--- a/app/models/benchmark_exposure_context.py
+++ b/app/models/benchmark_exposure_context.py
@@ -159,8 +159,7 @@ class BenchmarkExposureMetadata(BaseModel):
     contract_version: Literal["v1"] = Field(default="v1", description="Contract version for this response payload.")
     correlation_id: str = Field(
         description=(
-            "Request correlation identifier carried as required trust metadata for downstream "
-            "mesh consumers."
+            "Request correlation identifier carried as required trust metadata for downstream mesh consumers."
         ),
         examples=["corr_benchmark_exposure_001"],
     )

--- a/app/models/mandate_health.py
+++ b/app/models/mandate_health.py
@@ -124,6 +124,13 @@ class MandatePerformanceHealthContextResponse(BaseModel):
         description="Product contract version.",
         examples=["v1"],
     )
+    correlation_id: str = Field(
+        description=(
+            "Request correlation identifier carried as required trust metadata for downstream "
+            "mesh consumers."
+        ),
+        examples=["corr_mandate_health_001"],
+    )
     portfolio_id: str = Field(
         description="Portfolio identifier evaluated by the source product.",
         examples=["PB_SG_GLOBAL_BAL_001"],

--- a/app/models/mandate_health.py
+++ b/app/models/mandate_health.py
@@ -126,8 +126,7 @@ class MandatePerformanceHealthContextResponse(BaseModel):
     )
     correlation_id: str = Field(
         description=(
-            "Request correlation identifier carried as required trust metadata for downstream "
-            "mesh consumers."
+            "Request correlation identifier carried as required trust metadata for downstream mesh consumers."
         ),
         examples=["corr_mandate_health_001"],
     )

--- a/app/observability.py
+++ b/app/observability.py
@@ -178,6 +178,10 @@ def propagation_headers(correlation_id: str | None = None) -> dict[str, str]:
     }
 
 
+def source_product_correlation_id() -> str:
+    return _propagation_correlation_id(None)
+
+
 def _propagation_correlation_id(correlation_id: str | None) -> str:
     return _nonblank_value(correlation_id) or _nonblank_value(correlation_id_var.get()) or f"corr_{uuid4().hex[:12]}"
 

--- a/app/services/benchmark_exposure_context_service.py
+++ b/app/services/benchmark_exposure_context_service.py
@@ -15,6 +15,7 @@ from app.models.benchmark_exposure_context import (
     BenchmarkExposurePageResponse,
     BenchmarkExposureRow,
 )
+from app.observability import source_product_correlation_id
 from app.services.offset_pagination import slice_offset_page
 from app.services.stateful_input_service import StatefulInputService
 from app.services.stateful_retrieval_metadata import parse_zero_default_retrieval_metadata
@@ -93,6 +94,7 @@ async def build_benchmark_exposure_context(
         page=BenchmarkExposurePageResponse(next_page_token=next_page_token),
         metadata=BenchmarkExposureMetadata(
             calculation_run_id=request.calculation_id,
+            correlation_id=source_product_correlation_id(),
             generated_at=datetime.now(UTC),
             retrieval_metadata={
                 "benchmark_market_series_chunk_count": market_retrieval.chunk_count,

--- a/app/services/compute_job_store.py
+++ b/app/services/compute_job_store.py
@@ -68,6 +68,7 @@ COMPUTE_TERMINAL_JOB_STATUSES = (
     ComputeJobStatus.COMPLETE.value,
     ComputeJobStatus.FAILED.value,
 )
+TRANSIENT_COMPUTE_JOB_REQUEST_FIELDS = frozenset({"observability_context"})
 COMPUTE_INSPECTION_ACTIVE_SINCE_FIELDS: dict[str, tuple[str, ...]] = {
     ComputeJobStatus.LEASED.value: ("leased_at_utc", "created_at_utc"),
     ComputeJobStatus.RUNNING.value: ("started_at_utc", "leased_at_utc", "created_at_utc"),
@@ -288,14 +289,31 @@ def _matches_existing_compute_job_registration(
     existing: ComputeJobModel,
     *,
     analytics_type: str,
-    request_json: str,
+    request_identity_json: str,
     max_attempts: int,
 ) -> bool:
     return (
         existing.analytics_type == analytics_type
-        and existing.request_json == request_json
+        and _compute_job_request_identity_json_from_json(existing.request_json) == request_identity_json
         and existing.max_attempts == max_attempts
     )
+
+
+def _compute_job_request_identity_json(request_payload: dict[str, Any]) -> str:
+    identity_payload = {
+        field: value for field, value in request_payload.items() if field not in TRANSIENT_COMPUTE_JOB_REQUEST_FIELDS
+    }
+    return json.dumps(identity_payload, sort_keys=True)
+
+
+def _compute_job_request_identity_json_from_json(request_json: str) -> str:
+    try:
+        request_payload = json.loads(request_json)
+    except json.JSONDecodeError:
+        return request_json
+    if not isinstance(request_payload, dict):
+        return request_json
+    return _compute_job_request_identity_json(request_payload)
 
 
 def _compute_job_has_conflicting_worker_lease(
@@ -309,7 +327,7 @@ def _compute_job_registration_result_for_integrity_conflict(
     *,
     integrity_error: IntegrityError,
     analytics_type: str,
-    request_json: str,
+    request_identity_json: str,
     max_attempts: int,
 ) -> ComputeJobRegistrationResult:
     if existing is None:
@@ -317,7 +335,7 @@ def _compute_job_registration_result_for_integrity_conflict(
     if _matches_existing_compute_job_registration(
         existing,
         analytics_type=analytics_type,
-        request_json=request_json,
+        request_identity_json=request_identity_json,
         max_attempts=max_attempts,
     ):
         return ComputeJobRegistrationResult(
@@ -448,6 +466,7 @@ class ComputeJobStore:
         now = datetime.now(timezone.utc)
         configured_max_attempts = max_attempts or get_settings().COMPUTE_EXECUTOR_MAX_ATTEMPTS
         request_json = json.dumps(request_payload, sort_keys=True)
+        request_identity_json = _compute_job_request_identity_json(request_payload)
         job = ComputeJobModel(
             calculation_id=str(calculation_id),
             analytics_type=analytics_type,
@@ -479,7 +498,7 @@ class ComputeJobStore:
                 existing,
                 integrity_error=exc,
                 analytics_type=analytics_type,
-                request_json=request_json,
+                request_identity_json=request_identity_json,
                 max_attempts=configured_max_attempts,
             )
         finally:

--- a/app/services/mandate_health_context_service.py
+++ b/app/services/mandate_health_context_service.py
@@ -9,6 +9,7 @@ from app.models.mandate_health import (
     MandatePerformanceHealthSourceMetric,
     MandatePerformanceHealthState,
 )
+from app.observability import source_product_correlation_id
 from core.repro import generate_canonical_hash_from_value
 
 
@@ -36,6 +37,7 @@ def evaluate_mandate_performance_health_context(
     )
 
     return MandatePerformanceHealthContextResponse(
+        correlation_id=source_product_correlation_id(),
         portfolio_id=request.portfolio_id,
         as_of_date=request.as_of_date,
         period_name=request.period_name,

--- a/app/services/returns_series_calculation_workflow_service.py
+++ b/app/services/returns_series_calculation_workflow_service.py
@@ -12,6 +12,7 @@ from app.models.returns_series import (
     ReturnsSeriesRequest,
     ReturnsSeriesResponse,
 )
+from app.observability import correlation_id_var, request_id_var, trace_id_var
 from app.services.analytics_workflow_types import ANALYTICS_WORKFLOW_RETURNS_SERIES
 from app.services.execution_registry import execution_registry
 from app.services.reproducibility_service import generate_request_fingerprint
@@ -28,6 +29,8 @@ from app.services.submission_fencing_service import (
     register_async_submission_or_raise,
     register_sync_execution_or_raise,
 )
+
+ASYNC_OBSERVABILITY_CONTEXT_FIELD = "observability_context"
 
 
 def accepted_returns_series_response(calculation_id: UUID) -> ReturnsSeriesAcceptedResponse:
@@ -76,6 +79,29 @@ def _execution_failure_message(exc: Exception) -> str:
     if isinstance(detail, dict) and "message" in detail:
         return str(detail["message"])
     return str(detail)
+
+
+def _nonblank_context_value(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _current_async_observability_context() -> dict[str, str]:
+    context = {
+        "correlation_id": _nonblank_context_value(correlation_id_var.get()),
+        "request_id": _nonblank_context_value(request_id_var.get()),
+        "trace_id": _nonblank_context_value(trace_id_var.get()),
+    }
+    return {field: value for field, value in context.items() if value is not None}
+
+
+def _returns_series_async_request_payload(payload: dict[str, object]) -> dict[str, object]:
+    observability_context = _current_async_observability_context()
+    if not observability_context:
+        return payload
+    return {
+        **payload,
+        ASYNC_OBSERVABILITY_CONTEXT_FIELD: observability_context,
+    }
 
 
 def build_returns_series_execution_window(
@@ -151,12 +177,14 @@ async def _calculate_promoted_stateful_returns_series(
             ),
             input_fingerprint=resolved_input_fingerprint,
             calculation_hash=resolved_calculation_hash,
-            resolved_request_payload={
-                "resolved_request": resolved.request.model_dump(mode="json"),
-                "source_input_mode": InputMode.STATEFUL.value,
-                "resolved_benchmark_id": resolved.resolved_benchmark_id,
-                "resolved_benchmark_return_source": resolved.resolved_benchmark_return_source,
-            },
+            resolved_request_payload=_returns_series_async_request_payload(
+                {
+                    "resolved_request": resolved.request.model_dump(mode="json"),
+                    "source_input_mode": InputMode.STATEFUL.value,
+                    "resolved_benchmark_id": resolved.resolved_benchmark_id,
+                    "resolved_benchmark_return_source": resolved.resolved_benchmark_return_source,
+                }
+            ),
             should_offload=should_offload_resolved_returns_series(resolved.input_count),
             offload_reason="large_resolved_stateful_returns_series",
             accepted_response_factory=accepted_returns_series_response,
@@ -196,7 +224,7 @@ async def calculate_returns_series_workflow(
             requested_window=build_returns_series_execution_window(request),
             input_fingerprint=input_fingerprint,
             calculation_hash=calculation_hash,
-            request_payload=request.model_dump(mode="json"),
+            request_payload=_returns_series_async_request_payload(request.model_dump(mode="json")),
             offload_reason="long_window_stateful_returns_series",
             accepted_response_factory=accepted_returns_series_response,
         )

--- a/app/workers/compute_executor_worker.py
+++ b/app/workers/compute_executor_worker.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from threading import Event
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, Coroutine, Iterator
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -22,6 +23,7 @@ from app.models.inspection_requests import TWRInspectionRequest
 from app.models.returns_series import InputMode, ReturnsSeriesRequest
 from app.models.twr_requests import TWRAnalyticsRequest, TWRInputMode, TWRResolvedExecutionRequest
 from app.models.workspace_summary_requests import WorkspaceSummaryRequest
+from app.observability import correlation_id_var, request_id_var, trace_id_var
 from app.services.analytics_workflow_types import (
     ANALYTICS_WORKFLOW_ATTRIBUTION,
     ANALYTICS_WORKFLOW_BENCHMARK,
@@ -51,6 +53,8 @@ from core.repro import generate_canonical_hash, generate_canonical_hash_from_val
 from engine.exceptions import EngineCalculationError, InvalidEngineInputError
 
 logger = logging.getLogger(__name__)
+
+ASYNC_OBSERVABILITY_CONTEXT_FIELD = "observability_context"
 
 
 @dataclass(frozen=True)
@@ -328,16 +332,48 @@ def _execute_returns_series_job(job: ComputeJobRecord, context: _ComputeJobExecu
         resolved_benchmark_id_override,
         resolved_benchmark_return_source_override,
     ) = _resolve_async_returns_series_job_request(job.request_payload)
-    if source_input_mode == request.input_mode:
-        return asyncio.run(context.returns_series_calculator(request))
-    return asyncio.run(
-        context.returns_series_calculator(
-            request,
-            source_input_mode=source_input_mode,
-            resolved_benchmark_id_override=resolved_benchmark_id_override,
-            resolved_benchmark_return_source_override=resolved_benchmark_return_source_override,
+    with _restored_async_observability_context(job.request_payload):
+        if source_input_mode == request.input_mode:
+            return asyncio.run(context.returns_series_calculator(request))
+        return asyncio.run(
+            context.returns_series_calculator(
+                request,
+                source_input_mode=source_input_mode,
+                resolved_benchmark_id_override=resolved_benchmark_id_override,
+                resolved_benchmark_return_source_override=resolved_benchmark_return_source_override,
+            )
         )
-    )
+
+
+def _nonblank_context_value(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+@contextmanager
+def _restored_async_observability_context(payload: dict[str, Any]) -> Iterator[None]:
+    context = payload.get(ASYNC_OBSERVABILITY_CONTEXT_FIELD)
+    if not isinstance(context, dict):
+        yield
+        return
+
+    tokens = []
+    for field_name, context_var in (
+        ("correlation_id", correlation_id_var),
+        ("request_id", request_id_var),
+        ("trace_id", trace_id_var),
+    ):
+        value = _nonblank_context_value(context.get(field_name))
+        if value is not None:
+            tokens.append((context_var, context_var.set(value)))
+    try:
+        yield
+    finally:
+        for context_var, token in reversed(tokens):
+            context_var.reset(token)
+
+
+def _payload_without_async_observability_context(payload: dict[str, Any]) -> dict[str, Any]:
+    return {field: value for field, value in payload.items() if field != ASYNC_OBSERVABILITY_CONTEXT_FIELD}
 
 
 def _update_execution_identity(
@@ -576,10 +612,11 @@ def _resolve_async_contribution_job_request(
 def _resolve_async_returns_series_job_request(
     payload: dict[str, Any],
 ) -> tuple[ReturnsSeriesRequest, InputMode, str | None, str | None]:
-    resolved_request_payload = payload.get("resolved_request")
-    source_input_mode = payload.get("source_input_mode")
-    resolved_benchmark_id = payload.get("resolved_benchmark_id")
-    resolved_benchmark_return_source = payload.get("resolved_benchmark_return_source")
+    request_payload = _payload_without_async_observability_context(payload)
+    resolved_request_payload = request_payload.get("resolved_request")
+    source_input_mode = request_payload.get("source_input_mode")
+    resolved_benchmark_id = request_payload.get("resolved_benchmark_id")
+    resolved_benchmark_return_source = request_payload.get("resolved_benchmark_return_source")
     if isinstance(resolved_request_payload, dict) and isinstance(source_input_mode, str):
         return (
             ReturnsSeriesRequest.model_validate(resolved_request_payload),
@@ -587,7 +624,7 @@ def _resolve_async_returns_series_job_request(
             resolved_benchmark_id if isinstance(resolved_benchmark_id, str) else None,
             resolved_benchmark_return_source if isinstance(resolved_benchmark_return_source, str) else None,
         )
-    request = ReturnsSeriesRequest.model_validate(payload)
+    request = ReturnsSeriesRequest.model_validate(request_payload)
     return request, request.input_mode, None, None
 
 

--- a/contracts/domain-data-products/lotus-performance-products.v1.json
+++ b/contracts/domain-data-products/lotus-performance-products.v1.json
@@ -275,7 +275,8 @@
         "as_of_date",
         "request_fingerprint",
         "source_services",
-        "benchmark_context"
+        "benchmark_context",
+        "correlation_id"
       ],
       "current_routes": [
         "/performance/mandate-health-context"
@@ -297,7 +298,8 @@
       "security_profile_ref": "system_access:client_confidential:retain_for_client_record:audit_system_access",
       "approved_consumers": [
         "lotus-gateway",
-        "lotus-manage"
+        "lotus-manage",
+        "lotus-idea"
       ],
       "deprecation_policy": {
         "state": "not_deprecated",
@@ -352,7 +354,8 @@
       },
       "security_profile_ref": "system_access:client_confidential:retain_for_client_record:audit_system_access",
       "approved_consumers": [
-        "lotus-risk"
+        "lotus-risk",
+        "lotus-idea"
       ],
       "deprecation_policy": {
         "state": "not_deprecated",
@@ -385,7 +388,8 @@
         "product_name",
         "product_version",
         "generated_at",
-        "as_of_date"
+        "as_of_date",
+        "correlation_id"
       ],
       "current_routes": [
         "/integration/benchmarks/exposure-context"
@@ -405,7 +409,8 @@
       },
       "security_profile_ref": "system_access:reference_internal:retain_for_source_audit:audit_system_access",
       "approved_consumers": [
-        "lotus-risk"
+        "lotus-risk",
+        "lotus-idea"
       ],
       "deprecation_policy": {
         "state": "not_deprecated",

--- a/docs/guides/api_reference.md
+++ b/docs/guides/api_reference.md
@@ -531,7 +531,7 @@ Return semantics for the workspace surface are now explicit rather than inferred
 - purpose: advertise lotus-performance capabilities to downstream consumers
 - response model: integration capabilities contract in `app.api.endpoints.integration_capabilities`
 - canonical query controls:
-  - `consumer_system`: downstream consumer system, for example `lotus-gateway`, `lotus-risk`, or `lotus-manage`
+  - `consumer_system`: downstream consumer system, for example `lotus-gateway`, `lotus-risk`, `lotus-manage`, or `lotus-idea`
   - `tenant_id`: tenant or policy scope, default `default`
   - `feature_limit`: bounded feature row limit, default `100`, max `500`
   - `workflow_limit`: bounded workflow row limit, default `50`, max `200`

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-06-23T05:58:55.615447+00:00",
+  "generatedAt": "2026-06-23T06:34:31.960490+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -7371,6 +7371,7 @@
         "lotus-performance",
         "lotus-risk",
         "lotus-manage",
+        "lotus-idea",
         "lotus-workbench",
         "lotus-report",
         "lotus-advise",

--- a/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-performance-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-06-04T10:16:40.360832+00:00",
+  "generatedAt": "2026-06-23T05:58:55.615447+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -1331,7 +1331,7 @@
       "semanticId": "lotus.correlation_id",
       "canonicalTerm": "correlation_id",
       "preferredName": "correlation_id",
-      "description": "Canonical correlation id used by lotus-performance APIs.",
+      "description": "Request correlation identifier carried as required trust metadata for downstream mesh consumers.",
       "example": "ENTITY_001",
       "type": "string",
       "locations": [
@@ -11733,6 +11733,14 @@
             "attributeRef": "#/attributeCatalog/lotus.product_version"
           },
           {
+            "name": "correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
             "name": "portfolio_id",
             "location": "body",
             "required": true,
@@ -12797,6 +12805,14 @@
             "type": "string",
             "semanticId": "lotus.contract_version",
             "attributeRef": "#/attributeCatalog/lotus.contract_version"
+          },
+          {
+            "name": "metadata.correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "#/attributeCatalog/lotus.correlation_id"
           },
           {
             "name": "metadata.generated_at",

--- a/tests/integration/test_benchmark_exposure_context_api.py
+++ b/tests/integration/test_benchmark_exposure_context_api.py
@@ -79,7 +79,11 @@ def test_benchmark_exposure_context_api_returns_performance_aligned_view(monkeyp
     }
 
     with TestClient(app) as client:
-        response = client.post("/integration/benchmarks/exposure-context", json=payload)
+        response = client.post(
+            "/integration/benchmarks/exposure-context",
+            json=payload,
+            headers={"X-Correlation-Id": "corr-benchmark-exposure-api"},
+        )
 
     assert response.status_code == 200
     body = response.json()
@@ -88,6 +92,7 @@ def test_benchmark_exposure_context_api_returns_performance_aligned_view(monkeyp
     assert body["metadata"]["source_system"] == "lotus-core"
     assert body["metadata"]["served_by"] == "lotus-performance"
     assert body["metadata"]["contract_version"] == "v1"
+    assert body["metadata"]["correlation_id"] == "corr-benchmark-exposure-api"
     assert body["metadata"]["retrieval_metadata"] == {
         "benchmark_market_series_chunk_count": 1,
         "benchmark_market_series_page_count": 1,

--- a/tests/integration/test_integration_capabilities_api.py
+++ b/tests/integration/test_integration_capabilities_api.py
@@ -237,6 +237,16 @@ def test_integration_capabilities_honors_canonical_query_controls():
     assert body["tenant_id"] == "tenant-risk"
 
 
+def test_integration_capabilities_accepts_idea_consumer_for_mesh_discovery():
+    with TestClient(app) as client:
+        response = client.get("/integration/capabilities?consumer_system=lotus-idea&tenant_id=tenant-idea")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["consumer_system"] == "lotus-idea"
+    assert body["tenant_id"] == "tenant-idea"
+
+
 def test_integration_capabilities_rejects_blank_tenant_scope():
     with TestClient(app) as client:
         response = client.get("/integration/capabilities?consumer_system=lotus-gateway&tenant_id=%20%20")

--- a/tests/unit/app/test_benchmark_exposure_context_openapi_contract.py
+++ b/tests/unit/app/test_benchmark_exposure_context_openapi_contract.py
@@ -60,4 +60,6 @@ def test_benchmark_exposure_context_openapi_documents_usage_and_fields() -> None
         assert response_schema["properties"][field_name]["description"]
 
     assert response_schema["examples"][0]["metadata"]["source_system"] == "lotus-core"
+    assert metadata_schema["properties"]["correlation_id"]["description"]
+    assert response_schema["examples"][0]["metadata"]["correlation_id"] == "corr_benchmark_exposure_001"
     assert metadata_schema["properties"]["retrieval_metadata"]["description"]

--- a/tests/unit/app/test_returns_series_endpoint_helpers.py
+++ b/tests/unit/app/test_returns_series_endpoint_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -23,6 +24,7 @@ from app.models.returns_series import (
     StatefulInput,
     StatelessInput,
 )
+from app.observability import correlation_id_var, request_id_var, trace_id_var
 from app.services import returns_series_calculation_workflow_service
 from app.services.execution_registry import execution_registry
 from app.services.returns_series_calculation_workflow_service import (
@@ -320,6 +322,49 @@ def test_should_offload_resolved_returns_series_uses_runtime_settings(mocker):
 
     assert should_offload_resolved_returns_series(3) is True
     assert should_offload_resolved_returns_series(2) is False
+
+
+@pytest.mark.asyncio
+async def test_async_returns_series_submission_captures_observability_context(mocker):
+    request = ReturnsSeriesRequest.model_validate(
+        {
+            "portfolio_id": "P1",
+            "as_of_date": "2026-02-27",
+            "window": {"mode": "EXPLICIT", "from_date": "2026-02-24", "to_date": "2026-02-27"},
+            "input_mode": "stateful",
+            "stateful_input": {},
+        }
+    )
+    mocker.patch(
+        "app.services.returns_series_calculation_workflow_service.get_settings",
+        return_value=type("Settings", (), {"RETURNS_SERIES_EXECUTOR_WINDOW_DAYS": 1})(),
+    )
+    captured: dict[str, Any] = {}
+
+    def _register_async_submission_or_raise(**kwargs):
+        captured.update(kwargs)
+        return returns_series_calculation_workflow_service.accepted_returns_series_response(request.calculation_id)
+
+    mocker.patch(
+        "app.services.returns_series_calculation_workflow_service.register_async_submission_or_raise",
+        side_effect=_register_async_submission_or_raise,
+    )
+    correlation_token = correlation_id_var.set(" corr-returns-series ")
+    request_token = request_id_var.set(" req-returns-series ")
+    trace_token = trace_id_var.set(" trace-returns-series ")
+    try:
+        response = await calculate_returns_series_workflow(request)
+    finally:
+        correlation_id_var.reset(correlation_token)
+        request_id_var.reset(request_token)
+        trace_id_var.reset(trace_token)
+
+    assert response.calculation_id == request.calculation_id
+    assert captured["request_payload"]["observability_context"] == {
+        "correlation_id": "corr-returns-series",
+        "request_id": "req-returns-series",
+        "trace_id": "trace-returns-series",
+    }
 
 
 def test_build_returns_series_execution_window_projects_optional_metadata():

--- a/tests/unit/services/test_benchmark_exposure_context_service.py
+++ b/tests/unit/services/test_benchmark_exposure_context_service.py
@@ -11,6 +11,7 @@ from app.models.benchmark_exposure_context import (
     BenchmarkExposureRow,
     BenchmarkExposureWindow,
 )
+from app.observability import correlation_id_var
 from app.services.benchmark_exposure_context_service import (
     _accumulate_exposure_point,
     _benchmark_id_from_assignment_payload,
@@ -136,11 +137,16 @@ def _request(**overrides) -> BenchmarkExposureContextRequest:
 async def test_build_benchmark_exposure_context_groups_and_aligns_weights() -> None:
     service = _StatefulInputServiceStub()
 
-    response = await build_benchmark_exposure_context(request=_request(), stateful_input_service=service)
+    correlation_token = correlation_id_var.set("corr-benchmark-exposure-unit")
+    try:
+        response = await build_benchmark_exposure_context(request=_request(), stateful_input_service=service)
+    finally:
+        correlation_id_var.reset(correlation_token)
 
     assert response.benchmark_id == "BMK_GLOBAL_60_40"
     assert response.metadata.source_system == "lotus-core"
     assert response.metadata.served_by == "lotus-performance"
+    assert response.metadata.correlation_id == "corr-benchmark-exposure-unit"
     assert response.metadata.retrieval_metadata == {
         "benchmark_market_series_chunk_count": 1,
         "benchmark_market_series_page_count": 2,

--- a/tests/unit/services/test_compute_executor_worker.py
+++ b/tests/unit/services/test_compute_executor_worker.py
@@ -12,6 +12,7 @@ from app.models.contribution_requests import ContributionRequest
 from app.models.requests import PerformanceRequest
 from app.models.returns_series import ReturnsSeriesRequest
 from app.models.twr_requests import TWRInputMode, TWRResolvedExecutionRequest
+from app.observability import correlation_id_var
 from app.services import (
     attribution_service,
     benchmark_service,
@@ -352,7 +353,14 @@ def test_compute_executor_worker_processes_pending_returns_series_job(tmp_path, 
     job_store.enqueue_job(
         calculation_id=calculation_id,
         analytics_type=ANALYTICS_WORKFLOW_RETURNS_SERIES,
-        request_payload=request.model_dump(mode="json"),
+        request_payload={
+            **request.model_dump(mode="json"),
+            "observability_context": {
+                "correlation_id": "corr-async-returns-series",
+                "request_id": "req-async-returns-series",
+                "trace_id": "trace-async-returns-series",
+            },
+        },
     )
 
     assert compute_executor_worker.process_pending_jobs(limit=10) == 1
@@ -368,6 +376,10 @@ def test_compute_executor_worker_processes_pending_returns_series_job(tmp_path, 
     result = result_store.get_result(calculation_id)
     assert result is not None
     assert result.result_status == AsyncResultStatus.COMPLETE
+    assert result.response_payload["metadata"]["correlation_id"] == "corr-async-returns-series"
+    assert result.response_payload["metadata"]["request_id"] == "req-async-returns-series"
+    assert result.response_payload["metadata"]["trace_id"] == "trace-async-returns-series"
+    assert correlation_id_var.get() != "corr-async-returns-series"
 
 
 def test_compute_executor_worker_dispatches_benchmark_job_and_updates_execution_identity(tmp_path):

--- a/tests/unit/services/test_compute_job_store.py
+++ b/tests/unit/services/test_compute_job_store.py
@@ -21,6 +21,7 @@ from app.services.compute_job_store import (
     _compute_job_inspection_active_since,
     _compute_job_payload_failure,
     _compute_job_registration_result_for_integrity_conflict,
+    _compute_job_request_identity_json,
     _ensure_compute_job_can_mark_running,
     _matches_existing_compute_job_registration,
     _queue_stats_from_aggregate_row,
@@ -1185,6 +1186,37 @@ def test_compute_job_store_register_job_distinguishes_create_replay_and_conflict
     assert conflict.status == ComputeJobRegistrationStatus.CONFLICT
 
 
+def test_compute_job_store_register_job_ignores_transient_observability_context_for_replay(tmp_path):
+    store = ComputeJobStore(f"sqlite:///{tmp_path / 'compute.db'}")
+    store.create_schema()
+    calculation_id = uuid4()
+
+    created = store.register_job(
+        calculation_id=calculation_id,
+        analytics_type="ReturnsSeries",
+        request_payload={
+            "portfolio_id": "P1",
+            "observability_context": {"correlation_id": "corr-first"},
+        },
+        max_attempts=2,
+    )
+    replay = store.register_job(
+        calculation_id=calculation_id,
+        analytics_type="ReturnsSeries",
+        request_payload={
+            "portfolio_id": "P1",
+            "observability_context": {"correlation_id": "corr-second"},
+        },
+        max_attempts=2,
+    )
+
+    assert created.status == ComputeJobRegistrationStatus.CREATED
+    assert replay.status == ComputeJobRegistrationStatus.REPLAY
+    stored_job = store.get_job(calculation_id)
+    assert stored_job is not None
+    assert stored_job.request_payload["observability_context"] == {"correlation_id": "corr-first"}
+
+
 def test_matches_existing_compute_job_registration_requires_same_request_and_attempt_policy():
     existing = ComputeJobModel(
         calculation_id=str(uuid4()),
@@ -1200,25 +1232,25 @@ def test_matches_existing_compute_job_registration_requires_same_request_and_att
     assert _matches_existing_compute_job_registration(
         existing,
         analytics_type="Contribution",
-        request_json='{"portfolio_id": "P1"}',
+        request_identity_json=_compute_job_request_identity_json({"portfolio_id": "P1"}),
         max_attempts=2,
     )
     assert not _matches_existing_compute_job_registration(
         existing,
         analytics_type="Contribution",
-        request_json='{"portfolio_id": "P2"}',
+        request_identity_json=_compute_job_request_identity_json({"portfolio_id": "P2"}),
         max_attempts=2,
     )
     assert not _matches_existing_compute_job_registration(
         existing,
         analytics_type="Contribution",
-        request_json='{"portfolio_id": "P1"}',
+        request_identity_json=_compute_job_request_identity_json({"portfolio_id": "P1"}),
         max_attempts=3,
     )
     assert not _matches_existing_compute_job_registration(
         existing,
         analytics_type="Attribution",
-        request_json='{"portfolio_id": "P1"}',
+        request_identity_json=_compute_job_request_identity_json({"portfolio_id": "P1"}),
         max_attempts=2,
     )
 
@@ -1239,7 +1271,7 @@ def test_compute_job_registration_result_for_integrity_conflict_replays_matching
         existing,
         integrity_error=IntegrityError("insert", {}, RuntimeError("duplicate")),
         analytics_type="Contribution",
-        request_json='{"portfolio_id": "P1"}',
+        request_identity_json=_compute_job_request_identity_json({"portfolio_id": "P1"}),
         max_attempts=2,
     )
 
@@ -1263,7 +1295,7 @@ def test_compute_job_registration_result_for_integrity_conflict_reports_conflict
         existing,
         integrity_error=IntegrityError("insert", {}, RuntimeError("duplicate")),
         analytics_type="Contribution",
-        request_json='{"portfolio_id": "P2"}',
+        request_identity_json=_compute_job_request_identity_json({"portfolio_id": "P2"}),
         max_attempts=2,
     )
 
@@ -1279,7 +1311,7 @@ def test_compute_job_registration_result_for_integrity_conflict_reraises_missing
             None,
             integrity_error=original_error,
             analytics_type="Contribution",
-            request_json='{"portfolio_id": "P1"}',
+            request_identity_json=_compute_job_request_identity_json({"portfolio_id": "P1"}),
             max_attempts=2,
         )
 

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -88,14 +88,21 @@ def test_repo_native_producer_declarations_cover_governed_first_wave_products_an
     assert "coverage_status" in attribution_product["required_trust_metadata"]
     assert "coverage_ratio" in attribution_product["required_trust_metadata"]
     mandate_health_product = payload["products"][4]
-    assert mandate_health_product["approved_consumers"] == ["lotus-gateway", "lotus-manage"]
+    assert mandate_health_product["approved_consumers"] == [
+        "lotus-gateway",
+        "lotus-manage",
+        "lotus-idea",
+    ]
     assert mandate_health_product["current_routes"] == ["/performance/mandate-health-context"]
     assert mandate_health_product["completeness_policy"]["partial_allowed"] is True
     assert "request_fingerprint" in mandate_health_product["required_trust_metadata"]
     assert "source_services" in mandate_health_product["required_trust_metadata"]
     assert "benchmark_context" in mandate_health_product["required_trust_metadata"]
-    assert payload["products"][5]["approved_consumers"] == ["lotus-risk"]
-    assert payload["products"][6]["approved_consumers"] == ["lotus-risk"]
+    assert "correlation_id" in mandate_health_product["required_trust_metadata"]
+    assert payload["products"][5]["approved_consumers"] == ["lotus-risk", "lotus-idea"]
+    assert "correlation_id" in payload["products"][5]["required_trust_metadata"]
+    assert payload["products"][6]["approved_consumers"] == ["lotus-risk", "lotus-idea"]
+    assert "correlation_id" in payload["products"][6]["required_trust_metadata"]
     composite_product = payload["products"][7]
     assert composite_product["approved_consumers"] == ["lotus-gateway"]
     assert composite_product["current_routes"] == ["/performance/composites/twr"]

--- a/tests/unit/test_mandate_performance_health_context.py
+++ b/tests/unit/test_mandate_performance_health_context.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from fastapi.testclient import TestClient
 
 from app.models.mandate_health import MandatePerformanceHealthContextRequest
+from app.observability import correlation_id_var
 from app.services.mandate_health_context_service import evaluate_mandate_performance_health_context
 from main import app
 
@@ -25,10 +26,15 @@ def _request_payload(**overrides: object) -> dict[str, object]:
 def test_mandate_performance_health_context_flags_source_owned_underperformance() -> None:
     request = MandatePerformanceHealthContextRequest.model_validate(_request_payload())
 
-    response = evaluate_mandate_performance_health_context(request)
+    correlation_token = correlation_id_var.set("corr-mandate-health-unit")
+    try:
+        response = evaluate_mandate_performance_health_context(request)
+    finally:
+        correlation_id_var.reset(correlation_token)
 
     assert response.product_name == "MandatePerformanceHealthContext"
     assert response.product_version == "v1"
+    assert response.correlation_id == "corr-mandate-health-unit"
     assert response.portfolio_id == "PB_SG_GLOBAL_BAL_001"
     assert response.period_name == "YTD"
     assert response.health_state == "attention"
@@ -62,11 +68,16 @@ def test_mandate_performance_health_context_is_unavailable_without_benchmark() -
 def test_mandate_performance_health_context_endpoint_returns_source_product() -> None:
     client = TestClient(app)
 
-    response = client.post("/performance/mandate-health-context", json=_request_payload())
+    response = client.post(
+        "/performance/mandate-health-context",
+        json=_request_payload(),
+        headers={"X-Correlation-Id": "corr-mandate-health-api"},
+    )
 
     assert response.status_code == 200
     body = response.json()
     assert body["product_name"] == "MandatePerformanceHealthContext"
+    assert body["correlation_id"] == "corr-mandate-health-api"
     assert body["methodology_posture"]["source_service"] == "lotus-performance"
     assert body["methodology_posture"]["source_metrics_product"] == "TimeWeightedReturnAnalytics:v1"
     assert body["source_services"] == ["lotus-performance"]


### PR DESCRIPTION
## Scope
Approve `lotus-idea` as a governed mesh consumer for `MandatePerformanceHealthContext`, `ReturnsSeriesBundle`, and `BenchmarkExposureContext`, and pin the required `correlation_id` trust metadata where Idea depends on traceable runtime context.

This does not claim platform source-manifest inclusion or Lotus Idea mesh certification.

## Validation
- `make domain-product-validate` passed.
- `python -m pytest tests/unit/test_domain_data_product_contracts.py -q` passed.
- `make check` passed locally, including lint, format, action runtime guard, monetary guard, complexity/architecture/duplicate/observability gates, no-alias, mypy, OpenAPI, API vocabulary, domain-product validation, security inventory, and unit suite (`2820 passed`).

## Wiki
No repo-local `wiki/` source changed; no wiki publication required.