### PR TITLE
Centralize annualization basis policy

### DIFF
--- a/core/annualize.py
+++ b/core/annualize.py
@@ -6,6 +6,18 @@ from .errors import APIBadRequestError
 BasisType = Literal["BUS/252", "ACT/365", "ACT/ACT"]
 
 
+def periods_per_year_for_basis(*, basis: BasisType, periods_per_year: float | None = None) -> float:
+    if periods_per_year is not None:
+        if periods_per_year <= 0:
+            raise APIBadRequestError("Periods per year for annualization must be positive.")
+        return periods_per_year
+    if basis == "BUS/252":
+        return 252.0
+    if basis == "ACT/ACT":
+        return 365.25
+    return 365.0
+
+
 def annualize_return(period_return: float, num_periods: int, periods_per_year: float, basis: BasisType) -> float:
     """
     Annualizes a period return using geometric compounding.
@@ -25,10 +37,5 @@ def annualize_return(period_return: float, num_periods: int, periods_per_year: f
     if periods_per_year <= 0:
         raise APIBadRequestError("Periods per year for annualization must be positive.")
 
-    # For ACT/ACT, the scale factor is simply 365.25 / actual days
-    if basis == "ACT/ACT":
-        scale = 365.25 / num_periods
-    else:
-        scale = periods_per_year / num_periods
-
+    scale = periods_per_year / num_periods
     return (1 + period_return) ** scale - 1

--- a/docs/methodologies/metrics/metric-mwr-xirr.md
+++ b/docs/methodologies/metrics/metric-mwr-xirr.md
@@ -52,7 +52,8 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
   earliest cash-flow date when no start date is supplied)
 - `T`: terminal valuation date `as_of`
 - `r`: XIRR annualized decimal rate
-- `D`: day-count denominator (`annualization.periods_per_year`, else `365.25` for `ACT/ACT`, else `365.0`)
+- `D`: day-count denominator (`annualization.periods_per_year`, else `252.0` for `BUS/252`,
+  `365.25` for `ACT/ACT`, else `365.0`)
 - `tau_j`: year fraction from anchor date using `(date_j - anchor).days / D`
 - `V_j`: signed value at position `j` in the solver vector after same-day netting
 - `NPV(r)`: discounted cash-flow sum used for root solving
@@ -151,8 +152,8 @@ Money-Weighted Return via XIRR (`money_weighted_return` when method resolves to 
 
 ## Configuration Options
 - `mwr_method`: must be `XIRR` to attempt this path.
-- `annualization.basis`: controls dated year fractions (`ACT/365` default behavior for current
-  MWR examples; `ACT/ACT` uses `365.25`).
+- `annualization.basis`: controls dated year fractions (`BUS/252` uses `252.0`, `ACT/365` uses
+  `365.0`, and `ACT/ACT` uses `365.25` unless `annualization.periods_per_year` is supplied).
 - `annualization.periods_per_year`: overrides day-count denominator when supplied.
 - `solver.rate_lower_bound` and `solver.rate_upper_bound`: searched annual-rate bounds.
 - `solver.root_scan_steps`: number of log-rate scan points before bisection.

--- a/engine/breakdown.py
+++ b/engine/breakdown.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from common.enums import Frequency
 from common.precision_policy import quantize_performance
-from core.annualize import annualize_return
+from core.annualize import annualize_return, periods_per_year_for_basis
 from core.envelope import Annualization
 from engine.schema import PortfolioColumns
 
@@ -56,8 +56,9 @@ def _period_annualized_return_pct(
     days_in_period = (last_day[PortfolioColumns.PERF_DATE.value] - first_day[PortfolioColumns.PERF_DATE.value]).days + 1
     if days_in_period <= 0:
         return None
-    ppy = annualization.periods_per_year or (
-        252 if annualization.basis == "BUS/252" else 365.25 if annualization.basis == "ACT/ACT" else 365.0
+    ppy = periods_per_year_for_basis(
+        basis=annualization.basis,
+        periods_per_year=annualization.periods_per_year,
     )
     annualized_pct = annualize_return(period_ror, days_in_period, ppy, annualization.basis) * 100
     quantized = float(quantize_performance(annualized_pct))

--- a/engine/mwr.py
+++ b/engine/mwr.py
@@ -6,18 +6,16 @@ from typing import Callable, Literal, Sequence
 
 import numpy as np
 
+from core.annualize import periods_per_year_for_basis
 from core.envelope import Annualization
 from engine.mwr_types import CashFlowLike, MWRConvergence, MWRResult, Number
 
 
 def _day_count_denominator(annualization: Annualization) -> float:
-    if annualization.periods_per_year:
-        return float(annualization.periods_per_year)
-    if annualization.basis == "BUS/252":
-        return 252.0
-    if annualization.basis == "ACT/ACT":
-        return 365.25
-    return 365.0
+    return periods_per_year_for_basis(
+        basis=annualization.basis,
+        periods_per_year=annualization.periods_per_year,
+    )
 
 
 def _net_same_day_flows(values: list[float], dates: list[date]) -> tuple[np.ndarray, np.ndarray]:

--- a/tests/unit/core/test_annualize.py
+++ b/tests/unit/core/test_annualize.py
@@ -1,7 +1,7 @@
 # tests/unit/core/test_annualize.py
 import pytest
 
-from core.annualize import annualize_return
+from core.annualize import annualize_return, periods_per_year_for_basis
 from core.errors import APIBadRequestError
 
 
@@ -28,3 +28,15 @@ def test_annualize_return_invalid_inputs():
 
     with pytest.raises(APIBadRequestError, match="Periods per year for annualization must be positive"):
         annualize_return(0.05, 252, 0, "BUS/252")
+
+
+def test_periods_per_year_for_basis_uses_governed_defaults_and_explicit_override():
+    assert periods_per_year_for_basis(basis="BUS/252") == pytest.approx(252.0)
+    assert periods_per_year_for_basis(basis="ACT/365") == pytest.approx(365.0)
+    assert periods_per_year_for_basis(basis="ACT/ACT") == pytest.approx(365.25)
+    assert periods_per_year_for_basis(basis="ACT/ACT", periods_per_year=12) == pytest.approx(12.0)
+
+
+def test_periods_per_year_for_basis_rejects_non_positive_override():
+    with pytest.raises(APIBadRequestError, match="Periods per year for annualization must be positive"):
+        periods_per_year_for_basis(basis="BUS/252", periods_per_year=0)


### PR DESCRIPTION
## Summary
- Centralizes governed annualization basis-to-periods resolution in `core.annualize.periods_per_year_for_basis(...)`.
- Routes MWR and TWR breakdown annualization through the shared helper so `BUS/252`, `ACT/365`, `ACT/ACT`, and explicit `periods_per_year` overrides use one policy.
- Updates the XIRR methodology document and adds focused unit coverage for the shared policy.

Supersedes the reusable-pattern portion of #352. The original defect issue #344 is already closed by #384.

## Validation
- `python -m pytest tests\unit\core\test_annualize.py tests\unit\engine\test_mwr.py tests\integration\test_mwr_api.py tests\unit\docs\test_public_docs_contract.py -q` (`115 passed`)
- `python -m ruff check core\annualize.py engine\breakdown.py engine\mwr.py tests\unit\core\test_annualize.py`
- `python -m mypy core\annualize.py engine\breakdown.py engine\mwr.py`

## Documentation And Wiki
- Methodology documentation changed in `docs/methodologies/metrics/metric-mwr-xirr.md`.
- No repo-local wiki source change is required because the wiki does not own metric-methodology formulas.