### PR TITLE
[codex] Support canonical contribution economics

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -76,7 +76,9 @@ Current repository posture:
 13. HTTP boundary hardening is centralized in `app.http_security`: `HTTP_ALLOWED_HOSTS` controls
     host allow-listing, `CORS_ALLOWED_ORIGINS` controls explicit browser origins, standard security
     headers are emitted on success and error responses, and `HTTP_SECURITY_HSTS_ENABLED` is used
-    only when the service owns the HTTPS boundary rather than delegating TLS to ingress.
+    only when the service owns the HTTPS boundary rather than delegating TLS to ingress. Local
+    canonical Docker deployments must allow `host.docker.internal` because `lotus-gateway` reaches
+    `lotus-performance` through that Docker-to-host alias.
 14. API runtime serialization uses standard FastAPI/Pydantic response-model behavior. Do not add
     global null stripping: OpenAPI nullable fields must be returned as explicit JSON `null` values
     unless a route explicitly documents sparse `response_model_exclude_none=True` behavior.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     APP_DESCRIPTION: str = "API for calculating portfolio performance metrics."
     LOG_LEVEL: str = "INFO"
     decimal_precision: int = 28
-    HTTP_ALLOWED_HOSTS: str = "testserver,localhost,127.0.0.1,*.dev.lotus"
+    HTTP_ALLOWED_HOSTS: str = "testserver,localhost,127.0.0.1,host.docker.internal,*.dev.lotus"
     CORS_ALLOWED_ORIGINS: str = (
         "http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173"
     )

--- a/app/services/core_integration_service.py
+++ b/app/services/core_integration_service.py
@@ -4,6 +4,8 @@ from typing import Any
 from app.observability import propagation_headers
 from app.services.http_resilience import get_with_retry, post_with_retry
 
+PERFORMANCE_COMPONENT_ECONOMICS_PAGE_SIZE = 1000
+
 
 class CoreIntegrationService:
     def __init__(
@@ -108,7 +110,7 @@ class CoreIntegrationService:
         end_date: date,
         security_ids: list[str] | None = None,
         transaction_types: list[str] | None = None,
-        page_size: int = 5000,
+        page_size: int = PERFORMANCE_COMPONENT_ECONOMICS_PAGE_SIZE,
         page_token: str | None = None,
     ) -> tuple[int, dict[str, Any]]:
         payload: dict[str, Any] = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     container_name: performance-analytics
     environment:
       CORE_CONTROL_PLANE_BASE_URL: "${CORE_CONTROL_PLANE_BASE_URL:-http://host.docker.internal:8202}"
+      HTTP_ALLOWED_HOSTS: "${HTTP_ALLOWED_HOSTS:-testserver,localhost,127.0.0.1,host.docker.internal,*.dev.lotus}"
       LINEAGE_METADATA_DATABASE_URL: "${LINEAGE_METADATA_DATABASE_URL:-postgresql+psycopg://lotus:lotus@performance-lineage-db:5432/lotus_performance}"
     volumes:
       - performance-lineage-data:/app/lineage_data
@@ -36,6 +37,7 @@ services:
     command: ["python", "-m", "app.workers.lineage_worker"]
     environment:
       CORE_CONTROL_PLANE_BASE_URL: "${CORE_CONTROL_PLANE_BASE_URL:-http://host.docker.internal:8202}"
+      HTTP_ALLOWED_HOSTS: "${HTTP_ALLOWED_HOSTS:-testserver,localhost,127.0.0.1,host.docker.internal,*.dev.lotus}"
       LINEAGE_METADATA_DATABASE_URL: "${LINEAGE_METADATA_DATABASE_URL:-postgresql+psycopg://lotus:lotus@performance-lineage-db:5432/lotus_performance}"
     volumes:
       - performance-lineage-data:/app/lineage_data
@@ -51,6 +53,7 @@ services:
     command: ["python", "-m", "app.workers.compute_executor_worker"]
     environment:
       CORE_CONTROL_PLANE_BASE_URL: "${CORE_CONTROL_PLANE_BASE_URL:-http://host.docker.internal:8202}"
+      HTTP_ALLOWED_HOSTS: "${HTTP_ALLOWED_HOSTS:-testserver,localhost,127.0.0.1,host.docker.internal,*.dev.lotus}"
       LINEAGE_METADATA_DATABASE_URL: "${LINEAGE_METADATA_DATABASE_URL:-postgresql+psycopg://lotus:lotus@performance-lineage-db:5432/lotus_performance}"
     volumes:
       - performance-lineage-data:/app/lineage_data
@@ -67,6 +70,7 @@ services:
     profiles: ["ops"]
     environment:
       CORE_CONTROL_PLANE_BASE_URL: "${CORE_CONTROL_PLANE_BASE_URL:-http://host.docker.internal:8202}"
+      HTTP_ALLOWED_HOSTS: "${HTTP_ALLOWED_HOSTS:-testserver,localhost,127.0.0.1,host.docker.internal,*.dev.lotus}"
       LINEAGE_METADATA_DATABASE_URL: "${LINEAGE_METADATA_DATABASE_URL:-postgresql+psycopg://lotus:lotus@performance-lineage-db:5432/lotus_performance}"
       RUNTIME_RETENTION_WORKER_APPLY: "${RUNTIME_RETENTION_WORKER_APPLY:-false}"
     volumes:

--- a/docs/standards/enterprise-readiness.md
+++ b/docs/standards/enterprise-readiness.md
@@ -7,8 +7,8 @@
 ## Security and IAM Baseline
 
 - HTTP boundary hardening is registered centrally through `app.http_security`.
-- Host allow-listing is governed by `HTTP_ALLOWED_HOSTS`; defaults are scoped to local test and
-  Lotus development hosts.
+- Host allow-listing is governed by `HTTP_ALLOWED_HOSTS`; defaults are scoped to local test,
+  `host.docker.internal` Docker-to-host calls, and Lotus development hosts.
 - CORS is explicit through `CORS_ALLOWED_ORIGINS`; the service does not use wildcard browser
   origins by default.
 - Standard security headers are emitted on success and error responses:

--- a/tests/integration/test_http_security_api.py
+++ b/tests/integration/test_http_security_api.py
@@ -80,3 +80,10 @@ def test_trusted_host_policy_denies_unconfigured_host(client):
 
     assert response.status_code == 400
     assert "Invalid host header" in response.text
+
+
+def test_trusted_host_policy_allows_canonical_docker_host_alias(client):
+    response = client.get("/health", headers={"Host": "host.docker.internal:8002"})
+
+    assert response.status_code == 200
+    _assert_security_headers(response)

--- a/tests/unit/services/test_core_integration_service.py
+++ b/tests/unit/services/test_core_integration_service.py
@@ -222,7 +222,7 @@ async def test_get_performance_component_economics_posts_contract_payload():
     assert _FakeAsyncClient.calls[0]["json"] == {
         "as_of_date": "2026-02-24",
         "window": {"start_date": "2026-01-01", "end_date": "2026-02-24"},
-        "page": {"page_size": 5000, "page_token": None},
+        "page": {"page_size": 1000, "page_token": None},
         "security_ids": ["SEC_1"],
         "transaction_types": ["DIVIDEND"],
     }

--- a/tests/unit/services/test_stateful_input_service.py
+++ b/tests/unit/services/test_stateful_input_service.py
@@ -1386,6 +1386,29 @@ async def test_get_performance_component_economics_chunks_merges_coverage_and_re
     assert component_snapshots[0].paging_metadata["security_ids"] == ["SEC_1", "SEC_2"]
 
 
+@pytest.mark.asyncio
+async def test_get_performance_component_economics_uses_core_bounded_pages_for_canonical_window():
+    core_service = _CoreServiceStub()
+    service = StatefulInputService(core_service=core_service)
+
+    status_code, payload = await service.get_performance_component_economics(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        as_of_date=date(2026, 4, 10),
+        start_date=date(2025, 3, 31),
+        end_date=date(2026, 4, 10),
+    )
+
+    assert status_code == 200
+    assert payload["retrieval_metadata"] == {"chunk_count": 2, "page_count": 2}
+    assert [
+        (call["start_date"], call["end_date"], call.get("page_size"))
+        for call in core_service.performance_component_economics_calls
+    ] == [
+        (date(2025, 3, 31), date(2026, 3, 31), None),
+        (date(2026, 4, 1), date(2026, 4, 10), None),
+    ]
+
+
 def test_performance_component_economics_supportability_policy_requires_every_chunk_ready():
     accumulator = _PerformanceComponentEconomicsAccumulator(
         observed_component_families={"fee", "income"},

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -66,6 +66,10 @@ Operators should review these settings for each environment:
 - `HTTP_SECURITY_HSTS_ENABLED`: enable only when this service owns the HTTPS boundary
 - `HTTP_SECURITY_HSTS_MAX_AGE_SECONDS`: HSTS max-age when HSTS is enabled
 
+Local Docker deployments should keep `host.docker.internal` in `HTTP_ALLOWED_HOSTS` because
+`lotus-gateway` calls `lotus-performance` through that Docker-to-host alias in the canonical
+front-office stack.
+
 Every success and handled error response should include `X-Content-Type-Options`,
 `X-Frame-Options`, `Referrer-Policy`, and `Content-Security-Policy`. If TLS terminates at platform
 ingress, HSTS may be owned there instead of by the service process; keep that decision explicit in


### PR DESCRIPTION
## Summary
- allow canonical Docker host aliases in the trusted host defaults
- cap Core component-economics page size at the Core contract maximum
- add regression coverage for canonical contribution chunking/page-size behavior
- document the canonical host and contribution economics posture

## Validation
- `python -m pytest tests/integration/test_http_security_api.py tests/unit/docs/test_public_docs_contract.py::test_public_docs_document_http_security_boundary_contract -q`
- `python -m pytest tests/unit/services/test_core_integration_service.py::test_get_performance_component_economics_posts_contract_payload tests/unit/services/test_stateful_input_service.py::test_get_performance_component_economics_chunks_merges_coverage_and_records_snapshots tests/unit/services/test_stateful_input_service.py::test_get_performance_component_economics_uses_core_bounded_pages_for_canonical_window tests/unit/services/test_stateful_input_service.py::test_get_performance_component_economics_degrades_when_any_chunk_is_unavailable -q`
- rebuilt performance services in the canonical local stack
- direct Gateway performance details returned supported contribution detail with 4 asset-class rows
- coordinated `npm run live:validate` passed for `PB_SG_GLOBAL_BAL_001` from `lotus-workbench`

## Notes
- Stranded-truth reconciliation found no unmerged remote branches against `origin/main`.