### PR TITLE
Sync AGENTS wiki-check guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,10 +116,14 @@ When documentation, RFC, context, runbook, or operator-facing truth changes:
 
 1. update the repo-local `wiki/` source in the same PR when wiki truth changed,
 2. record an explicit no-wiki-change decision when no wiki update is needed,
-3. run `lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository <repo-name>` before merge,
+3. before merge, run
+   `lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository <repo-name> -AllowUnpublishedSourceChanges`
+   when the branch intentionally changes repo-local `wiki/` source,
 4. after merge to `main`, publish with
    `lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository <repo-name>`,
-5. use `-AllRepositories` only for platform-wide audits or coordinated publication sweeps.
+5. after publishing, run strict parity verification with
+   `lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository <repo-name>`,
+6. use `-AllRepositories` only for platform-wide audits or coordinated publication sweeps.
 
 Repo-local `wiki/` is the authored source of truth. The separate GitHub `*.wiki.git` repository is
 only the publication target and must not receive hand-edited truth that is absent from repo source.

--- a/poetry.lock
+++ b/poetry.lock
@@ -60,14 +60,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.3.3"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
-    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
+    {file = "click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"},
+    {file = "click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2"},
 ]
 
 [package.dependencies]

--- a/quality/license_compliance_inventory.md
+++ b/quality/license_compliance_inventory.md
@@ -26,7 +26,7 @@ Mode: generated first-party and third-party dependency license evidence.
 | `anyio` | runtime | `anyio==4.10.0` | `4.14.1` | MIT | License-Expression | allowed | - | - |
 | `bandit` | development | `bandit>=1.9.4,<2.0.0` | `1.9.4` | Apache-2.0 | License | allowed | - | - |
 | `certifi` | runtime | `certifi==2026.2.25` | `2026.6.17` | MPL-2.0 | License | review_required_exception | platform-security | 2027-01-31 |
-| `click` | runtime | `click==8.2.1` | `8.4.2` | BSD-3-Clause | License-Expression | allowed | - | - |
+| `click` | runtime | `click==8.3.3` | `8.4.2` | BSD-3-Clause | License-Expression | allowed | - | - |
 | `colorama` | runtime | `colorama==0.4.6` | `0.4.6` | BSD License | Classifier | allowed | - | - |
 | `coverage` | development | `coverage>=7.6.0,<8.0.0` | `7.14.3` | Apache-2.0 | License | allowed | - | - |
 | `deptry` | development | `deptry>=0.25,<1.0.0` | `0.25.1` | MIT | License-Expression | allowed | - | - |
@@ -57,7 +57,7 @@ Mode: generated first-party and third-party dependency license evidence.
 | `python-dotenv` | runtime | `python-dotenv==1.2.2` | `1.2.2` | BSD-3-Clause | License | allowed | - | - |
 | `pytz` | runtime | `pytz==2025.2` | `2025.2` | MIT | License | allowed | - | - |
 | `radon` | development | `radon>=6.0.1,<7.0.0` | `6.0.1` | MIT | License | allowed | - | - |
-| `ruff` | development | `ruff>=0.6.9,<0.7.0` | `0.15.20` | MIT | License-Expression | allowed | - | - |
+| `ruff` | development | `ruff>=0.6.9,<0.7.0` | `0.15.21` | MIT | License-Expression | allowed | - | - |
 | `six` | runtime | `six==1.17.0` | `1.17.0` | MIT | License | allowed | - | - |
 | `sniffio` | runtime | `sniffio==1.3.1` | `1.3.1` | MIT OR Apache-2.0 | License | allowed | - | - |
 | `SQLAlchemy` | development, runtime | `SQLAlchemy==2.0.39; SQLAlchemy>=2.0.0,<3.0.0` | `2.0.39` | MIT | License | allowed | - | - |
@@ -65,7 +65,7 @@ Mode: generated first-party and third-party dependency license evidence.
 | `typing_extensions` | runtime | `typing_extensions==4.15.0` | `4.15.0` | PSF-2.0 | License-Expression | allowed | - | - |
 | `typing-inspection` | runtime | `typing-inspection==0.4.2` | `0.4.2` | MIT | License-Expression | allowed | - | - |
 | `tzdata` | runtime | `tzdata==2025.3` | `2025.3` | Apache-2.0 | License | allowed | - | - |
-| `uvicorn` | runtime | `uvicorn==0.35.0` | `0.49.0` | BSD-3-Clause | License-Expression | allowed | - | - |
+| `uvicorn` | runtime | `uvicorn==0.35.0` | `0.51.0` | BSD-3-Clause | License-Expression | allowed | - | - |
 | `vulture` | development | `vulture>=2.16,<3.0.0` | `2.16` | The MIT License (MIT) Copyright (c) 2012-2020 Jendrik Seipp (jendrikseipp@gmail.com) Permission is hereby granted, free of charge, to any person obtaining a cop | License | allowed | - | - |
 
 ## Review Rules

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.7.0
 anyio==4.10.0
 certifi==2026.2.25
-click==8.2.1
+click==8.3.3
 colorama==0.4.6
 fastapi==0.136.3
 h11==0.16.0


### PR DESCRIPTION
## Summary
- Sync repo-root `AGENTS.md` from `lotus-platform/context/AGENTS-OPERATING-CONTRACT.md`.
- Propagate the governed wiki-check guidance: use `-AllowUnpublishedSourceChanges` before merge when wiki source changes, then strict `-CheckOnly` after publish.
- Upgrade `click` from `8.2.1` to `8.3.3` to clear the PR security audit vulnerability `PYSEC-2026-2132` / `CVE-2026-7246` discovered by the Feature Lane.

## Governance
- Refs sgajbi/lotus-platform#524.
- AGENTS change generated with `lotus-platform/automation/Sync-AgentOperatingContract.ps1`; no hand-edited copy.
- File organization: repo-root `AGENTS.md` remains at the governed root; dependency truth remains in `requirements.txt`, `poetry.lock`, and generated `quality/license_compliance_inventory.md`.

## Validation
- `powershell -ExecutionPolicy Bypass -File automation/Sync-AgentOperatingContract.ps1 -AllRepoRoots -CheckOnly` from `lotus-platform` => synchronized 13 targets.
- `python automation/validate_engineering_context_system.py` from `lotus-platform` => passed with no warnings.
- `python scripts/dependency_health_check.py --skip-outdated --requirement requirements.txt --requirement requirements-dev.txt` from `lotus-performance` => Known vulnerabilities: 0.
- `python scripts/license_compliance_inventory.py --check` from `lotus-performance` => passed.